### PR TITLE
B/wep 189 richtext placeholder nonempty text

### DIFF
--- a/packages/editor/__tests__/specs/__snapshots__/authorEditPanel.tsx.snap
+++ b/packages/editor/__tests__/specs/__snapshots__/authorEditPanel.tsx.snap
@@ -6887,16 +6887,6 @@ exports[`Author Edit Panel should render 1`] = `
                           </div>
                         </div>
                       </Toolbar>
-                      <div
-                        onClick={[Function]}
-                        style={
-                          Object {
-                            "color": "#cad5e4",
-                          }
-                        }
-                      >
-                        blocks.richText.startWriting
-                      </div>
                       <Editable
                         onBlur={[Function]}
                         renderElement={[Function]}

--- a/packages/editor/src/client/blocks/richTextBlock/richTextBlock.tsx
+++ b/packages/editor/src/client/blocks/richTextBlock/richTextBlock.tsx
@@ -30,7 +30,6 @@ export const RichTextBlock = memo(function RichTextBlock({
   )
   const [hasFocus, setFocus] = useState(false)
   const [location, setLocation] = useState<Location | null>(null)
-  const [isEmpty, setIsEmpty] = useState(true)
 
   const {t} = useTranslation()
 
@@ -53,7 +52,6 @@ export const RichTextBlock = memo(function RichTextBlock({
         setFocus(ReactEditor.isFocused(editor))
         if (value !== newValue) {
           onChange(newValue)
-          setIsEmpty(false)
         }
       }}>
       <Toolbar
@@ -103,7 +101,7 @@ export const RichTextBlock = memo(function RichTextBlock({
           <EmojiPicker doWithEmoji={emoji => editor.insertText(emoji)} />
         </EditorSubMenuButton>
       </Toolbar>
-      {isEmpty && ( // Alternative placeholder
+      {WepublishEditor.isEmpty(editor) && ( // Alternative placeholder
         <div onClick={() => ReactEditor.focus(editor)} style={{color: '#cad5e4'}}>
           {t('blocks.richText.startWriting')}
         </div>
@@ -115,7 +113,6 @@ export const RichTextBlock = memo(function RichTextBlock({
         renderLeaf={renderLeaf}
         onBlur={() => {
           setLocation(editor.selection)
-          setIsEmpty(WepublishEditor.isEmpty(editor))
         }}
       />
     </Slate>


### PR DESCRIPTION
Now placeholder only shows up on empty blocks. Staying on a page things work smoothly now. If you save an empty block (respectively the article or page ...) and then reopen, the placeholder will not show up on the block. But I tried couple of things and seems there is some more complexity involved not worth the effort for saving empty blocks as it makes not so much sense IMO.