### PR TITLE
Always set updatedAt and publishedAt date

### DIFF
--- a/packages/api/src/graphql/query.public.ts
+++ b/packages/api/src/graphql/query.public.ts
@@ -150,9 +150,9 @@ export const GraphQLPublicQuery = new GraphQLObjectType<undefined, Context>({
               ? ({
                   id: privateArticle.id,
                   shared: privateArticle.shared,
+                  ...privateArticle.draft,
                   updatedAt: new Date(),
-                  publishedAt: new Date(),
-                  ...privateArticle.draft
+                  publishedAt: new Date()
                 } as PublicArticle)
               : null
           } catch (error) {


### PR DESCRIPTION
WPC-271. This bug fix makes sure that the API always sets publishedAt and updatedAt field when delivering a draft article