### PR TITLE
Allow previews for peered articles

### DIFF
--- a/examples/api/src/index.ts
+++ b/examples/api/src/index.ts
@@ -12,7 +12,8 @@ import {
   StripePaymentProvider,
   URLAdapter,
   WepublishServer,
-  JobType
+  JobType,
+  Peer
 } from '@wepublish/api'
 
 import {KarmaMediaAdapter} from '@wepublish/api-media-karma'
@@ -41,6 +42,10 @@ class ExampleURLAdapter implements URLAdapter {
 
   getPublicArticleURL(article: PublicArticle): string {
     return `${this.websiteURL}/a/${article.id}/${article.slug}`
+  }
+
+  getPeeredArticleURL(peer: Peer, article: PublicArticle): string {
+    return `${this.websiteURL}/p/${peer.id}/${article.id}`
   }
 
   getPublicPageURL(page: PublicPage): string {

--- a/examples/website/src/shared/route/routeContext.ts
+++ b/examples/website/src/shared/route/routeContext.ts
@@ -24,7 +24,7 @@ export enum RouteType {
 
 export const PeerArticleRoute = route(
   RouteType.PeerArticle,
-  routePath`/needs_to_be_fixed/${required('peerID')}/${required('id')}/${optional('slug')}`,
+  routePath`/p/${required('peerID')}/${required('id')}/${optional('slug')}`,
   null as PublishedArticle | null
 )
 

--- a/packages/api/__tests__/utility.ts
+++ b/packages/api/__tests__/utility.ts
@@ -10,7 +10,8 @@ import {
   PublicPage,
   URLAdapter,
   PublicComment,
-  CommentItemType
+  CommentItemType,
+  Peer
 } from '../src'
 import {ApolloServer} from 'apollo-server'
 import {createTestClient} from 'apollo-server-testing'
@@ -30,6 +31,10 @@ class ExampleURLAdapter implements URLAdapter {
 
   getPublicPageURL(page: PublicPage): string {
     return `https://demo.wepublish.ch/page/${page.id}/${page.slug}`
+  }
+
+  getPeeredArticleURL(peer: Peer, article: PublicArticle): string {
+    return `https://demo.wepublish.ch/peerArticle/${peer.id}/${article.id}`
   }
 
   getAuthorURL(author: Author): string {

--- a/packages/api/src/graphql/article.ts
+++ b/packages/api/src/graphql/article.ts
@@ -204,7 +204,7 @@ export const GraphQLPeerArticle = new GraphQLObjectType<PeerArticle, Context>({
       type: GraphQLNonNull(GraphQLPeer),
       resolve: createProxyingResolver(({peerID}, {}, {loaders}) => loaders.peer.load(peerID))
     },
-    peeredURL: {
+    peeredArticleURL: {
       type: GraphQLNonNull(GraphQLString),
       resolve: createProxyingResolver(
         async ({peerID, article}, {}, {loaders, dbAdapter, urlAdapter}) => {

--- a/packages/api/src/graphql/article.ts
+++ b/packages/api/src/graphql/article.ts
@@ -204,6 +204,16 @@ export const GraphQLPeerArticle = new GraphQLObjectType<PeerArticle, Context>({
       type: GraphQLNonNull(GraphQLPeer),
       resolve: createProxyingResolver(({peerID}, {}, {loaders}) => loaders.peer.load(peerID))
     },
+    peeredURL: {
+      type: GraphQLNonNull(GraphQLString),
+      resolve: createProxyingResolver(
+        async ({peerID, article}, {}, {loaders, dbAdapter, urlAdapter}) => {
+          const peer = await loaders.peer.load(peerID)
+          if (!peer || !article) return ''
+          return urlAdapter.getPeeredArticleURL(peer, article)
+        }
+      )
+    },
     article: {type: GraphQLNonNull(GraphQLArticle)}
   }
 })

--- a/packages/api/src/graphql/query.private.ts
+++ b/packages/api/src/graphql/query.private.ts
@@ -591,6 +591,10 @@ export const GraphQLQuery = new GraphQLObjectType<undefined, Context>({
                         ...subtree.selections,
                         {
                           kind: Kind.FIELD,
+                          name: {kind: Kind.NAME, value: 'id'}
+                        },
+                        {
+                          kind: Kind.FIELD,
                           name: {kind: Kind.NAME, value: 'latest'},
                           selectionSet: {
                             kind: Kind.SELECTION_SET,

--- a/packages/api/src/urlAdapter.ts
+++ b/packages/api/src/urlAdapter.ts
@@ -2,9 +2,11 @@ import {PublicArticle} from './db/article'
 import {PublicPage} from './db/page'
 import {Author} from './db/author'
 import {PublicComment} from './db/comment'
+import {Peer} from './db/peer'
 
 export interface URLAdapter {
   getPublicArticleURL(article: PublicArticle): string
+  getPeeredArticleURL(peer: Peer, article: PublicArticle): string
   getPublicPageURL(page: PublicPage): string
   getAuthorURL(author: Author): string
   getArticlePreviewURL(token: string): string

--- a/packages/editor/src/client/api/article.graphql
+++ b/packages/editor/src/client/api/article.graphql
@@ -86,7 +86,7 @@ query PeerArticleList($filter: String, $after: ID, $first: Int) {
         ...PeerWithProfile
       }
 
-      peeredURL
+      peeredArticleURL
 
       article {
         ...ArticleRef

--- a/packages/editor/src/client/api/article.graphql
+++ b/packages/editor/src/client/api/article.graphql
@@ -86,6 +86,8 @@ query PeerArticleList($filter: String, $after: ID, $first: Int) {
         ...PeerWithProfile
       }
 
+      peeredURL
+
       article {
         ...ArticleRef
       }

--- a/packages/editor/src/client/api/index.ts
+++ b/packages/editor/src/client/api/index.ts
@@ -1203,7 +1203,7 @@ export type Peer = {
 export type PeerArticle = {
   __typename?: 'PeerArticle';
   peer: Peer;
-  peeredURL: Scalars['String'];
+  peeredArticleURL: Scalars['String'];
   article: Article;
 };
 
@@ -1908,7 +1908,7 @@ export type PeerArticleListQuery = (
     & Pick<PeerArticleConnection, 'totalCount'>
     & { nodes: Array<(
       { __typename?: 'PeerArticle' }
-      & Pick<PeerArticle, 'peeredURL'>
+      & Pick<PeerArticle, 'peeredArticleURL'>
       & { peer: (
         { __typename?: 'Peer' }
         & PeerWithProfileFragment
@@ -4099,7 +4099,7 @@ export const PeerArticleListDocument = gql`
       peer {
         ...PeerWithProfile
       }
-      peeredURL
+      peeredArticleURL
       article {
         ...ArticleRef
       }

--- a/packages/editor/src/client/api/index.ts
+++ b/packages/editor/src/client/api/index.ts
@@ -1203,6 +1203,7 @@ export type Peer = {
 export type PeerArticle = {
   __typename?: 'PeerArticle';
   peer: Peer;
+  peeredURL: Scalars['String'];
   article: Article;
 };
 
@@ -1907,6 +1908,7 @@ export type PeerArticleListQuery = (
     & Pick<PeerArticleConnection, 'totalCount'>
     & { nodes: Array<(
       { __typename?: 'PeerArticle' }
+      & Pick<PeerArticle, 'peeredURL'>
       & { peer: (
         { __typename?: 'Peer' }
         & PeerWithProfileFragment
@@ -4097,6 +4099,7 @@ export const PeerArticleListDocument = gql`
       peer {
         ...PeerWithProfile
       }
+      peeredURL
       article {
         ...ArticleRef
       }

--- a/packages/editor/src/client/locales/en.json
+++ b/packages/editor/src/client/locales/en.json
@@ -138,7 +138,8 @@
         "articlePreviewLink": "Article Preview Link",
         "articlePreviewLinkDesc": "Preview Links always shows the latest changes in the draft of the article. Preview Links stop working after you publish the article",
         "articlePreviewLinkHours": "Validity period of link",
-        "articlePreviewLinkField": "Preview Link"
+        "articlePreviewLinkField": "Preview Link",
+        "peeredArticlePreview": "Preview"
       }
     },
     "comments": {

--- a/packages/editor/src/client/panel/teaserSelectPanel.tsx
+++ b/packages/editor/src/client/panel/teaserSelectPanel.tsx
@@ -145,7 +145,7 @@ export function TeaserSelectPanel({onClose, onSelect}: TeaserSelectPanelProps) {
       case TeaserType.PeerArticle:
         return (
           <>
-            {peerArticles.map(({peer, article, peeredURL}) => {
+            {peerArticles.map(({peer, article, peeredArticleURL}) => {
               const states = []
 
               if (article.draft) states.push(t('articleEditor.panels.draft'))
@@ -173,7 +173,7 @@ export function TeaserSelectPanel({onClose, onSelect}: TeaserSelectPanelProps) {
                       {states.join(' / ')}
                     </div>
                     <div style={{display: 'inline', fontSize: 12, marginLeft: 8}}>
-                      <a href={peeredURL} target="_blank" rel="noreferrer">
+                      <a href={peeredArticleURL} target="_blank" rel="noreferrer">
                         {t('articleEditor.panels.peeredArticlePreview')}{' '}
                         <Icon icon="external-link" />
                       </a>

--- a/packages/editor/src/client/panel/teaserSelectPanel.tsx
+++ b/packages/editor/src/client/panel/teaserSelectPanel.tsx
@@ -145,7 +145,7 @@ export function TeaserSelectPanel({onClose, onSelect}: TeaserSelectPanelProps) {
       case TeaserType.PeerArticle:
         return (
           <>
-            {peerArticles.map(({peer, article}) => {
+            {peerArticles.map(({peer, article, peeredURL}) => {
               const states = []
 
               if (article.draft) states.push(t('articleEditor.panels.draft'))
@@ -171,6 +171,12 @@ export function TeaserSelectPanel({onClose, onSelect}: TeaserSelectPanelProps) {
                     </div>
                     <div style={{display: 'inline', fontSize: 12, marginLeft: 8}}>
                       {states.join(' / ')}
+                    </div>
+                    <div style={{display: 'inline', fontSize: 12, marginLeft: 8}}>
+                      <a href={peeredURL} target="_blank" rel="noreferrer">
+                        {t('articleEditor.panels.peeredArticlePreview')}{' '}
+                        <Icon icon="external-link" />
+                      </a>
                     </div>
                   </div>
                 </List.Item>


### PR DESCRIPTION
WPC-17 This PR adds a new method to the `URLAdapter` that returns the URL of a peered article. GraphQL will return this url in the `PeerArticle` type and the editor will display it in the Teaser selection list.