### PR TITLE
send next invoice reminder fix

### DIFF
--- a/packages/api/src/memberContext.ts
+++ b/packages/api/src/memberContext.ts
@@ -140,8 +140,8 @@ function getNextReminderAndDeactivationDate({
   sentReminderAt,
   createdAt
 }: GetNextReminderAndDeactivationDateProps): ReminderAndDeactivationDate {
-  const invoiceReminderFrequencyInDays = parseInt(process.env.INVOICE_REMINDER_FREQ ?? '') ?? 3
-  const invoiceReminderMaxTries = parseInt(process.env.INVOICE_REMINDER_MAX_TRIES ?? '') ?? 5
+  const invoiceReminderFrequencyInDays = parseInt(process.env.INVOICE_REMINDER_FREQ ?? '') || 3
+  const invoiceReminderMaxTries = parseInt(process.env.INVOICE_REMINDER_MAX_TRIES ?? '') || 5
 
   const nextReminder = new Date(
     sentReminderAt.getTime() +


### PR DESCRIPTION
This PR fixes a bug in the `memberContext`. If `parseInt returns `NaN` it should take the right side value. This works with `||` but not with `??`.