### PR TITLE
Unique page slug

### DIFF
--- a/packages/api-db-mongodb/src/migration.ts
+++ b/packages/api-db-mongodb/src/migration.ts
@@ -85,8 +85,6 @@ export const Migrations: Migration[] = [
       await pages.createIndex({'pending.tags': 1}, {collation: {locale, strength: 2}})
       await pages.createIndex({'published.tags': 1}, {collation: {locale, strength: 2}})
 
-      // TODO: Add unique index for slug on published page
-
       await db.createCollection(CollectionName.PagesHistory, {
         strict: true
       })
@@ -564,6 +562,21 @@ export const Migrations: Migration[] = [
       })
       await comments.createIndex({createdAt: -1})
       await comments.createIndex({'revisions.createdAt': -1})
+    }
+  },
+  {
+    //  Make slug for published pages unique
+    version: 12,
+    async migrate(db, locale) {
+      const pages = await db.collection(CollectionName.Pages)
+      await pages.createIndex(
+        {'published.slug': 1},
+        {
+          collation: {locale, strength: 2},
+          unique: true,
+          partialFilterExpression: {'published.slug': {$exists: true}}
+        }
+      )
     }
   }
 ]

--- a/packages/api/__tests__/specs/__snapshots__/page.ts.snap
+++ b/packages/api/__tests__/specs/__snapshots__/page.ts.snap
@@ -436,3 +436,20 @@ Object {
   },
 }
 `;
+
+exports[`Pages can be created/edited/published/unpublished/deleted: can not be published with the same slug 1`] = `
+Object {
+  "data": Object {
+    "publishPage": null,
+  },
+  "errors": Array [
+    [GraphQLError: Page with ID SbMakd04JFNBjtOG already uses the slug "testing-page"],
+  ],
+  "extensions": undefined,
+  "http": Object {
+    "headers": Headers {
+      Symbol(map): Object {},
+    },
+  },
+}
+`;

--- a/packages/api/__tests__/specs/__snapshots__/page.ts.snap
+++ b/packages/api/__tests__/specs/__snapshots__/page.ts.snap
@@ -442,9 +442,7 @@ Object {
   "data": Object {
     "publishPage": null,
   },
-  "errors": Array [
-    [GraphQLError: Page with ID SbMakd04JFNBjtOG already uses the slug "testing-page"],
-  ],
+  "errors": Any<Array>,
   "extensions": undefined,
   "http": Object {
     "headers": Headers {

--- a/packages/api/__tests__/specs/page.ts
+++ b/packages/api/__tests__/specs/page.ts
@@ -289,6 +289,35 @@ describe('Pages', () => {
       })
     })
 
+    test('can not be published with the same slug', async () => {
+      const {mutate} = testClientPrivate
+
+      const input: PageInput = {
+        title: 'Testing Page with the same slug',
+        slug: 'testing-page',
+        tags: [],
+        properties: [],
+        blocks: []
+      }
+      const newPage = await mutate({
+        mutation: CreatePage,
+        variables: {
+          input: input
+        }
+      })
+
+      const res = await mutate({
+        mutation: PublishPage,
+        variables: {
+          id: newPage.data?.createPage?.id,
+          publishAt: '2020-11-25T23:55:35.000Z',
+          publishedAt: '2020-11-25T23:55:35.000Z',
+          updatedAt: '2020-11-25T23:55:35.000Z'
+        }
+      })
+      expect(res).toMatchSnapshot()
+    })
+
     test('can be unpublished', async () => {
       const {mutate} = testClientPrivate
       const res = await mutate({

--- a/packages/api/__tests__/specs/page.ts
+++ b/packages/api/__tests__/specs/page.ts
@@ -315,7 +315,9 @@ describe('Pages', () => {
           updatedAt: '2020-11-25T23:55:35.000Z'
         }
       })
-      expect(res).toMatchSnapshot()
+      expect(res).toMatchSnapshot({
+        errors: expect.any(Array)
+      })
     })
 
     test('can be unpublished', async () => {

--- a/packages/api/src/error.ts
+++ b/packages/api/src/error.ts
@@ -98,7 +98,7 @@ export class UserInputError extends ApolloError {
   }
 }
 
-export class DuplicatePageSlug extends ApolloError {
+export class DuplicatePageSlugError extends ApolloError {
   constructor(publishedPageID: string, slug: string) {
     super(
       `Page with ID ${publishedPageID} already uses the slug "${slug}"`,

--- a/packages/api/src/error.ts
+++ b/packages/api/src/error.ts
@@ -13,7 +13,8 @@ export enum ErrorCode {
   EmailAlreadyInUse = 'EMAIL_ALREADY_IN_USE',
   MonthlyAmountNotEnough = 'MONTHLY_AMOUNT_NOT_ENOUGH',
   PaymentConfigurationNotAllowed = 'PAYMENT_CONFIGURATION_NOT_ALLOWED',
-  UserInputError = 'USER_INPUT_ERROR'
+  UserInputError = 'USER_INPUT_ERROR',
+  DuplicatePageSlug = 'DUPLICATE_PAGE_SLUG'
 }
 
 export class TokenExpiredError extends ApolloError {
@@ -94,5 +95,14 @@ export class PaymentConfigurationNotAllowed extends ApolloError {
 export class UserInputError extends ApolloError {
   constructor(actualError: string) {
     super(`User Input Error: \n${actualError}`, ErrorCode.UserInputError)
+  }
+}
+
+export class DuplicatePageSlug extends ApolloError {
+  constructor(publishedPageID: string, slug: string) {
+    super(
+      `Page with ID ${publishedPageID} already uses the slug "${slug}"`,
+      ErrorCode.DuplicatePageSlug
+    )
   }
 }

--- a/packages/api/src/graphql/mutation.private.ts
+++ b/packages/api/src/graphql/mutation.private.ts
@@ -13,7 +13,7 @@ import {GraphQLSession, GraphQLSessionWithToken} from './session'
 import {Context} from '../context'
 
 import {
-  DuplicatePageSlug,
+  DuplicatePageSlugError,
   InvalidCredentialsError,
   InvalidOAuth2TokenError,
   NotActiveError,
@@ -783,7 +783,7 @@ export const GraphQLAdminMutation = new GraphQLObjectType<undefined, Context>({
 
         const publishedPage = await loaders.publicPagesBySlug.load(page.draft.slug)
         if (publishedPage && publishedPage.id !== id)
-          throw new DuplicatePageSlug(publishedPage.id, publishedPage.slug)
+          throw new DuplicatePageSlugError(publishedPage.id, publishedPage.slug)
 
         return dbAdapter.page.publishPage({
           id,


### PR DESCRIPTION
Fixes WPC-5. This PR makes the slug field for published pages unique. The `publishPage` mutation now checks if there is another published page with the same slug. If so it returns an error.