### PR TITLE
bug fix - Delete-Dialog not disappearing in pageList

### DIFF
--- a/packages/editor/src/client/routes/pageList.tsx
+++ b/packages/editor/src/client/routes/pageList.tsx
@@ -41,7 +41,7 @@ export function PageList() {
   const listVariables = {filter: filter || undefined, first: PagesPerPage}
   const {data, fetchMore, loading: isLoading} = usePageListQuery({
     variables: {filter: filter || undefined, first: 50},
-    fetchPolicy: 'no-cache'
+    fetchPolicy: 'network-only'
   })
 
   useEffect(() => {


### PR DESCRIPTION
Fixed #73 Delete-Dialog not disappearing in pageList

The code in `pageList.tsx` tries to query the cache. Since the fetchPolicy was `no-cache` the cache was empty and it threw an error. 

```
// This throws an error, since the cache is empty
const query = cache.readQuery<PageListQuery>({
  query: PageListDocument,
  variables: listVariables
})
```
If you dont want to use a cache, you can use the `refetch` function returned from `usePageListQuery`.
Or you can change the fetchPolicy to something else, like `cache-and-network`. I am not sure what you prefer.

I changed to the fetchPolicy that was the closest to the one originally used `no-cache`, but a fetchPolicy that would still write to cache so to avoid the error. This way the `cache.readQuery<PageListQuery>(...)` function works and returns the latest (cached) results once a page is deleted.
