### PR TITLE
Article Preview Links

### DIFF
--- a/examples/api/src/index.ts
+++ b/examples/api/src/index.ts
@@ -39,7 +39,7 @@ class ExampleURLAdapter implements URLAdapter {
   }
 
   getPublicArticleURL(article: PublicArticle): string {
-    return `${this.websiteURL}/article/${article.id}/${article.slug}`
+    return `${this.websiteURL}/a/${article.id}/${article.slug}`
   }
 
   getPublicPageURL(page: PublicPage): string {
@@ -51,11 +51,11 @@ class ExampleURLAdapter implements URLAdapter {
   }
 
   getCommentURL(article: PublicArticle, comment: PublicComment) {
-    return `${this.websiteURL}/article/${article.id}/${article.slug}#${comment.id}`
+    return `${this.websiteURL}/a/${article.id}/${article.slug}#${comment.id}`
   }
 
   getArticlePreviewURL(token: string) {
-    return `${this.websiteURL}/article/${token}`
+    return `${this.websiteURL}/a/preview/${token}`
   }
 }
 

--- a/examples/api/src/index.ts
+++ b/examples/api/src/index.ts
@@ -53,6 +53,10 @@ class ExampleURLAdapter implements URLAdapter {
   getCommentURL(article: PublicArticle, comment: PublicComment) {
     return `${this.websiteURL}/article/${article.id}/${article.slug}#${comment.id}`
   }
+
+  getArticlePreviewURL(token: string) {
+    return `${this.websiteURL}/article/${token}`
+  }
 }
 
 async function asyncMain() {

--- a/examples/website/src/shared/route/articleTemplateContainer.tsx
+++ b/examples/website/src/shared/route/articleTemplateContainer.tsx
@@ -39,8 +39,8 @@ import {Color} from '../style/colors'
 import {RichTextBlock} from '../blocks/richTextBlock/richTextBlock'
 
 const ArticleQuery = gql`
-  query Article($id: ID!) {
-    article(id: $id) {
+  query Article($id: ID, $slug: Slug, $token: String) {
+    article(id: $id, slug: $slug, token: $token) {
       ...ArticleMetaData
 
       blocks {
@@ -85,6 +85,7 @@ const ArticleQuery = gql`
 export interface ArticleTemplateContainerProps {
   id: string
   slug?: string
+  token?: string
 }
 
 const mapAuthors = (metaData: any[] | undefined) => {
@@ -95,7 +96,14 @@ const mapAuthors = (metaData: any[] | undefined) => {
 
 export function ArticleTemplateContainer({id, slug}: ArticleTemplateContainerProps) {
   const {canonicalHost} = useAppContext()
-  const {data, loading, error} = useQuery(ArticleQuery, {variables: {id}})
+  const variables =
+    id === 'preview'
+      ? {
+          token: slug
+        }
+      : {id}
+
+  const {data, loading, error} = useQuery(ArticleQuery, {variables})
 
   if (error) return <NotFoundTemplate statusCode={500} />
 

--- a/examples/website/src/shared/route/articleTemplateContainer.tsx
+++ b/examples/website/src/shared/route/articleTemplateContainer.tsx
@@ -85,7 +85,6 @@ const ArticleQuery = gql`
 export interface ArticleTemplateContainerProps {
   id: string
   slug?: string
-  token?: string
 }
 
 const mapAuthors = (metaData: any[] | undefined) => {

--- a/packages/api-db-mongodb/src/db/article.ts
+++ b/packages/api-db-mongodb/src/db/article.ts
@@ -413,6 +413,19 @@ export class MongoDBArticleAdapter implements DBArticleAdapter {
     return ids.map(id => (articleMap[id] as PublicArticle) ?? null)
   }
 
+  async getPublishedArticleBySlug(slug: string): Promise<OptionalPublicArticle> {
+    await this.updatePendingArticles()
+    const article = await this.articles.findOne({'published.slug': {$eq: slug}})
+
+    return article?.published
+      ? ({
+          id: article._id,
+          shared: article.shared,
+          ...article.published
+        } as PublicArticle)
+      : null
+  }
+
   async getPublishedArticles({
     filter,
     sort,

--- a/packages/api/__tests__/specs/__snapshots__/user.ts.snap
+++ b/packages/api/__tests__/specs/__snapshots__/user.ts.snap
@@ -175,6 +175,11 @@ Object {
                 },
                 Object {
                   "deprecated": false,
+                  "description": "Allows to get preview links for articles",
+                  "id": "CAN_GET_ARTICLE_PREVIEW_LINK",
+                },
+                Object {
+                  "deprecated": false,
                   "description": "Allows to publish articles",
                   "id": "CAN_PUBLISH_ARTICLE",
                 },

--- a/packages/api/__tests__/specs/__snapshots__/userRole.ts.snap
+++ b/packages/api/__tests__/specs/__snapshots__/userRole.ts.snap
@@ -95,6 +95,11 @@ Object {
         },
         Object {
           "deprecated": false,
+          "description": "Allows to get preview links for articles",
+          "id": "CAN_GET_ARTICLE_PREVIEW_LINK",
+        },
+        Object {
+          "deprecated": false,
           "description": "Allows to publish articles",
           "id": "CAN_PUBLISH_ARTICLE",
         },
@@ -487,6 +492,11 @@ Object {
             },
             Object {
               "deprecated": false,
+              "description": "Allows to get preview links for articles",
+              "id": "CAN_GET_ARTICLE_PREVIEW_LINK",
+            },
+            Object {
+              "deprecated": false,
               "description": "Allows to publish articles",
               "id": "CAN_PUBLISH_ARTICLE",
             },
@@ -832,6 +842,11 @@ Object {
             },
             Object {
               "deprecated": false,
+              "description": "Allows to get preview links for articles",
+              "id": "CAN_GET_ARTICLE_PREVIEW_LINK",
+            },
+            Object {
+              "deprecated": false,
               "description": "Allows to create Pages",
               "id": "CAN_CREATE_PAGE",
             },
@@ -957,6 +972,11 @@ Object {
               "deprecated": false,
               "description": "Allows to delete articles",
               "id": "CAN_DELETE_ARTICLE",
+            },
+            Object {
+              "deprecated": false,
+              "description": "Allows to get preview links for articles",
+              "id": "CAN_GET_ARTICLE_PREVIEW_LINK",
             },
             Object {
               "deprecated": false,
@@ -1341,6 +1361,11 @@ Object {
         "deprecated": false,
         "description": "Allows to delete articles",
         "id": "CAN_DELETE_ARTICLE",
+      },
+      Object {
+        "deprecated": false,
+        "description": "Allows to get preview links for articles",
+        "id": "CAN_GET_ARTICLE_PREVIEW_LINK",
       },
       Object {
         "deprecated": false,

--- a/packages/api/__tests__/utility.ts
+++ b/packages/api/__tests__/utility.ts
@@ -33,6 +33,10 @@ class ExampleURLAdapter implements URLAdapter {
   getAuthorURL(author: Author): string {
     return `https://demo.wepublish.ch/author/${author.slug || author.id}`
   }
+
+  getArticlePreviewURL(token: string): string {
+    return `https://demo.wepulish.ch/article/preview/${token}`
+  }
 }
 
 export async function createGraphQLTestClientWithMongoDB(): Promise<TestClient> {

--- a/packages/api/src/context.ts
+++ b/packages/api/src/context.ts
@@ -146,7 +146,7 @@ export interface CreatePaymentWithProvider {
 }
 
 export interface GenerateJWTProps {
-  userID: string
+  id: string
   audience?: string
   expiresInMinutes?: number
 }
@@ -354,7 +354,7 @@ export async function contextFromRequest(
         algorithm: 'HS256',
         expiresIn: `${props.expiresInMinutes ?? 5}m`
       }
-      return jwt.sign({sub: props.userID}, process.env.JWT_SECRET_KEY, jwtOptions)
+      return jwt.sign({sub: props.id}, process.env.JWT_SECRET_KEY, jwtOptions)
     },
 
     verifyJWT(token: string): string {

--- a/packages/api/src/db/article.ts
+++ b/packages/api/src/db/article.ts
@@ -153,6 +153,8 @@ export interface DBArticleAdapter {
   getArticlesByID(ids: readonly string[]): Promise<OptionalArticle[]>
   getPublishedArticlesByID(ids: readonly string[]): Promise<OptionalPublicArticle[]>
 
+  getPublishedArticleBySlug(slug: string): Promise<OptionalPublicArticle>
+
   getArticles(args: GetArticlesArgs): Promise<ConnectionResult<Article>>
   getPublishedArticles(args: GetPublishedArticlesArgs): Promise<ConnectionResult<PublicArticle>>
 

--- a/packages/api/src/events.ts
+++ b/packages/api/src/events.ts
@@ -187,7 +187,7 @@ invoiceModelEvents.on('update', async (context, model) => {
         })
         // Send FirstTime Hello
         const token = context.generateJWT({
-          userID: user.id,
+          id: user.id,
           expiresInMinutes: 60 * 24
         })
         const link = `${context.websiteURL}/login/jwt=${token}` // TODO: make this a setting

--- a/packages/api/src/graphql/mutation.private.ts
+++ b/packages/api/src/graphql/mutation.private.ts
@@ -318,7 +318,7 @@ export const GraphQLAdminMutation = new GraphQLObjectType<undefined, Context>({
 
         const user = await dbAdapter.user.getUser(email)
         if (!user) throw new Error('User does not exist') // TODO: make this proper error
-        const token = generateJWT({userID: user.id})
+        const token = generateJWT({id: user.id})
         const link = `${url}?jwt=${token}`
         await sendMailFromProvider({
           message: `Click the link to login:\n\n${link}`,

--- a/packages/api/src/graphql/mutation.public.ts
+++ b/packages/api/src/graphql/mutation.public.ts
@@ -265,7 +265,7 @@ export const GraphQLPublicMutation = new GraphQLObjectType<undefined, Context>({
         const user = await dbAdapter.user.getUser(email)
         if (!user) return email // TODO: implement check to avoid bots
 
-        const token = generateJWT({userID: user.id})
+        const token = generateJWT({id: user.id})
         const link = `${process.env.WEBSITE_URL}/login?jwt=${token}`
         await sendMailFromProvider({
           message: `Click the link to login:\n\n${link}`,

--- a/packages/api/src/graphql/permissions.ts
+++ b/packages/api/src/graphql/permissions.ts
@@ -159,6 +159,12 @@ export const CanDeleteArticle: Permission = {
   deprecated: false
 }
 
+export const CanGetArticlePreviewLink: Permission = {
+  id: 'CAN_GET_ARTICLE_PREVIEW_LINK',
+  description: 'Allows to get preview links for articles',
+  deprecated: false
+}
+
 export const CanTakeActionOnComment: Permission = {
   id: 'CAN_TAKE_COMMENT_ACTION',
   description: 'Allows to take an action on comment',
@@ -447,6 +453,7 @@ export const AllPermissions: Permission[] = [
   CanGetArticle,
   CanGetArticles,
   CanDeleteArticle,
+  CanGetArticlePreviewLink,
   CanPublishArticle,
   CanGetPeerArticle,
   CanGetPeerArticles,
@@ -510,6 +517,7 @@ export const EditorPermissions: Permission[] = [
   CanGetArticle,
   CanGetArticles,
   CanPublishArticle,
+  CanGetArticlePreviewLink,
   CanCreatePage,
   CanGetPage,
   CanGetPages,

--- a/packages/api/src/graphql/query.private.ts
+++ b/packages/api/src/graphql/query.private.ts
@@ -757,7 +757,7 @@ export const GraphQLQuery = new GraphQLObjectType<undefined, Context>({
         if (!article.draft) throw new UserInputError('Article needs to have a draft')
 
         const token = generateJWT({
-          userID: article.id,
+          id: article.id,
           expiresInMinutes: hours * 60
         })
 

--- a/packages/api/src/graphql/query.private.ts
+++ b/packages/api/src/graphql/query.private.ts
@@ -88,7 +88,8 @@ import {
   CanGetInvoices,
   CanGetPayment,
   CanGetPayments,
-  CanGetPaymentProviders
+  CanGetPaymentProviders,
+  CanGetArticlePreviewLink
 } from './permissions'
 import {GraphQLUserConnection, GraphQLUserFilter, GraphQLUserSort, GraphQLUser} from './user'
 import {
@@ -100,7 +101,7 @@ import {
 } from './userRole'
 import {UserRoleSort} from '../db/userRole'
 
-import {NotAuthorisedError} from '../error'
+import {NotAuthorisedError, NotFound} from '../error'
 import {GraphQLCommentConnection, GraphQLCommentFilter, GraphQLCommentSort} from './comment'
 import {
   GraphQLMemberPlan,
@@ -739,6 +740,28 @@ export const GraphQLQuery = new GraphQLObjectType<undefined, Context>({
             hasNextPage: hasNextPage
           }
         }
+      }
+    },
+
+    articlePreviewLink: {
+      type: GraphQLString,
+      args: {id: {type: GraphQLNonNull(GraphQLID)}, hours: {type: GraphQLNonNull(GraphQLInt)}},
+      async resolve(root, {id, hours}, {authenticate, loaders, urlAdapter, generateJWT}) {
+        const {roles} = authenticate()
+        authorise(CanGetArticlePreviewLink, roles)
+
+        const article = await loaders.articles.load(id)
+
+        if (!article) throw new NotFound('article', id)
+
+        if (!article.draft) throw new UserInputError('Article needs to have a draft')
+
+        const token = generateJWT({
+          userID: article.id,
+          expiresInMinutes: hours * 60
+        })
+
+        return urlAdapter.getArticlePreviewURL(token)
       }
     },
 

--- a/packages/api/src/graphql/query.public.ts
+++ b/packages/api/src/graphql/query.public.ts
@@ -149,6 +149,8 @@ export const GraphQLPublicQuery = new GraphQLObjectType<undefined, Context>({
               ? ({
                   id: privateArticle.id,
                   shared: privateArticle.shared,
+                  updatedAt: new Date(),
+                  publishedAt: new Date(),
                   ...privateArticle.draft
                 } as PublicArticle)
               : null

--- a/packages/api/src/urlAdapter.ts
+++ b/packages/api/src/urlAdapter.ts
@@ -6,4 +6,5 @@ export interface URLAdapter {
   getPublicArticleURL(article: PublicArticle): string
   getPublicPageURL(page: PublicPage): string
   getAuthorURL(author: Author): string
+  getArticlePreviewURL(token: string): string
 }

--- a/packages/editor/src/client/api/article.graphql
+++ b/packages/editor/src/client/api/article.graphql
@@ -138,6 +138,10 @@ mutation DuplicateArticle($id: ID!) {
   }
 }
 
+query ArticlePreviewLink($id: ID!, $hours: Int!) {
+  articlePreviewLink(id: $id, hours: $hours)
+}
+
 query Article($id: ID!) {
   article(id: $id) {
     id

--- a/packages/editor/src/client/api/index.ts
+++ b/packages/editor/src/client/api/index.ts
@@ -1303,6 +1303,7 @@ export type Query = {
   articles: ArticleConnection;
   peerArticle?: Maybe<Article>;
   peerArticles: PeerArticleConnection;
+  articlePreviewLink?: Maybe<Scalars['String']>;
   page?: Maybe<Page>;
   pages: PageConnection;
   memberPlan?: Maybe<MemberPlan>;
@@ -1440,6 +1441,12 @@ export type QueryPeerArticlesArgs = {
   filter?: Maybe<ArticleFilter>;
   sort?: Maybe<ArticleSort>;
   order?: Maybe<SortOrder>;
+};
+
+
+export type QueryArticlePreviewLinkArgs = {
+  id: Scalars['ID'];
+  hours: Scalars['Int'];
 };
 
 
@@ -1979,6 +1986,17 @@ export type DuplicateArticleMutation = (
     { __typename?: 'Article' }
     & MutationArticleFragment
   ) }
+);
+
+export type ArticlePreviewLinkQueryVariables = Exact<{
+  id: Scalars['ID'];
+  hours: Scalars['Int'];
+}>;
+
+
+export type ArticlePreviewLinkQuery = (
+  { __typename?: 'Query' }
+  & Pick<Query, 'articlePreviewLink'>
 );
 
 export type ArticleQueryVariables = Exact<{
@@ -4247,6 +4265,38 @@ export function useDuplicateArticleMutation(baseOptions?: Apollo.MutationHookOpt
 export type DuplicateArticleMutationHookResult = ReturnType<typeof useDuplicateArticleMutation>;
 export type DuplicateArticleMutationResult = Apollo.MutationResult<DuplicateArticleMutation>;
 export type DuplicateArticleMutationOptions = Apollo.BaseMutationOptions<DuplicateArticleMutation, DuplicateArticleMutationVariables>;
+export const ArticlePreviewLinkDocument = gql`
+    query ArticlePreviewLink($id: ID!, $hours: Int!) {
+  articlePreviewLink(id: $id, hours: $hours)
+}
+    `;
+
+/**
+ * __useArticlePreviewLinkQuery__
+ *
+ * To run a query within a React component, call `useArticlePreviewLinkQuery` and pass it any options that fit your needs.
+ * When your component renders, `useArticlePreviewLinkQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useArticlePreviewLinkQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *      hours: // value for 'hours'
+ *   },
+ * });
+ */
+export function useArticlePreviewLinkQuery(baseOptions?: Apollo.QueryHookOptions<ArticlePreviewLinkQuery, ArticlePreviewLinkQueryVariables>) {
+        return Apollo.useQuery<ArticlePreviewLinkQuery, ArticlePreviewLinkQueryVariables>(ArticlePreviewLinkDocument, baseOptions);
+      }
+export function useArticlePreviewLinkLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ArticlePreviewLinkQuery, ArticlePreviewLinkQueryVariables>) {
+          return Apollo.useLazyQuery<ArticlePreviewLinkQuery, ArticlePreviewLinkQueryVariables>(ArticlePreviewLinkDocument, baseOptions);
+        }
+export type ArticlePreviewLinkQueryHookResult = ReturnType<typeof useArticlePreviewLinkQuery>;
+export type ArticlePreviewLinkLazyQueryHookResult = ReturnType<typeof useArticlePreviewLinkLazyQuery>;
+export type ArticlePreviewLinkQueryResult = Apollo.QueryResult<ArticlePreviewLinkQuery, ArticlePreviewLinkQueryVariables>;
 export const ArticleDocument = gql`
     query Article($id: ID!) {
   article(id: $id) {

--- a/packages/editor/src/client/locales/en.json
+++ b/packages/editor/src/client/locales/en.json
@@ -130,7 +130,11 @@
         "charCountWarning": "The maximum number of characters should be {{charCountWarning}}",
         "totalCharCount": "Total characters count is {{totalCharCount}}",
         "seoTitleHelpBlock": "Please use an SEO-optimised title. <2>SEO Guide</2>",
-        "dontChangeSlug": "Please don't change the slug once the article is published"
+        "dontChangeSlug": "Please don't change the slug once the article is published",
+        "articlePreviewLink": "Article Preview Link",
+        "articlePreviewLinkDesc": "Preview Links always shows the latest changes in the draft of the article. Preview Links stop working after you publish the article",
+        "articlePreviewLinkHours": "Validity period of link",
+        "articlePreviewLinkField": "Preview Link"
       }
     },
     "comments": {

--- a/packages/editor/src/client/panel/articlePreviewLinkPanel.tsx
+++ b/packages/editor/src/client/panel/articlePreviewLinkPanel.tsx
@@ -1,0 +1,92 @@
+import React, {useEffect, useState} from 'react'
+import {useTranslation} from 'react-i18next'
+import {
+  Alert,
+  Button,
+  ControlLabel,
+  Form,
+  FormControl,
+  FormGroup,
+  Message,
+  Modal,
+  Slider
+} from 'rsuite'
+
+import {useArticlePreviewLinkQuery} from '../api'
+
+export interface ArticlePreviewProps {
+  id: string
+}
+
+export interface ArticlePreviewLinkPanelProps {
+  props: ArticlePreviewProps
+
+  onClose(): void
+}
+
+export function ArticlePreviewLinkPanel({props, onClose}: ArticlePreviewLinkPanelProps) {
+  const [hours, setHours] = useState<number>(12)
+
+  const {t} = useTranslation()
+
+  const {data, loading: isLoading, error: loadError, refetch} = useArticlePreviewLinkQuery({
+    variables: {
+      id: props.id,
+      hours
+    }
+  })
+
+  useEffect(() => {
+    refetch({id: props.id, hours})
+  }, [hours])
+
+  useEffect(() => {
+    if (loadError?.message) {
+      Alert.error(loadError.message, 0)
+    }
+  }, [loadError])
+
+  return (
+    <>
+      <Modal.Header>
+        <Modal.Title>{t('articleEditor.panels.articlePreviewLink')}</Modal.Title>
+      </Modal.Header>
+
+      <Modal.Body>
+        <Message
+          style={{marginBottom: '20px'}}
+          type="warning"
+          description={t('articleEditor.panels.articlePreviewLinkDesc')}
+        />
+
+        <Form fluid={true}>
+          <FormGroup style={{paddingLeft: '20px', paddingRight: '20px'}}>
+            <ControlLabel>{t('articleEditor.panels.articlePreviewLinkHours')}</ControlLabel>
+            <Slider
+              value={hours}
+              min={6}
+              step={6}
+              max={48}
+              graduated
+              progress
+              renderMark={mark => {
+                return `${mark} h`
+              }}
+              onChange={value => setHours(value)}
+            />
+          </FormGroup>
+          <FormGroup style={{paddingTop: '20px'}}>
+            <ControlLabel>{t('articleEditor.panels.articlePreviewLinkField')}</ControlLabel>
+            <FormControl disabled={isLoading} value={data?.articlePreviewLink} />
+          </FormGroup>
+        </Form>
+      </Modal.Body>
+
+      <Modal.Footer>
+        <Button appearance="subtle" onClick={() => onClose()}>
+          {t('articleEditor.panels.close')}
+        </Button>
+      </Modal.Footer>
+    </>
+  )
+}

--- a/packages/editor/src/client/routes/articleList.tsx
+++ b/packages/editor/src/client/routes/articleList.tsx
@@ -19,6 +19,7 @@ import {DescriptionList, DescriptionListItem} from '../atoms/descriptionList'
 import {useTranslation} from 'react-i18next'
 import {FlexboxGrid, Input, InputGroup, Icon, IconButton, Table, Modal, Button} from 'rsuite'
 import {DEFAULT_TABLE_PAGE_SIZES, mapTableSortTypeToGraphQLSortOrder} from '../utility'
+import {ArticlePreviewLinkPanel} from '../panel/articlePreviewLinkPanel'
 const {Column, HeaderCell, Cell, Pagination} = Table
 
 enum ConfirmAction {
@@ -44,6 +45,7 @@ export function ArticleList() {
   const [filter, setFilter] = useState('')
 
   const [isConfirmationDialogOpen, setConfirmationDialogOpen] = useState(false)
+  const [isArticlePreviewLinkOpen, setArticlePreviewLinkOpen] = useState(false)
   const [currentArticle, setCurrentArticle] = useState<ArticleRefFragment>()
   const [confirmAction, setConfirmAction] = useState<ConfirmAction>()
 
@@ -170,7 +172,7 @@ export function ArticleList() {
               }}
             </Cell>
           </Column>
-          <Column width={100} align="center" fixed="right">
+          <Column width={200} align="center" fixed="right">
             <HeaderCell>{t('articles.overview.action')}</HeaderCell>
             <Cell style={{padding: '6px 0'}}>
               {(rowData: ArticleRefFragment) => (
@@ -209,6 +211,16 @@ export function ArticleList() {
                       setConfirmationDialogOpen(true)
                     }}
                   />
+                  <IconButton
+                    icon={<Icon icon="eye" />}
+                    circle
+                    size="sm"
+                    style={{marginLeft: '5px'}}
+                    onClick={() => {
+                      setCurrentArticle(rowData)
+                      setArticlePreviewLinkOpen(true)
+                    }}
+                  />
                 </>
               )}
             </Cell>
@@ -225,6 +237,18 @@ export function ArticleList() {
           onChangeLength={limit => setLimit(limit)}
         />
       </div>
+
+      <Modal
+        show={isArticlePreviewLinkOpen}
+        width={'sm'}
+        onHide={() => setArticlePreviewLinkOpen(false)}>
+        {currentArticle && (
+          <ArticlePreviewLinkPanel
+            props={{id: currentArticle.id, title: currentArticle.latest.title}}
+            onClose={() => setArticlePreviewLinkOpen(false)}
+          />
+        )}
+      </Modal>
 
       <Modal
         show={isConfirmationDialogOpen}

--- a/packages/editor/src/client/routes/articleList.tsx
+++ b/packages/editor/src/client/routes/articleList.tsx
@@ -211,16 +211,18 @@ export function ArticleList() {
                       setConfirmationDialogOpen(true)
                     }}
                   />
-                  <IconButton
-                    icon={<Icon icon="eye" />}
-                    circle
-                    size="sm"
-                    style={{marginLeft: '5px'}}
-                    onClick={() => {
-                      setCurrentArticle(rowData)
-                      setArticlePreviewLinkOpen(true)
-                    }}
-                  />
+                  {rowData.draft && (
+                    <IconButton
+                      icon={<Icon icon="eye" />}
+                      circle
+                      size="sm"
+                      style={{marginLeft: '5px'}}
+                      onClick={() => {
+                        setCurrentArticle(rowData)
+                        setArticlePreviewLinkOpen(true)
+                      }}
+                    />
+                  )}
                 </>
               )}
             </Cell>
@@ -244,7 +246,7 @@ export function ArticleList() {
         onHide={() => setArticlePreviewLinkOpen(false)}>
         {currentArticle && (
           <ArticlePreviewLinkPanel
-            props={{id: currentArticle.id, title: currentArticle.latest.title}}
+            props={{id: currentArticle.id}}
             onClose={() => setArticlePreviewLinkOpen(false)}
           />
         )}


### PR DESCRIPTION
WPC-61. This PR introduces a new GraphQL mutation that generates a JWT out of the article ID. This token is then combined with a URL that can be shared with externals. The token have a validation period and will not work afterwards.