### PR TITLE
fix missing media server setup

### DIFF
--- a/examples/api/.env.example
+++ b/examples/api/.env.example
@@ -3,7 +3,7 @@ MONGO_URL=mongodb://localhost:27017/wepublish
 WEBSITE_URL=http://localhost:5000
 
 MEDIA_SERVER_URL=http://localhost:3004
-MEDIA_SERVER_TOKEN=secret
+MEDIA_SERVER_TOKEN=tPcvBRM2B3uSulyxjXm2ciqH5f1vQy2VDAsf
 
 OAUTH_GOOGLE_DISCOVERY_URL=https://accounts.google.com
 OAUTH_GOOGLE_CLIENT_ID=617896178757-i6ldn0nni9qtle8o6eu76lv93d78nvfi.apps.googleusercontent.com

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "publish": "lerna publish from-package --ignore-scripts",
     "watch": "run-p --print-label watch:*",
     "lint": "run-p --print-label lint:*",
-    "start:docker": "docker-compose up mongo mongo-express",
+    "start:docker": "docker-compose up mongo mongo-express media",
     "setup:api": "yarn workspace @wepublish/api setup",
     "clean:api": "yarn workspace @wepublish/api clean",
     "build:api": "yarn workspace @wepublish/api build",


### PR DESCRIPTION
If we run `yarn run` along the Readme instructions no media server is setup and thus no images can be uploaded in the editor.