### PR TITLE
generate loginURL for mails

### DIFF
--- a/examples/api/src/index.ts
+++ b/examples/api/src/index.ts
@@ -74,7 +74,7 @@ class ExampleURLAdapter implements URLAdapter {
   }
 
   getLoginURL(token: string): string {
-    return `${this.websiteURL}/login/jwt=${token}`
+    return `${this.websiteURL}/login?jwt=${token}`
   }
 }
 

--- a/examples/api/templates/emails/memberSubscriptionPayment/offSessionPaymentOneWeekBefore/html.pug
+++ b/examples/api/templates/emails/memberSubscriptionPayment/offSessionPaymentOneWeekBefore/html.pug
@@ -3,5 +3,5 @@ extends ../../base.pug
 block content
     h1 Hi #{user.name}
 
-    p We will try to bill your cc in #{invoice.dueAt}. If you want to change the amount, payment method or something else. Please use the link: #{userPaymentURL}
+    p We will try to bill your cc in #{invoice.dueAt}. If you want to change the amount, payment method or something else. Please use the link: #{loginURL}&invoice=#{invoice.id}
 

--- a/examples/api/templates/emails/memberSubscriptionPayment/onSessionAfter/html.pug
+++ b/examples/api/templates/emails/memberSubscriptionPayment/onSessionAfter/html.pug
@@ -3,5 +3,5 @@ extends ../../base.pug
 block content
     h1 Hi #{user.name}
 
-    p Your invoice is due since ${invoice.dueAt.toISOString()}. Please click the link to pay otherwise your account will be suspended: #{userPaymentURL}?invoice=#{invoice.id}
+    p Your invoice is due since ${invoice.dueAt.toISOString()}. Please click the link to pay otherwise your account will be suspended: #{loginURL}&invoice=#{invoice.id}
 

--- a/examples/api/templates/emails/memberSubscriptionPayment/onSessionBefore/html.pug
+++ b/examples/api/templates/emails/memberSubscriptionPayment/onSessionBefore/html.pug
@@ -3,5 +3,5 @@ extends ../../base.pug
 block content
     h1 Hi #{user.name}
 
-    p You have a new invoice open which is due at  #{invoice.dueAt}. Click the link to pay: #{userPaymentURL}?invoice=${invoice.id}
+    p You have a new invoice open which is due at  #{invoice.dueAt}. Click the link to pay: #{loginURL}&invoice=${invoice.id}
 

--- a/packages/api/src/context.ts
+++ b/packages/api/src/context.ts
@@ -309,6 +309,12 @@ export async function contextFromRequest(
     return jwt.sign({sub: props.id}, process.env.JWT_SECRET_KEY, jwtOptions)
   }
 
