### PR TITLE
fix preset buttons on date picker

### DIFF
--- a/packages/editor/src/client/atoms/dateTimePicker.less
+++ b/packages/editor/src/client/atoms/dateTimePicker.less
@@ -53,6 +53,10 @@
     font-weight: unset;
   }
 
+  &__close-icon::after {
+    padding: unset;
+  }
+
   &__input-container {
     margin-bottom: 10px;
     width: unset;

--- a/packages/editor/src/client/atoms/dateTimePicker.tsx
+++ b/packages/editor/src/client/atoms/dateTimePicker.tsx
@@ -56,6 +56,7 @@ export function DateTimePicker({
     }
     day.setDate(day.getDate() + offset)
     setDateSelection(day)
+    changeDate(day)
   }
 
   const handleTimePresetButton = (hour: number) => {
@@ -65,9 +66,11 @@ export function DateTimePicker({
       day.setHours(now.getHours())
       day.setMinutes(now.getMinutes())
       setDateSelection(day)
+      changeDate(day)
     } else {
       day.setHours(hour, 0, 0)
       setDateSelection(day)
+      changeDate(day)
     }
   }
   return (


### PR DESCRIPTION
WPC-543: 
- Fix bug on preset buttons in the date picker to use selected date/time for publishing instead of now.
- Fix date clear button to be round in Firefox.