### PR TITLE
Member context improvements

### DIFF
--- a/examples/api/src/index.ts
+++ b/examples/api/src/index.ts
@@ -432,6 +432,17 @@ async function asyncMain() {
         await server.runJob(JobType.DailyInvoiceCharger, {})
         process.exit(0)
       }
+    )
+    .command(
+      'checkdic',
+      'check open invoices',
+      () => {
+        /* do nothing */
+      },
+      async () => {
+        await server.runJob(JobType.DailyInvoiceChecker, {})
+        process.exit(0)
+      }
     ).argv
 }
 

--- a/packages/api/src/graphql/query.public.ts
+++ b/packages/api/src/graphql/query.public.ts
@@ -413,7 +413,11 @@ export const GraphQLPublicQuery = new GraphQLObjectType<undefined, Context>({
           if (!paymentProvider) continue // TODO: what happens if we don't find a paymentProvider
 
           const intentState = await paymentProvider.checkIntentStatus({intentID: payment.intentID})
-          await paymentProvider.updatePaymentWithIntentState({intentState, context})
+          await paymentProvider.updatePaymentWithIntentState({
+            intentState,
+            dbAdapter: context.dbAdapter,
+            loaders: context.loaders
+          })
         }
 
         // FIXME: We need to implement a way to wait for all the database

--- a/packages/api/src/jobs.ts
+++ b/packages/api/src/jobs.ts
@@ -4,6 +4,7 @@ import {SendMailType} from './mails/mailContext'
 
 export enum JobType {
   DailyMembershipRenewal = 'dailyMembershipRenewal',
+  DailyInvoiceChecker = 'dailyInvoiceChecker',
   DailyInvoiceCharger = 'dailyInvoiceCharger',
   DailyInvoiceReminder = 'dailyInvoiceReminder',
   SendTestMail = 'sendTestMail'
@@ -19,6 +20,12 @@ async function dailyMembershipRenewal(context: Context, data: any): Promise<void
     daysToLookAhead
   })
   logger('jobs').info('finishing dailyMembershipRenewal')
