### PR TITLE
fix(editor): unnecessary recalcs in  useUnsavedChangesDialog

### DIFF
--- a/packages/editor/__tests__/specs/unsavedChangesDialog.test.tsx
+++ b/packages/editor/__tests__/specs/unsavedChangesDialog.test.tsx
@@ -1,0 +1,86 @@
+import {mount} from 'enzyme'
+import React from 'react'
+import {
+  UnsavedChangesDialogMessage,
+  useUnsavedChangesDialog
+} from '../../src/client/unsavedChangesDialog'
+
+const TestComponent = ({hasChanged}: {hasChanged: boolean}) => {
+  const openDialog = useUnsavedChangesDialog(hasChanged)
+
+  return <button onClick={openDialog}></button>
+}
+
+describe('Unsaved Changes Dialog', () => {
+  beforeAll(() => {
+    window.confirm = jest.fn()
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it.each([
+    {
+      current: false,
+      next: true,
+      shouldAdd: true,
+      shouldUpdate: false
+    },
+    {
+      current: true,
+      next: false,
+      shouldAdd: true,
+      shouldUpdate: true
+    },
+    {
+      current: false,
+      next: false,
+      shouldAdd: false,
+      shouldUpdate: false
+    }
+  ])(
+    'should properly attach and detach listeners for %s',
+    async ({current, next, shouldAdd, shouldUpdate}) => {
+      const addEventListenerSpy = jest.spyOn(window, 'addEventListener')
+      const removeEventListenerSpy = jest.spyOn(window, 'removeEventListener')
+
+      const wrapper = mount(<TestComponent hasChanged={current} />)
+      wrapper.setProps({hasChanged: next})
+
+      if (shouldAdd) {
+        expect(addEventListenerSpy).toHaveBeenCalledWith('beforeunload', expect.any(Function))
+
+        if (shouldUpdate) {
+          expect(removeEventListenerSpy).toHaveBeenCalledWith('beforeunload', expect.any(Function))
+        }
+      } else {
+        expect(addEventListenerSpy).not.toHaveBeenCalledWith('beforeunload', expect.any(Function))
+        expect(removeEventListenerSpy).not.toHaveBeenCalledWith(
+          'beforeunload',
+          expect.any(Function)
+        )
+      }
+    }
+  )
+
+  it.each([
+    {
+      hasChanged: false,
+      shouldOpenDialog: false
+    },
+    {
+      hasChanged: true,
+      shouldOpenDialog: true
+    }
+  ])('should work when executing callback for %s', async ({hasChanged, shouldOpenDialog}) => {
+    const wrapper = mount(<TestComponent hasChanged={hasChanged} />)
+    wrapper.find('button').simulate('click')
+
+    if (shouldOpenDialog) {
+      expect(window.confirm).toHaveBeenCalledWith(UnsavedChangesDialogMessage)
+    } else {
+      expect(window.confirm).not.toHaveBeenCalled()
+    }
+  })
+})

--- a/packages/editor/src/client/unsavedChangesDialog.tsx
+++ b/packages/editor/src/client/unsavedChangesDialog.tsx
@@ -27,7 +27,7 @@ export function useUnsavedChangesDialog(hasChanges: boolean) {
     return () => {
       window.removeEventListener('beforeunload', handleBeforeUnload)
     }
-  })
+  }, [hasChanges])
 
   return () => {
     return !hasChanges || window.confirm(UnsavedChangesDialogMessage)


### PR DESCRIPTION
The old behaviour was to call useEffect on every single state change, it now only re-calculates the effect when it goes from `false` to `true` and the other way around.