### PR TITLE
Proper check if the path includes login or logout

### DIFF
--- a/packages/editor/src/client/index.tsx
+++ b/packages/editor/src/client/index.tsx
@@ -82,7 +82,10 @@ const onDOMContentLoaded = async () => {
       graphQLErrors.forEach(({/* message, locations, path, */ extensions}) => {
         if (
           ['UNAUTHENTICATED', 'TOKEN_EXPIRED'].includes(extensions?.code) &&
-          !['/logout', '/login'].includes(window.location.pathname)
+          !(
+            window.location.pathname.includes('/logout') ||
+            window.location.pathname.includes('/login')
+          )
         ) {
           localStorage.removeItem(LocalStorageKey.SessionToken)
           window.location.pathname = '/logout'


### PR DESCRIPTION
This PR fixes a check in the Editor that doesn't redirect to /logout if the URL path starts with `/login` or `/logout`. The old check failed if the URL continued after `/login`. The URL path `/login/oauth/google?code=123....` failed but is required if we want to login with google or other oauth2 providers.