### PR TITLE
date fixes on calendar picker

### DIFF
--- a/packages/editor/src/client/panel/publishArticlePanel.tsx
+++ b/packages/editor/src/client/panel/publishArticlePanel.tsx
@@ -26,7 +26,9 @@ export function PublishArticlePanel({
 }: PublishArticlePanelProps) {
   const now = new Date()
 
-  const [publishDate, setPublishDate] = useState<Date | undefined>(initialPublishDate ?? now)
+  const [publishDate, setPublishDate] = useState<Date | undefined>(
+    pendingPublishDate ?? initialPublishDate ?? now
+  )
   const [updateDate, setUpdateDate] = useState<Date | undefined>(now)
 
   const {t} = useTranslation()
@@ -47,7 +49,7 @@ export function PublishArticlePanel({
           />
         )}
         <DateTimePicker
-          dateTime={pendingPublishDate ?? publishDate}
+          dateTime={publishDate}
           label={t('articleEditor.panels.publishDate')}
           changeDate={date => setPublishDate(date)}
         />

--- a/packages/editor/src/client/panel/publishPagePanel.tsx
+++ b/packages/editor/src/client/panel/publishPagePanel.tsx
@@ -27,7 +27,9 @@ export function PublishPagePanel({
 }: PublishPagePanelProps) {
   const now = new Date()
 
-  const [publishDate, setPublishDate] = useState<Date | undefined>(initialPublishDate ?? now)
+  const [publishDate, setPublishDate] = useState<Date | undefined>(
+    pendingPublishDate ?? initialPublishDate ?? now
+  )
   const [updateDate, setUpdateDate] = useState<Date | undefined>(now)
 
   const {t} = useTranslation()
@@ -46,7 +48,7 @@ export function PublishPagePanel({
           />
         )}
         <DateTimePicker
-          dateTime={pendingPublishDate ?? publishDate}
+          dateTime={publishDate}
           label={t('articleEditor.panels.publishDate')}
           changeDate={date => setPublishDate(date)}
         />


### PR DESCRIPTION
WPC-566: This fixes the bug where the date picker set the publish date as today when it displayed a future date without selecting.