### PR TITLE
implemented a quick fix for failed registrations

### DIFF
--- a/packages/api/src/error.ts
+++ b/packages/api/src/error.ts
@@ -18,7 +18,7 @@ export enum ErrorCode {
   DuplicatePageSlug = 'DUPLICATE_PAGE_SLUG',
   CommentLengthError = 'COMMENT_LENGTH_ERROR',
   PeerTokenInvalid = 'PEER_TOKEN_INVALID',
-
+  InternalError = 'InternalError',
   UserSubscriptionAlreadyDeactivated = 'USER_SUBSCRIPTION_ALREADY_DEACTIVATED'
 }
 
@@ -124,6 +124,12 @@ export class CommentLengthError extends ApolloError {
 export class PeerTokenInvalidError extends ApolloError {
   constructor(peerUrl: string) {
     super(`Token for peer ${peerUrl} is invalid`, ErrorCode.PeerTokenInvalid)
+  }
+}
+
+export class InternalError extends ApolloError {
+  constructor() {
+    super(`Internal Error`, ErrorCode.InternalError)
   }
 }
 

--- a/packages/api/src/graphql/mutation.public.ts
+++ b/packages/api/src/graphql/mutation.public.ts
@@ -28,7 +28,8 @@ import {
   NotAuthenticatedError,
   UserInputError,
   CommentLengthError,
-  UserSubscriptionAlreadyDeactivated
+  UserSubscriptionAlreadyDeactivated,
+  InternalError
 } from '../error'
 import {GraphQLPaymentFromInvoiceInput, GraphQLPublicPayment} from './payment'
 import {GraphQLPaymentPeriodicity} from './memberPlan'
@@ -50,7 +51,8 @@ import {
   countRichtextChars,
   FIFTEEN_MINUTES_IN_MILLISECONDS,
   MAX_COMMENT_LENGTH,
-  USER_PROPERTY_LAST_LOGIN_LINK_SEND
+  USER_PROPERTY_LAST_LOGIN_LINK_SEND,
+  USER_PROPERTY_ORG_EMAIL
 } from '../utility'
 import {SendMailType} from '../mails/mailContext'
 import {GraphQLSlug} from './slug'
@@ -223,12 +225,8 @@ export const GraphQLPublicMutation = new GraphQLObjectType<undefined, Context>({
           successURL,
           failureURL
         },
-        {dbAdapter, loaders, authenticateUser, memberContext, createPaymentWithProvider}
+        {dbAdapter, loaders, memberContext, createPaymentWithProvider}
       ) {
-        /* const userSession = authenticateUser()
-        if(userSession.user) throw new Error('Can not register authenticated user') // TODO: check this again
-        */
-
         if (
           (memberPlanID == null && memberPlanSlug == null) ||
           (memberPlanID != null && memberPlanSlug != null)
@@ -257,20 +255,35 @@ export const GraphQLPublicMutation = new GraphQLObjectType<undefined, Context>({
         )
           throw new PaymentConfigurationNotAllowed()
 
+        const userExists = await dbAdapter.user.getUser(email)
+        if (userExists) throw new EmailAlreadyInUseError()
+
+        // FIXME: tempEmail is need because the register could fail and the user might try
+        //  again with the same mail address. This will be fixed in WPC-595
+        const tempEmail = `temp_${Date.now()}_${email}`
         const user = await dbAdapter.user.createUser({
           input: {
             name,
             preferredName,
-            email,
+            email: tempEmail,
             emailVerifiedAt: null,
             active: false,
-            properties: [],
+            properties: [
+              {
+                public: false,
+                key: USER_PROPERTY_ORG_EMAIL,
+                value: email
+              }
+            ],
             roleIDs: []
           },
           password: crypto.randomBytes(48).toString('hex')
         })
 
-        if (!user) throw new Error('Could not create user') // TODO: check if this is needed
+        if (!user) {
+          logger('mutation.public').error('Could not create new user for email "%s"', email)
+          throw new InternalError()
+        }
 
         const subscription = await dbAdapter.user.updateUserSubscription({
           userID: user.id,
@@ -286,17 +299,29 @@ export const GraphQLPublicMutation = new GraphQLObjectType<undefined, Context>({
           }
         })
 
-        if (!subscription) throw new Error('Could not create subscription')
+        if (!subscription) {
+          logger('mutation.public').error(
+            'Could not create new subscription for userID "%s"',
+            user.id
+          )
+          throw new InternalError()
+        }
 
         // Create Periods, Invoices and Payment
         const invoice = await memberContext.renewSubscriptionForUser({
           userID: user.id,
-          userEmail: user.email,
+          userEmail: email,
           userName: user.name,
           userSubscription: subscription
         })
 
-        if (!invoice) throw new Error('Could not create invoice')
+        if (!invoice) {
+          logger('mutation.public').error(
+            'Could not create new invoice for subscription of userID "%s"',
+            user.id
+          )
+          throw new InternalError()
+        }
 
         return await createPaymentWithProvider({
           invoice,

--- a/packages/api/src/utility.ts
+++ b/packages/api/src/utility.ts
@@ -168,3 +168,4 @@ export const ONE_DAY_IN_MILLISECONDS = 24 * ONE_HOUR_IN_MILLISECONDS
 export const FIFTEEN_MINUTES_IN_MILLISECONDS = 900000
 
 export const USER_PROPERTY_LAST_LOGIN_LINK_SEND = '_wepLastLoginLinkSentTimestamp'
+export const USER_PROPERTY_ORG_EMAIL = '_wepOrgEmail'


### PR DESCRIPTION
This PR introduces a quick way of handling failed registrations. During the registration the user will be created with a temporary mail address. Only after the first successful payment the user will be updated with the correct mail address.