### PR TITLE
Highlight link button

### DIFF
--- a/packages/editor/__tests__/specs/__snapshots__/authorEditPanel.tsx.snap
+++ b/packages/editor/__tests__/specs/__snapshots__/authorEditPanel.tsx.snap
@@ -1604,6 +1604,7 @@ exports[`Author Edit Panel should allow a new author to be created  1`] = `
                                       </defaultProps(Divider)>
                                     </ToolbarDivider>
                                     <ForwardRef
+                                      format="link"
                                       icon="link"
                                     >
                                       <withLocale(Whisper)
@@ -4596,6 +4597,7 @@ exports[`Author Edit Panel should expand links fields when Add Block button is c
                                       </defaultProps(Divider)>
                                     </ToolbarDivider>
                                     <ForwardRef
+                                      format="link"
                                       icon="link"
                                     >
                                       <withLocale(Whisper)
@@ -7115,6 +7117,7 @@ exports[`Author Edit Panel should render 1`] = `
                                       </defaultProps(Divider)>
                                     </ToolbarDivider>
                                     <ForwardRef
+                                      format="link"
                                       icon="link"
                                     >
                                       <withLocale(Whisper)
@@ -9626,6 +9629,7 @@ exports[`Author Edit Panel should render with ID 1`] = `
                                       </defaultProps(Divider)>
                                     </ToolbarDivider>
                                     <ForwardRef
+                                      format="link"
                                       icon="link"
                                     >
                                       <withLocale(Whisper)

--- a/packages/editor/src/client/atoms/toolbar.tsx
+++ b/packages/editor/src/client/atoms/toolbar.tsx
@@ -14,6 +14,9 @@ import {SVGIcon} from 'rsuite/lib/@types/common'
 import {IconNames} from 'rsuite/lib/Icon/Icon'
 
 import './toolbar.less'
+import {WepublishEditor} from '../blocks/richTextBlock/editor/wepublishEditor'
+import {Format} from '../blocks/richTextBlock/editor/formats'
+import {useSlate} from 'slate-react'
 
 export interface ToolbarProps {
   readonly onMouseDown?: ReactEventHandler
@@ -111,10 +114,11 @@ export const SubMenuContext = createContext<SubMenuContextProps>({
 
 export interface SubMenuButtonProps extends ToolbarIconButtonProps {
   readonly children?: ReactNode
+  readonly format?: Format
 }
 
 export const SubMenuButton = forwardRef<PopoverProps, SubMenuButtonProps>(
-  ({children, icon}, ref) => {
+  ({children, icon, format}, ref) => {
     // The Submenu buttons provides some local context to it's children.
     const [isMenuOpen, setIsMenuOpen] = useState(false)
     const localRef = useRef<PopoverProps>(null)
@@ -135,6 +139,8 @@ export const SubMenuButton = forwardRef<PopoverProps, SubMenuButtonProps>(
 
     const menu = <Popover ref={menuRef}>{children}</Popover>
 
+    const editor = useSlate()
+
     return (
       <SubMenuContext.Provider
         value={{
@@ -143,7 +149,7 @@ export const SubMenuButton = forwardRef<PopoverProps, SubMenuButtonProps>(
         }}>
         <Whisper placement="top" speaker={menu} ref={triggerRef} trigger="none">
           <ToolbarButton
-            active={isMenuOpen}
+            active={isMenuOpen || (format ? WepublishEditor.isFormatActive(editor, format) : false)}
             onMouseDown={e => {
               e.preventDefault()
               isMenuOpen ? closeMenu() : openMenu()

--- a/packages/editor/src/client/blocks/richTextBlock/richTextBlock.tsx
+++ b/packages/editor/src/client/blocks/richTextBlock/richTextBlock.tsx
@@ -9,7 +9,7 @@ import {Toolbar, ToolbarDivider, H1Icon, H2Icon, H3Icon, SubMenuButton} from '..
 import {RichTextBlockValue} from '../types'
 import {FormatButton, FormatIconButton, EditorSubMenuButton} from './toolbar/buttons'
 import {renderElement, renderLeaf} from './editor/render'
-import {BlockFormat, TextFormat} from './editor/formats'
+import {BlockFormat, TextFormat, InlineFormat} from './editor/formats'
 import {withRichText, withTable} from './editor/plugins'
 import {withNormalizeNode} from './editor/normalizing'
 import {TableMenu} from './toolbar/tableMenu'
@@ -134,7 +134,7 @@ export const RichTextBlock = memo(function RichTextBlock({
 
             <ToolbarDivider />
 
-            <SubMenuButton icon="link">
+            <SubMenuButton icon="link" format={InlineFormat.Link}>
               <LinkMenu />
             </SubMenuButton>
 


### PR DESCRIPTION
WPC-254: In Rich Text editor the link button should indicate whether a selected text includes link format with a blue border around the button. This is consistent with other Rich Text toolbar buttons.