### PR TITLE
Remove defunct link from green heart emoji

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ TBD
 * [GraphQL](https://graphql.org/)
 * [React](https://reactjs.org/)
 * [TypeScript](https://www.typescriptlang.org/)
-* [:green_heart:]()
+* :green_heart:
 
 
 ## Demo


### PR DESCRIPTION
Removing defunct link from heart emoji
Uncertain what the intention for that link was, but it's kinda irritating for a visitor, as it leads to a 404 page