### PR TITLE
F/wpc 524 color picker peered articles color

### DIFF
--- a/packages/editor/src/client/panel/peerEditPanel.tsx
+++ b/packages/editor/src/client/panel/peerEditPanel.tsx
@@ -220,13 +220,7 @@ export function PeerEditPanel({id, hostURL, onClose, onSave}: PeerEditPanelProps
                 {profile?.name}
               </DescriptionListItem>
               <DescriptionListItem label={t('peerList.panels.themeColor')}>
-                <div
-                  style={{
-                    backgroundColor: profile?.themeColor,
-                    width: '40px',
-                    height: '20px',
-                    padding: '5px'
-                  }}></div>
+                {profile?.themeColor}
               </DescriptionListItem>
               <DescriptionListItem label={t('peerList.panels.callToActionText')}>
                 {!!profile?.callToActionText && (

--- a/packages/editor/src/client/panel/peerEditPanel.tsx
+++ b/packages/editor/src/client/panel/peerEditPanel.tsx
@@ -220,7 +220,13 @@ export function PeerEditPanel({id, hostURL, onClose, onSave}: PeerEditPanelProps
                 {profile?.name}
               </DescriptionListItem>
               <DescriptionListItem label={t('peerList.panels.themeColor')}>
-                {profile?.themeColor}
+                <div
+                  style={{
+                    backgroundColor: profile?.themeColor,
+                    width: '40px',
+                    height: '20px',
+                    padding: '5px'
+                  }}></div>
               </DescriptionListItem>
               <DescriptionListItem label={t('peerList.panels.callToActionText')}>
                 {!!profile?.callToActionText && (

--- a/packages/editor/src/client/panel/peerEditPanel.tsx
+++ b/packages/editor/src/client/panel/peerEditPanel.tsx
@@ -220,7 +220,17 @@ export function PeerEditPanel({id, hostURL, onClose, onSave}: PeerEditPanelProps
                 {profile?.name}
               </DescriptionListItem>
               <DescriptionListItem label={t('peerList.panels.themeColor')}>
-                {profile?.themeColor}
+                <div style={{display: 'flex', flexDirection: 'row'}}>
+                  <p>{profile?.themeColor}</p>
+                  <div
+                    style={{
+                      backgroundColor: profile?.themeColor,
+                      width: '30px',
+                      height: '20px',
+                      padding: '5px',
+                      marginLeft: '5px'
+                    }}></div>
+                </div>
               </DescriptionListItem>
               <DescriptionListItem label={t('peerList.panels.callToActionText')}>
                 {!!profile?.callToActionText && (

--- a/packages/editor/src/client/panel/peerProfileEditPanel.tsx
+++ b/packages/editor/src/client/panel/peerProfileEditPanel.tsx
@@ -29,6 +29,7 @@ import {useTranslation} from 'react-i18next'
 import {ChooseEditImage} from '../atoms/chooseEditImage'
 import {createDefaultValue, RichTextBlock} from '../blocks/richTextBlock/richTextBlock'
 import {RichTextBlockValue} from '../blocks/types'
+import {ColorPicker} from '../atoms/colorPicker'
 
 type PeerProfileImage = NonNullable<PeerProfileQuery['peerProfile']>['logo']
 
@@ -133,10 +134,11 @@ export function PeerInfoEditPanel({onClose, onSave}: ImageEditPanelProps) {
             </FormGroup>
             <FormGroup>
               <ControlLabel>{t('peerList.panels.themeColor')}</ControlLabel>
-              <FormControl
-                name="themeColor"
-                value={themeColor}
-                onChange={value => setThemeColor(value)}
+              <ColorPicker
+                setColor={color => {
+                  setThemeColor(color)
+                }}
+                currentColor={themeColor}
               />
             </FormGroup>
 


### PR DESCRIPTION
I replaced the theme color in edit peer info by a color picker. 

I also replaced the color field in peer by a div showing the color (instead of the hex number).

![image](https://user-images.githubusercontent.com/58177575/134695023-c72638c4-8a43-4479-83ee-e62b15cf2574.png)
![image](https://user-images.githubusercontent.com/58177575/134696073-8bc303ba-86d2-40a1-94b8-00e83aca22ba.png)
