### PR TITLE
remove extra lead field from teaser panel

### DIFF
--- a/packages/editor/src/client/panel/teaserEditPanel.tsx
+++ b/packages/editor/src/client/panel/teaserEditPanel.tsx
@@ -79,10 +79,6 @@ export function TeaserEditPanel({
               <ControlLabel>{t('articleEditor.panels.lead')}</ControlLabel>
               <FormControl value={lead} onChange={lead => setLead(lead)} />
             </FormGroup>
-            <FormGroup>
-              <ControlLabel>{t('articleEditor.panels.lead')}</ControlLabel>
-              <FormControl value={lead} onChange={lead => setLead(lead)} />
-            </FormGroup>
           </Form>
         </Panel>
 


### PR DESCRIPTION
WPC-328:  Removes the extra lead field that was in the teaser edit panel.