### PR TITLE
fixed editor focus

### DIFF
--- a/packages/editor/src/client/blocks/richTextBlock/richTextBlock.tsx
+++ b/packages/editor/src/client/blocks/richTextBlock/richTextBlock.tsx
@@ -69,8 +69,8 @@ export const RichTextBlock = memo(function RichTextBlock({
         <>
           <Toolbar
             fadeOut={!hasFocus}
-            onMouseDown={e => {
-              e.preventDefault()
+            onMouseDown={() => {
+              // e.preventDefault()
               if (!hasFocus && location) focusAtPreviousLocation(location)
             }}>
             <FormatButton format={BlockFormat.H1}>


### PR DESCRIPTION
In this commit https://github.com/wepublish/wepublish/commit/2d70f0cfb9eecc81299da8933914ae54355ad73f we introduced an error that makes it impossible to focus an input field inside a sub menu (tables, emojis and links) in the editor.