### PR TITLE
bug fix for user.subscription.deactivation filters

### DIFF
--- a/packages/api-db-mongodb/src/db/user.ts
+++ b/packages/api-db-mongodb/src/db/user.ts
@@ -319,14 +319,28 @@ export class MongoDBUserAdapter implements DBUserAdapter {
         }
       })
     }
-    if (filter?.subscription?.deactivatedAt !== undefined) {
-      const {comparison, date} = filter.subscription.deactivatedAt
+    if (filter?.subscription?.deactivationDate !== undefined) {
+      const {comparison, date} = filter.subscription.deactivationDate
+
+      if (date === null) {
+        textFilter.$and?.push({'subscription.deactivation': {$eq: null}})
+      } else {
+        textFilter.$and?.push({
+          'subscription.deactivation.date': {
+            [mapDateFilterComparisonToMongoQueryOperatior(comparison)]: date
+          }
+        })
+      }
+    }
+
+    if (filter?.subscription?.deactivationReason !== undefined) {
+      const reason = filter.subscription.deactivationReason
+
       textFilter.$and?.push({
-        'subscription.deactivatedAt': {
-          [mapDateFilterComparisonToMongoQueryOperatior(comparison)]: date
-        }
+        'subscription.deactivation.reason': reason
       })
     }
+
     if (filter?.subscription?.autoRenew !== undefined) {
       textFilter.$and?.push({'subscription.autoRenew': {$eq: filter.subscription.autoRenew}})
     }

--- a/packages/api/__tests__/api/public/index.ts
+++ b/packages/api/__tests__/api/public/index.ts
@@ -419,7 +419,7 @@ export type Mutation = {
   /**
    * This mutation allows to update the user's subscription by taking an input of
    * type UserSubscription and throws an error if the user doesn't already have a
-   * subscription. Updating user subscriptions will set deactivatedAt to null
+   * subscription. Updating user subscriptions will set deactivation to null
    */
   updateUserSubscription?: Maybe<UserSubscription>
   /** This mutation allows to cancel the user's subscription. The deactivation date will be either paidUntil or now */

--- a/packages/api/src/db/user.ts
+++ b/packages/api/src/db/user.ts
@@ -46,7 +46,8 @@ export enum UserSort {
 export interface UserSubscriptionFilter {
   readonly startsAt?: DateFilter
   readonly paidUntil?: DateFilter
-  readonly deactivatedAt?: DateFilter
+  readonly deactivationDate?: DateFilter
+  readonly deactivationReason?: SubscriptionDeactivationReason
   readonly autoRenew?: boolean
 }
 

--- a/packages/api/src/graphql/mutation.public.ts
+++ b/packages/api/src/graphql/mutation.public.ts
@@ -472,7 +472,7 @@ export const GraphQLPublicMutation = new GraphQLObjectType<undefined, Context>({
         input: {type: GraphQLNonNull(GraphQLPublicUserSubscriptionInput)}
       },
       description:
-        "This mutation allows to update the user's subscription by taking an input of type UserSubscription and throws an error if the user doesn't already have a subscription. Updating user subscriptions will set deactivatedAt to null",
+        "This mutation allows to update the user's subscription by taking an input of type UserSubscription and throws an error if the user doesn't already have a subscription. Updating user subscriptions will set deactivation to null",
       async resolve(root, {input}, {authenticateUser, dbAdapter, loaders, memberContext}) {
         const {user} = authenticateUser()
 

--- a/packages/api/src/memberContext.ts
+++ b/packages/api/src/memberContext.ts
@@ -315,7 +315,7 @@ export class MemberContext implements MemberContext {
         subscription: {
           autoRenew: true,
           paidUntil: {date: lookAheadDate, comparison: DateFilterComparison.LowerThanOrEqual},
-          deactivatedAt: {date: null, comparison: DateFilterComparison.Equal}
+          deactivationDate: {date: null, comparison: DateFilterComparison.Equal}
         }
       },
       limit: {type: LimitType.First, count: 200},
@@ -329,7 +329,7 @@ export class MemberContext implements MemberContext {
         subscription: {
           autoRenew: true,
           paidUntil: {date: null, comparison: DateFilterComparison.Equal},
-          deactivatedAt: {date: null, comparison: DateFilterComparison.Equal}
+          deactivationDate: {date: null, comparison: DateFilterComparison.Equal}
         }
       },
       limit: {type: LimitType.First, count: 200},


### PR DESCRIPTION
The model/schema change in #475 did consider the GraphQL filters but not the actual mongodb filters. This PR will fix it.