### PR TITLE
save preTitel in teaser

### DIFF
--- a/packages/editor/src/client/blocks/types.ts
+++ b/packages/editor/src/client/blocks/types.ts
@@ -353,6 +353,7 @@ export function unionMapForBlock(block: BlockValue): BlockInput {
                   article: {
                     style: value.style,
                     imageID: value.image?.id,
+                    preTitle: value.preTitle || undefined,
                     title: value.title || undefined,
                     lead: value.lead || undefined,
                     articleID: value.article.id
@@ -364,6 +365,7 @@ export function unionMapForBlock(block: BlockValue): BlockInput {
                   peerArticle: {
                     style: value.style,
                     imageID: value.image?.id,
+                    preTitle: value.preTitle || undefined,
                     title: value.title || undefined,
                     lead: value.lead || undefined,
                     peerID: value.peer.id,
@@ -376,6 +378,7 @@ export function unionMapForBlock(block: BlockValue): BlockInput {
                   page: {
                     style: value.style,
                     imageID: value.image?.id,
+                    preTitle: value.preTitle || undefined,
                     title: value.title || undefined,
                     lead: value.lead || undefined,
                     pageID: value.page.id


### PR DESCRIPTION
In a teaser grid if you choose an article (article, peered article or a page) you can overwrite some of the metadata settings. Amongst them you could overwrite the `preTitle`. This PR fixes a bug that didn't save the preTitle.