### PR TITLE
Page slug can be empty string

### DIFF
--- a/packages/api/src/graphql/query.public.ts
+++ b/packages/api/src/graphql/query.public.ts
@@ -248,7 +248,8 @@ export const GraphQLPublicQuery = new GraphQLObjectType<undefined, Context>({
       async resolve(root, {id, slug, token}, {session, loaders, verifyJWT}) {
         let page = id ? await loaders.publicPagesByID.load(id) : null
 
-        if (!page && slug) {
+        if (!page) {
+          // slug can be empty string
           page = await loaders.publicPagesBySlug.load(slug)
         }
 


### PR DESCRIPTION
This PR fixes a bug introduced by https://github.com/wepublish/wepublish/pull/305