### PR TITLE
fixed links in example website

### DIFF
--- a/examples/website/src/shared/blocks/richTextBlock/editor/render.tsx
+++ b/examples/website/src/shared/blocks/richTextBlock/editor/render.tsx
@@ -53,7 +53,12 @@ export function renderElement({attributes, children, element}: RenderElementProp
       // title={title}
 
       return (
-        <a data-title={element.title} data-href={element.url} {...attributes}>
+        <a
+          target="_blank"
+          rel="noreferrer"
+          href={element.url as string}
+          title={element.title as string}
+          {...attributes}>
           {children}
         </a>
       )


### PR DESCRIPTION
WPC-257. Renders links in the example website correctly again. 