### PR TITLE
config: explicit-module-boundary-types=off

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
       "no-use-before-define": [
         0
       ],
+      "@typescript-eslint/explicit-module-boundary-types": "off",
       "@typescript-eslint/no-use-before-define": [
         1
       ]


### PR DESCRIPTION
No more eslint warnings on missing return types for React.FCs. Sofar no return type on React.FCs seems the convention in the repo.