### PR TITLE
fix(website): removed comments from graphql query for peer articles

### DIFF
--- a/examples/website/src/shared/route/articleTemplateContainer.tsx
+++ b/examples/website/src/shared/route/articleTemplateContainer.tsx
@@ -21,7 +21,8 @@ import {
   titleBlockDataFragment,
   articleMetaDataFragment,
   gridBlockFrontDataGQLfragment,
-  peerMetaDataFragment
+  peerMetaDataFragment,
+  peerArticleMetaDataFragment
 } from './gqlFragments'
 
 import {BlockRenderer} from '../blocks/blockRenderer'
@@ -192,7 +193,7 @@ const PeerQuery = gql`
 const PeerArticleQuery = gql`
   query PeerArticle($peerID: ID!, $id: ID!) {
     peerArticle(peerID: $peerID, id: $id) {
-      ...ArticleMetaData
+      ...PeerArticleMetaData
 
       blocks {
         __typename
@@ -216,7 +217,7 @@ const PeerArticleQuery = gql`
     }
   }
 
-  ${articleMetaDataFragment}
+  ${peerArticleMetaDataFragment}
   ${richTextBlockDataFragment}
   ${imageBlockDataFragment}
   ${imageGalleryBlockDataFragment}

--- a/examples/website/src/shared/route/gqlFragments.ts
+++ b/examples/website/src/shared/route/gqlFragments.ts
@@ -127,6 +127,43 @@ export const articleMetaDataFragment = gql`
   ${recursiveCommentsDataFragment}
 `
 
+export const peerArticleMetaDataFragment = gql`
+  fragment PeerArticleMetaData on Article {
+    __typename
+    id
+    url
+
+    updatedAt
+    publishedAt
+
+    slug
+    preTitle
+    title
+    lead
+    breaking
+    tags
+    authors {
+      ...AuthorsData
+    }
+    image {
+      ...SimpleImageData
+    }
+
+    socialMediaTitle
+    socialMediaDescription
+    socialMediaAuthors {
+      ...AuthorsData
+    }
+    socialMediaImage {
+      ...SimpleImageData
+    }
+  }
+  ${simpleImageDataFragment}
+  ${authorsDataFragment}
+  ${commentsDataFragment}
+  ${recursiveCommentsDataFragment}
+`
+
 export const pageMetaDataFragment = gql`
   fragment PageMetaData on Page {
     __typename
@@ -210,7 +247,7 @@ export const gridBlockFrontDataGQLfragment = gql`
 
         articleID
         article {
-          ...ArticleMetaData
+          ...PeerArticleMetaData
         }
       }
 
@@ -235,6 +272,7 @@ export const gridBlockFrontDataGQLfragment = gql`
   ${articleMetaDataFragment}
   ${pageMetaDataFragment}
   ${peerMetaDataFragment}
+  ${peerArticleMetaDataFragment}
 `
 
 // # transform(input: [{width: 1280, height: 400}])


### PR DESCRIPTION
This PR removes comments loading from peered articles in the website GraphQL Queries. Comments are not yet peerable.