+  const verifyJWT = (token: string): string => {
+    if (!process.env.JWT_SECRET_KEY) throw new Error('No JWT_SECRET_KEY defined in environment.')
+    const ver = jwt.verify(token, process.env.JWT_SECRET_KEY)
+    return typeof ver === 'object' && 'sub' in ver ? (ver as Record<string, any>).sub : ''
+  }
+
   const memberContext = new MemberContext({
     loaders,
     dbAdapter,
@@ -389,22 +395,9 @@ export async function contextFromRequest(
       return session
     },
 
-    generateJWT(props: GenerateJWTProps): string {
-      if (!process.env.JWT_SECRET_KEY) throw new Error('No JWT_SECRET_KEY defined in environment.')
-      const jwtOptions: SignOptions = {
-        issuer: hostURL,
-        audience: props.audience ?? websiteURL,
-        algorithm: 'HS256',
-        expiresIn: `${props.expiresInMinutes || 15}m`
-      }
-      return jwt.sign({sub: props.id}, process.env.JWT_SECRET_KEY, jwtOptions)
-    },
+    generateJWT,
 
-    verifyJWT(token: string): string {
-      if (!process.env.JWT_SECRET_KEY) throw new Error('No JWT_SECRET_KEY defined in environment.')
-      const ver = jwt.verify(token, process.env.JWT_SECRET_KEY)
-      return typeof ver === 'object' && 'sub' in ver ? (ver as Record<string, any>).sub : ''
-    },
+    verifyJWT,
 
     async createPaymentWithProvider({
       paymentMethodID,

--- a/packages/api/src/context.ts
+++ b/packages/api/src/context.ts
@@ -44,6 +44,7 @@ import {OptionalMailLog} from './db/mailLog'
 import {MemberContext} from './memberContext'
 import {Client, Issuer} from 'openid-client'
 import {MailContext, MailContextOptions} from './mails/mailContext'
+import {User} from './db/user'
 
 export interface DataLoaderContext {
   readonly navigationByID: DataLoader<string, OptionalNavigation>
@@ -297,11 +298,30 @@ export async function contextFromRequest(
     mailTemplatesPath: mailContextOptions.mailTemplatesPath
   })
 
+  const generateJWT = (props: GenerateJWTProps): string => {
+    if (!process.env.JWT_SECRET_KEY) throw new Error('No JWT_SECRET_KEY defined in environment.')
+    const jwtOptions: SignOptions = {
+      issuer: hostURL,
+      audience: props.audience ?? websiteURL,
+      algorithm: 'HS256',
+      expiresIn: `${props.expiresInMinutes || 15}m`
+    }
+    return jwt.sign({sub: props.id}, process.env.JWT_SECRET_KEY, jwtOptions)
+  }
+
   const memberContext = new MemberContext({
     loaders,
     dbAdapter,
     paymentProviders,
-    mailContext
+    mailContext,
+    getLoginUrlForUser(user: User): string {
+      const jwt = generateJWT({
+        id: user.id,
+        expiresInMinutes: 10080 // One week in minutes
+      })
+
+      return urlAdapter.getLoginURL(jwt)
+    }
   })
 
   return {

--- a/packages/api/src/jobs.ts
+++ b/packages/api/src/jobs.ts
@@ -37,19 +37,14 @@ async function dailyInvoiceCharger(context: Context): Promise<void> {
 async function dailyInvoiceReminder(context: Context, data: any): Promise<void> {
   logger('jobs').info('starting dailyInvoiceReminder')
 
-  const {userPaymentURL, replyToAddress} = data
+  const {replyToAddress} = data
 
   if (!replyToAddress) {
     throw new Error('No replyToAddress provided')
   }
 
-  if (!userPaymentURL) {
-    throw new Error('No userPaymentURL provided')
-  }
-
   await context.memberContext.sendReminderForInvoices({
-    replyToAddress,
-    userPaymentURL
+    replyToAddress
   })
   logger('jobs').info('finishing dailyInvoiceReminder')
 }

--- a/packages/api/src/memberContext.ts
+++ b/packages/api/src/memberContext.ts
@@ -46,12 +46,10 @@ export interface ChargeInvoiceProps {
 
 export interface SendReminderForInvoiceProps {
   invoice: Invoice
-  userPaymentURL: string
   replyToAddress: string
 }
 
 export interface SendReminderForInvoicesProps {
-  userPaymentURL: string
   replyToAddress: string
 }
 
@@ -71,6 +69,7 @@ export interface MemberContext {
   paymentProviders: PaymentProvider[]
 
   mailContext: MailContext
+  getLoginUrlForUser(user: User): string
 
   handleSubscriptionChange(props: HandleSubscriptionChangeProps): Promise<UserSubscription>
 
@@ -94,6 +93,7 @@ export interface MemberContextProps {
   readonly loaders: DataLoaderContext
   readonly paymentProviders: PaymentProvider[]
   readonly mailContext: MailContext
+  getLoginUrlForUser(user: User): string
 }
 
 function getNextDateForPeriodicity(start: Date, periodicity: PaymentPeriodicity): Date {
@@ -167,6 +167,7 @@ export class MemberContext implements MemberContext {
   paymentProviders: PaymentProvider[]
 
   mailContext: MailContext
+  getLoginUrlForUser: (user: User) => string
 
   constructor(props: MemberContextProps) {
     this.dbAdapter = props.dbAdapter
@@ -174,6 +175,8 @@ export class MemberContext implements MemberContext {
     this.paymentProviders = props.paymentProviders
 
     this.mailContext = props.mailContext
+
+    this.getLoginUrlForUser = props.getLoginUrlForUser
   }
 
   async handleSubscriptionChange({
@@ -640,10 +643,7 @@ export class MemberContext implements MemberContext {
     }
   }
 
-  async sendReminderForInvoices({
-    replyToAddress,
-    userPaymentURL
-  }: SendReminderForInvoicesProps): Promise<void> {
+  async sendReminderForInvoices({replyToAddress}: SendReminderForInvoicesProps): Promise<void> {
     const today = new Date()
 
     const invoices = await this.dbAdapter.invoice.getInvoices({
@@ -714,8 +714,7 @@ export class MemberContext implements MemberContext {
       try {
         await this.sendReminderForInvoice({
           invoice,
-          replyToAddress,
-          userPaymentURL
+          replyToAddress
         })
       } catch (error) {
         logger('memberContext').error(error, 'Error while sending reminder')
@@ -725,8 +724,7 @@ export class MemberContext implements MemberContext {
 
   async sendReminderForInvoice({
     invoice,
-    replyToAddress,
-    userPaymentURL
+    replyToAddress
   }: SendReminderForInvoiceProps): Promise<void> {
     const today = new Date()
 
@@ -746,7 +744,7 @@ export class MemberContext implements MemberContext {
           data: {
             invoice,
             user,
-            userPaymentURL
+            ...(user ? {loginURL: this.getLoginUrlForUser(user)} : {})
           }
         })
       } else {
@@ -760,7 +758,7 @@ export class MemberContext implements MemberContext {
           data: {
             invoice,
             user,
-            userPaymentURL
+            ...(user ? {loginURL: this.getLoginUrlForUser(user)} : {})
           }
         })
       } else {
@@ -770,7 +768,7 @@ export class MemberContext implements MemberContext {
           data: {
             invoice,
             user,
-            userPaymentURL
+            ...(user ? {loginURL: this.getLoginUrlForUser(user)} : {})
           }
         })
       }


### PR DESCRIPTION
This PR removes the `userPaymentURL` from the `sendReminderForInvoices` method and adds a loginURL for the subscription reminder mails.