+}
+
+async function dailyInvoiceChecker(context: Context): Promise<void> {
+  logger('jobs').info('starting dailyInvoiceChecker')
+  await context.memberContext.checkOpenInvoices()
+  logger('jobs').info('finishing dailyInvoiceChecker')
 }
 
 async function dailyInvoiceCharger(context: Context): Promise<void> {
@@ -64,6 +71,9 @@ export async function runJob(command: JobType, context: Context, data: any): Pro
   switch (command) {
     case JobType.DailyMembershipRenewal:
       await dailyMembershipRenewal(context, data)
+      break
+    case JobType.DailyInvoiceChecker:
+      await dailyInvoiceChecker(context)
       break
     case JobType.SendTestMail:
       await sendTestMail(context, data)

--- a/packages/api/src/memberContext.ts
+++ b/packages/api/src/memberContext.ts
@@ -85,7 +85,7 @@ export interface MemberContextProps {
 }
 
 function getNextDateForPeriodicity(start: Date, periodicity: PaymentPeriodicity): Date {
-  start = new Date(start) // create new Date object
+  start = new Date(start.getTime() - ONE_DAY_IN_MILLISECONDS) // create new Date object
   switch (periodicity) {
     case PaymentPeriodicity.Monthly:
       return new Date(start.setMonth(start.getMonth() + 1))

--- a/packages/api/src/memberContext.ts
+++ b/packages/api/src/memberContext.ts
@@ -50,6 +50,11 @@ export interface SendReminderForInvoicesProps {
   sendEveryDays?: number // defaults to 3
 }
 
+export interface CheckOpenInvoiceProps {
+  paymentMethodID: string
+  invoice: Invoice
+}
+
 export interface MemberContext {
   dbAdapter: DBAdapter
   loaders: DataLoaderContext
@@ -61,6 +66,9 @@ export interface MemberContext {
 
   renewSubscriptionForUser(props: RenewSubscriptionForUserProps): Promise<OptionalInvoice>
   renewSubscriptionForUsers(props: RenewSubscriptionForUsersProps): Promise<void>
+
+  checkOpenInvoices(): Promise<void>
+  checkOpenInvoice(props: CheckOpenInvoiceProps): Promise<void>
 
   chargeInvoice(props: ChargeInvoiceProps): Promise<void>
   chargeOpenInvoices(): Promise<void>
@@ -299,6 +307,103 @@ export class MemberContext implements MemberContext {
     }
   }
 
+  async checkOpenInvoices(): Promise<void> {
+    const invoices = await this.dbAdapter.invoice.getInvoices({
+      filter: {
+        paidAt: {
+          comparison: DateFilterComparison.Equal,
+          date: null
+        },
+        canceledAt: {
+          comparison: DateFilterComparison.Equal,
+          date: null
+        }
+      },
+      limit: {type: LimitType.First, count: 200},
+      order: SortOrder.Ascending,
+      sort: InvoiceSort.CreatedAt,
+      cursor: InputCursor()
+    })
+
+    for (const invoice of invoices.nodes) {
+      if (!invoice.userID) {
+        logger('memberContext').warn('invoice %s does not have an user ID', invoice.id)
+        continue
+      }
+
+      const user = await this.dbAdapter.user.getUserByID(invoice.userID)
+      if (!user || !user.subscription) {
+        logger('memberContext').warn('user or subscription %s not found', invoice.userID)
+        continue
+      }
+
+      const paymentMethod = await this.loaders.paymentMethodsByID.load(
+        user.subscription.paymentMethodID
+      )
+      if (!paymentMethod) {
+        logger('memberContext').warn(
+          'paymentMethod %s not found',
+          user.subscription.paymentMethodID
+        )
+        continue
+      }
+
+      await this.checkOpenInvoice({
+        paymentMethodID: paymentMethod.id,
+        invoice
+      })
+    }
+  }
+
+  async checkOpenInvoice({paymentMethodID, invoice}: CheckOpenInvoiceProps): Promise<void> {
+    const paymentMethods = await this.dbAdapter.paymentMethod.getPaymentMethods()
+    const paymentMethod = paymentMethods.find(method => method.id === paymentMethodID)
+    if (!paymentMethod) {
+      logger('memberContext').error('PaymentMethod %s does not exist', paymentMethodID)
+      return
+    }
+    const paymentProvider = this.paymentProviders.find(
+      provider => provider.id === paymentMethod.paymentProviderID
+    )
+    if (!paymentProvider) {
+      logger('memberContext').error(
+        'PaymentProvider %s does not exist',
+        paymentMethod.paymentProviderID
+      )
+      return
+    }
+
+    const payments = await this.dbAdapter.payment.getPaymentsByInvoiceID(invoice.id)
+
+    for (const payment of payments) {
+      if (!payment || !payment.intentID) {
+        logger('memberContext').error('Payment %s does not have an intetID', payment?.id)
+        continue
+      }
+      try {
+        const intentState = await paymentProvider.checkIntentStatus({
+          intentID: payment.intentID
+        })
+
+        await paymentProvider.updatePaymentWithIntentState({
+          intentState,
+          dbAdapter: this.dbAdapter,
+          loaders: this.loaders
+        })
+
+        // FIXME: We need to implement a way to wait for all the database
+        //  event hooks to finish before we return data. Will be solved in WPC-498
+        await new Promise(resolve => setTimeout(resolve, 100))
+      } catch (error) {
+        logger('memberContext').error(
+          error,
+          'Checking Intent State for Payment %s failed',
+          payment?.id
+        )
+      }
+    }
+  }
+
   private getOffSessionPaymentProviderIDs(): string[] {
     return this.paymentProviders
       .filter(provider => provider.offSessionPayments)
@@ -334,6 +439,11 @@ export class MemberContext implements MemberContext {
       const user = await this.dbAdapter.user.getUserByID(invoice.userID)
       if (!user || !user.subscription) {
         logger('memberContext').warn('user or subscription %s not found', invoice.userID)
+        continue
+      }
+
+      if (!user.active) {
+        logger('memberContext').warn('user %s is not active', user.id)
         continue
       }
 
@@ -402,14 +512,6 @@ export class MemberContext implements MemberContext {
       return
     }
 
-    const payment = await this.dbAdapter.payment.createPayment({
-      input: {
-        paymentMethodID,
-        invoiceID: invoice.id,
-        state: PaymentState.Created
-      }
-    })
-
     const paymentMethod = paymentMethods.find(method => method.id === paymentMethodID)
     if (!paymentMethod) {
       logger('memberContext').error('PaymentMethod %s does not exist', paymentMethodID)
@@ -425,6 +527,14 @@ export class MemberContext implements MemberContext {
       )
       return
     }
+
+    const payment = await this.dbAdapter.payment.createPayment({
+      input: {
+        paymentMethodID,
+        invoiceID: invoice.id,
+        state: PaymentState.Created
+      }
+    })
 
     const intent = await paymentProvider.createIntent({
       paymentID: payment.id,
@@ -485,7 +595,7 @@ export class MemberContext implements MemberContext {
     })
 
     if (invoices.nodes.length === 0) {
-      logger('memberContext').info('No open infos to remind')
+      logger('memberContext').info('No open invoices to remind')
     }
 
     for (const invoice of invoices.nodes) {
@@ -498,6 +608,24 @@ export class MemberContext implements MemberContext {
         ) > today
       ) {
         continue // skip reminder if not enough days passed
+      }
+
+      // TODO: check if user is not active and if true skip.
+
+      if (!invoice.userID) {
+        logger('memberContext').warn('invoice %s does not have an user ID', invoice.id)
+        continue
+      }
+
+      const user = await this.dbAdapter.user.getUserByID(invoice.userID)
+      if (!user || !user.subscription) {
+        logger('memberContext').warn('user or subscription %s not found', invoice.userID)
+        continue
+      }
+
+      if (!user.active) {
+        logger('memberContext').warn('user %s is not active', user.id)
+        continue
       }
 
       try {

--- a/packages/api/src/payments/paymentProvider.ts
+++ b/packages/api/src/payments/paymentProvider.ts
@@ -1,11 +1,12 @@
 import express, {Router} from 'express'
-import {Context, contextFromRequest} from '../context'
+import {contextFromRequest, DataLoaderContext} from '../context'
 import {logger, WepublishServerOpts} from '../server'
 import {Payment, PaymentState} from '../db/payment'
 import {Invoice} from '../db/invoice'
 import {NextHandleFunction} from 'connect'
 import bodyParser from 'body-parser'
 import {paymentModelEvents} from '../events'
+import {DBAdapter} from '../db/adapter'
 
 export const PAYMENT_WEBHOOK_PATH_PREFIX = 'payment-webhooks'
 
@@ -36,7 +37,8 @@ export interface CheckIntentProps {
 
 export interface UpdatePaymentWithIntentStateProps {
   intentState: IntentState
-  context: Context
+  dbAdapter: DBAdapter
+  loaders: DataLoaderContext
 }
 
 export interface WebhookUpdatesProps {
@@ -105,13 +107,14 @@ export abstract class BasePaymentProvider implements PaymentProvider {
 
   async updatePaymentWithIntentState({
     intentState,
-    context
+    dbAdapter,
+    loaders
   }: UpdatePaymentWithIntentStateProps): Promise<Payment> {
-    const payment = await context.loaders.paymentsByID.load(intentState.paymentID)
+    const payment = await loaders.paymentsByID.load(intentState.paymentID)
     // TODO: should we overwrite already paid/canceled payments
     if (!payment) throw new Error(`Payment with ID ${intentState.paymentID} not found`)
 
-    const updatedPayment = await context.dbAdapter.payment.updatePayment({
+    const updatedPayment = await dbAdapter.payment.updatePayment({
       id: payment.id,
       input: {
         state: intentState.state,
@@ -127,11 +130,11 @@ export abstract class BasePaymentProvider implements PaymentProvider {
     if (!updatedPayment) throw new Error('Error while updating Payment')
 
     if (intentState.customerID && payment.invoiceID) {
-      const invoice = await context.loaders.invoicesByID.load(payment.invoiceID)
+      const invoice = await loaders.invoicesByID.load(payment.invoiceID)
       if (!invoice?.userID)
         throw new Error(`Invoice with ID ${payment.invoiceID} does not have a userID`)
 
-      const user = await context.dbAdapter.user.getUserByID(invoice.userID)
+      const user = await dbAdapter.user.getUserByID(invoice.userID)
       if (!user) throw new Error(`User with ID ${invoice.userID} does not exist`)
 
       // adding or updating paymentProvider customer ID for user
@@ -142,7 +145,7 @@ export abstract class BasePaymentProvider implements PaymentProvider {
         paymentProviderID: this.id,
         customerID: intentState.customerID
       })
-      await context.dbAdapter.user.updatePaymentProviderCustomers({
+      await dbAdapter.user.updatePaymentProviderCustomers({
         userID: user.id,
         paymentProviderCustomers
       })
@@ -190,7 +193,8 @@ export function setupPaymentProvider(opts: WepublishServerOpts): Router {
             // TODO: handle errors properly
             await paymentProvider.updatePaymentWithIntentState({
               intentState: paymentStatus,
-              context
+              dbAdapter: context.dbAdapter,
+              loaders: context.loaders
             })
           }
         } catch (error) {


### PR DESCRIPTION
Added new job `dailyInvoiceChecker`  that checks the intent state of all payments on open invoices.
 
The job `chargeOpenInvoices` now charges open invoices only if the user is active.

The job `dailyInvoiceReminder` only sends mail if the user still exists and is active.

This PR also corrects the calculation for the end date of periods when renewing subscriptions. 