### PR TITLE
Enhanced User address

### DIFF
--- a/packages/api-db-mongodb/src/migration.ts
+++ b/packages/api-db-mongodb/src/migration.ts
@@ -580,7 +580,7 @@ export const Migrations: Migration[] = [
     }
   },
   {
-    //  Make slug for published pages unique
+    //  Rename street field in address to address
     version: 13,
     async migrate(db, locale) {
       const users = await db.collection(CollectionName.Users)

--- a/packages/api-db-mongodb/src/migration.ts
+++ b/packages/api-db-mongodb/src/migration.ts
@@ -589,7 +589,7 @@ export const Migrations: Migration[] = [
           'address.street': {$exists: true}
         },
         {
-          $rename: {'address.street': 'address.address'}
+          $rename: {'address.street': 'address.streetAddress'}
         }
       )
     }

--- a/packages/api-db-mongodb/src/migration.ts
+++ b/packages/api-db-mongodb/src/migration.ts
@@ -578,6 +578,21 @@ export const Migrations: Migration[] = [
         }
       )
     }
+  },
+  {
+    //  Make slug for published pages unique
+    version: 13,
+    async migrate(db, locale) {
+      const users = await db.collection(CollectionName.Users)
+      await users.updateMany(
+        {
+          'address.street': {$exists: true}
+        },
+        {
+          $rename: {'address.street': 'address.address'}
+        }
+      )
+    }
   }
 ]
 

--- a/packages/api/src/db/user.ts
+++ b/packages/api/src/db/user.ts
@@ -133,8 +133,8 @@ export interface PaymentProviderCustomer {
 
 export interface UserAddress {
   readonly company?: string
-  readonly address: string
-  readonly address2?: string
+  readonly streetAddress: string
+  readonly streetAddress2?: string
   readonly zipCode: string
   readonly city: string
   readonly country: string

--- a/packages/api/src/db/user.ts
+++ b/packages/api/src/db/user.ts
@@ -132,7 +132,9 @@ export interface PaymentProviderCustomer {
 }
 
 export interface UserAddress {
-  readonly street: string
+  readonly company?: string
+  readonly address: string
+  readonly address2: string
   readonly zipCode: string
   readonly city: string
   readonly country: string

--- a/packages/api/src/db/user.ts
+++ b/packages/api/src/db/user.ts
@@ -134,7 +134,7 @@ export interface PaymentProviderCustomer {
 export interface UserAddress {
   readonly company?: string
   readonly address: string
-  readonly address2: string
+  readonly address2?: string
   readonly zipCode: string
   readonly city: string
   readonly country: string

--- a/packages/api/src/graphql/user.ts
+++ b/packages/api/src/graphql/user.ts
@@ -73,8 +73,8 @@ export const GraphQLUserAddress = new GraphQLObjectType({
   name: 'UserAddress',
   fields: {
     company: {type: GraphQLString},
-    address: {type: GraphQLNonNull(GraphQLString)},
-    address2: {type: GraphQLString},
+    streetAddress: {type: GraphQLNonNull(GraphQLString)},
+    streetAddress2: {type: GraphQLString},
     zipCode: {type: GraphQLNonNull(GraphQLString)},
     city: {type: GraphQLNonNull(GraphQLString)},
     country: {type: GraphQLNonNull(GraphQLString)}
@@ -166,8 +166,8 @@ export const GraphQLUserAddressInput = new GraphQLInputObjectType({
   name: 'UserAddressInput',
   fields: {
     company: {type: GraphQLString},
-    address: {type: GraphQLNonNull(GraphQLString)},
-    address2: {type: GraphQLString},
+    streetAddress: {type: GraphQLNonNull(GraphQLString)},
+    streetAddress2: {type: GraphQLString},
     zipCode: {type: GraphQLNonNull(GraphQLString)},
     city: {type: GraphQLNonNull(GraphQLString)},
     country: {type: GraphQLNonNull(GraphQLString)}

--- a/packages/api/src/graphql/user.ts
+++ b/packages/api/src/graphql/user.ts
@@ -72,7 +72,9 @@ export const GraphQLPublicUserSubscription = new GraphQLObjectType({
 export const GraphQLUserAddress = new GraphQLObjectType({
   name: 'UserAddress',
   fields: {
-    street: {type: GraphQLNonNull(GraphQLString)},
+    company: {type: GraphQLString},
+    address: {type: GraphQLNonNull(GraphQLString)},
+    address2: {type: GraphQLString},
     zipCode: {type: GraphQLNonNull(GraphQLString)},
     city: {type: GraphQLNonNull(GraphQLString)},
     country: {type: GraphQLNonNull(GraphQLString)}
@@ -163,7 +165,9 @@ export const GraphQLUserConnection = new GraphQLObjectType<any, Context>({
 export const GraphQLUserAddressInput = new GraphQLInputObjectType({
   name: 'UserAddressInput',
   fields: {
-    street: {type: GraphQLNonNull(GraphQLString)},
+    company: {type: GraphQLString},
+    address: {type: GraphQLNonNull(GraphQLString)},
+    address2: {type: GraphQLString},
     zipCode: {type: GraphQLNonNull(GraphQLString)},
     city: {type: GraphQLNonNull(GraphQLString)},
     country: {type: GraphQLNonNull(GraphQLString)}


### PR DESCRIPTION
WPC-241. This PR adds two new fields "company" and "address2" to the user address. For the sake of consistency i renamed the field "street" to "address". For this we have a migration but this makes the PR also breaking because if somebody already uses this in a query or mutation they have to change that. 