### PR TITLE
Await mongoClient calls to avoid memory leaks

### DIFF
--- a/packages/api-db-mongodb/src/adapter.ts
+++ b/packages/api-db-mongodb/src/adapter.ts
@@ -170,7 +170,10 @@ export class MongoDBAdapter implements DBAdapter {
     if (!migrationState) {
       const adapter = await this.connect({sessionTTL, bcryptHashCostFactor, url, locale})
       await seed?.(adapter)
+      await adapter.client.close()
     }
+
+    await client.close()
 
     return {
       migrated: {

--- a/packages/api-db-mongodb/src/migration.ts
+++ b/packages/api-db-mongodb/src/migration.ts
@@ -107,7 +107,7 @@ export const Migrations: Migration[] = [
 
       await userRoles.createIndex({name: 1}, {unique: true})
 
-      userRoles.insertMany([
+      await userRoles.insertMany([
         {
           _id: 'admin',
           createdAt: new Date(),
@@ -130,7 +130,7 @@ export const Migrations: Migration[] = [
 
       const user = db.collection(CollectionName.Users)
 
-      user.updateMany({}, [
+      await user.updateMany({}, [
         {
           $set: {
             name: '$email',
@@ -146,7 +146,7 @@ export const Migrations: Migration[] = [
     async migrate(db) {
       const userRoles = db.collection(CollectionName.UserRoles)
 
-      userRoles.insertOne({
+      await userRoles.insertOne({
         _id: 'peer',
         createdAt: new Date(),
         modifiedAt: new Date(),


### PR DESCRIPTION
This PR fixes some missing awaits on async calls form mongoClient. Additionally it also closes the additional database connection which gets created during a migration.