### PR TITLE
Disable save without peer data and handle errors of invalid tokens

### DIFF
--- a/packages/api/src/graphql/peer.ts
+++ b/packages/api/src/graphql/peer.ts
@@ -79,7 +79,11 @@ export const GraphQLPeer = new GraphQLObjectType<Peer, Context>({
     profile: {
       type: GraphQLPeerProfile,
       resolve: createProxyingResolver(async (source, args, context, info) => {
-        return delegateToPeerSchema(source.id, true, context, {fieldName: 'peerProfile', info})
+        const peerProfile = await delegateToPeerSchema(source.id, true, context, {
+          fieldName: 'peerProfile',
+          info
+        })
+        return peerProfile.extensions?.code === 'UNAUTHENTICATED' ? null : peerProfile
       })
     }
   }

--- a/packages/api/src/graphql/peer.ts
+++ b/packages/api/src/graphql/peer.ts
@@ -83,6 +83,7 @@ export const GraphQLPeer = new GraphQLObjectType<Peer, Context>({
           fieldName: 'peerProfile',
           info
         })
+        // TODO: Improve error handling for invalid tokens WPC-298
         return peerProfile.extensions?.code === 'UNAUTHENTICATED' ? null : peerProfile
       })
     }

--- a/packages/editor/__tests__/specs/__snapshots__/peerEditPanel.tsx.snap
+++ b/packages/editor/__tests__/specs/__snapshots__/peerEditPanel.tsx.snap
@@ -552,6 +552,19 @@ exports[`Peer Edit Panel should be able to generate a new peering 1`] = `
                                   </FormControl>
                                 </FormControlWrapper>
                               </defaultProps(FormControlWrapper)>
+                              <defaultProps(HelpBlock)
+                                classPrefix="rs-help-block"
+                              >
+                                <HelpBlock
+                                  classPrefix="rs-help-block"
+                                >
+                                  <span
+                                    className="rs-help-block"
+                                  >
+                                    peerList.panels.validateToken
+                                  </span>
+                                </HelpBlock>
+                              </defaultProps(HelpBlock)>
                             </div>
                           </FormGroup>
                         </defaultProps(FormGroup)>
@@ -1233,6 +1246,17 @@ exports[`Peer Edit Panel should render 1`] = `
                                   </FormControl>
                                 </FormControlWrapper>
                               </defaultProps(FormControlWrapper)>
+                              <defaultProps(HelpBlock)
+                                classPrefix="rs-help-block"
+                              >
+                                <HelpBlock
+                                  classPrefix="rs-help-block"
+                                >
+                                  <span
+                                    className="rs-help-block"
+                                  />
+                                </HelpBlock>
+                              </defaultProps(HelpBlock)>
                             </div>
                           </FormGroup>
                         </defaultProps(FormGroup)>
@@ -1943,6 +1967,17 @@ exports[`Peer Edit Panel should render with ID 1`] = `
                                   </FormControl>
                                 </FormControlWrapper>
                               </defaultProps(FormControlWrapper)>
+                              <defaultProps(HelpBlock)
+                                classPrefix="rs-help-block"
+                              >
+                                <HelpBlock
+                                  classPrefix="rs-help-block"
+                                >
+                                  <span
+                                    className="rs-help-block"
+                                  />
+                                </HelpBlock>
+                              </defaultProps(HelpBlock)>
                             </div>
                           </FormGroup>
                         </defaultProps(FormGroup)>

--- a/packages/editor/src/client/locales/en.json
+++ b/packages/editor/src/client/locales/en.json
@@ -465,7 +465,8 @@
         "callToAction": "Call To Action",
         "callToActionText": "Call To Action Text",
         "callToActionURL": "Call To Action URL",
-        "image": "Image"
+        "image": "Image",
+        "validateToken": "Please confirm token is correct before saving"
       }
     },
     "tokenList": {

--- a/packages/editor/src/client/panel/peerEditPanel.tsx
+++ b/packages/editor/src/client/panel/peerEditPanel.tsx
@@ -1,6 +1,16 @@
 import React, {useState, useEffect} from 'react'
 
-import {Alert, Button, ControlLabel, Drawer, Form, FormControl, FormGroup, Panel} from 'rsuite'
+import {
+  Alert,
+  Button,
+  ControlLabel,
+  Drawer,
+  Form,
+  FormControl,
+  FormGroup,
+  Panel,
+  HelpBlock
+} from 'rsuite'
 import {ChooseEditImage} from '../atoms/chooseEditImage'
 
 import {
@@ -49,7 +59,8 @@ export function PeerEditPanel({id, onClose, onSave}: ImageEditPanelProps) {
     refetchQueries: [getOperationNameFromDocument(PeerListDocument)]
   })
 
-  const isDisabled = isLoading || isLoadingPeerProfile || isCreating || isUpdating || !isValidURL
+  const isDisabled =
+    isLoading || isLoadingPeerProfile || isCreating || isUpdating || !isValidURL || (!token && !id)
 
   const {t} = useTranslation()
 
@@ -188,10 +199,11 @@ export function PeerEditPanel({id, onClose, onSave}: ImageEditPanelProps) {
                   setToken(value)
                 }}
               />
+              <HelpBlock>{token ? t('peerList.panels.validateToken') : ''}</HelpBlock>
             </FormGroup>
           </Form>
         </Panel>
-        {!isLoadingPeerProfile && isValidURL && (
+        {!isLoadingPeerProfile && (token || id) && isValidURL && (
           <Panel header={t('peerList.panels.information')}>
             <ChooseEditImage disabled image={profile?.logo} />
             <DescriptionList>


### PR DESCRIPTION
- WPC-262: Set the peered data to display & button to save peer only after a token has been entered.
- WPC-263: Setup error handling on token so an unauthenticated token won't log the user out. Further improvements on token validation with WPC-298.