### PR TITLE
refactor(api-db-mongodb/api/editor): remove ts-ignores

### DIFF
--- a/packages/api-db-mongodb/src/migration.ts
+++ b/packages/api-db-mongodb/src/migration.ts
@@ -628,8 +628,13 @@ export const Migrations: Migration[] = [
         const paymentProvidersCustomersArray: PaymentProviderCustomer[] = []
         const paymentProviderCustomers = Object.keys(user.paymentProviderCustomers)
         paymentProviderCustomers.forEach(ppc => {
-          // @ts-ignore
-          const userPPC = user.paymentProviderCustomers[ppc]
+          interface OldPaymentProviderCustomer extends PaymentProviderCustomer {
+            customerID: never
+            id: PaymentProviderCustomer['customerID']
+          }
+
+          const userPPC = user.paymentProviderCustomers[+ppc] as OldPaymentProviderCustomer
+
           paymentProvidersCustomersArray.push({
             paymentProviderID: ppc,
             customerID: userPPC.id

--- a/packages/api/src/events.ts
+++ b/packages/api/src/events.ts
@@ -25,10 +25,11 @@ interface ModelEvents<T> {
   delete: (context: Context, id: string) => void
 }
 
-interface PublishableModelEvents<T> extends ModelEvents<T> {
+export interface PublishableModelEvents<T> extends ModelEvents<T> {
   publish: (context: Context, model: T) => void
   unpublish: (context: Context, model: T) => void
 }
+
 export type ArticleModelEventEmitter = TypedEmitter<PublishableModelEvents<Article>>
 export const articleModelEvents = new EventEmitter() as ArticleModelEventEmitter
 

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -13,7 +13,6 @@ import {JobType, runJob} from './jobs'
 import pino from 'pino'
 import pinoHttp from 'pino-http'
 import TypedEmitter from 'typed-emitter'
-import {DBAdapters} from './db/adapter'
 
 let serverLogger: pino.Logger
 
@@ -43,7 +42,7 @@ export class WepublishServer {
       if (mtp.key in dbAdapter) {
         const dbAdapterKeyTyped = mtp.key as keyof typeof dbAdapter
         mtp.methods.forEach(method => {
-          const adapter = dbAdapter[dbAdapterKeyTyped] as Record<string, any>
+          const adapter = dbAdapter[dbAdapterKeyTyped] as Record<string, Function | any>
           const methodName = `${method}${capitalizeFirstLetter(mtp.key)}`
 
           if (methodName in adapter) {

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -8,10 +8,12 @@ import {MAIL_WEBHOOK_PATH_PREFIX, setupMailProvider} from './mails/mailProvider'
 import {setupPaymentProvider, PAYMENT_WEBHOOK_PATH_PREFIX} from './payments/paymentProvider'
 import {capitalizeFirstLetter, MAX_PAYLOAD_SIZE} from './utility'
 
-import {methodsToProxy} from './events'
+import {methodsToProxy, PublishableModelEvents} from './events'
 import {JobType, runJob} from './jobs'
 import pino from 'pino'
 import pinoHttp from 'pino-http'
+import TypedEmitter from 'typed-emitter'
+import {DBAdapters} from './db/adapter'
 
 let serverLogger: pino.Logger
 
@@ -41,34 +43,34 @@ export class WepublishServer {
       if (mtp.key in dbAdapter) {
         const dbAdapterKeyTyped = mtp.key as keyof typeof dbAdapter
         mtp.methods.forEach(method => {
+          const adapter = dbAdapter[dbAdapterKeyTyped] as Record<string, any>
           const methodName = `${method}${capitalizeFirstLetter(mtp.key)}`
-          if (methodName in dbAdapter[dbAdapterKeyTyped]) {
-            // @ts-ignore
-            dbAdapter[dbAdapterKeyTyped][methodName] = new Proxy(
-              // @ts-ignore
-              dbAdapter[dbAdapterKeyTyped][methodName],
-              {
-                // create proxy for method
-                async apply(target: any, thisArg: any, argArray?: any): Promise<any> {
-                  const result = await target.bind(thisArg)(...argArray) // execute actual method "Create, Update, Publish, ..."
-                  setImmediate(async () => {
-                    // make sure event gets executed in the next event loop
-                    try {
-                      logger('server').info('emitting event for %s', methodName)
-                      // @ts-ignore
-                      mtp.eventEmitter.emit(method, await contextFromRequest(null, opts), result) // execute event emitter
-                    } catch (error) {
-                      logger('server').error(
-                        error,
-                        'error during emitting event for %s',
-                        methodName
-                      )
-                    }
-                  })
-                  return result // return actual result "Article, Page, User, ..."
-                }
+
+          if (methodName in adapter) {
+            adapter[methodName] = new Proxy(adapter[methodName], {
+              // create proxy for method
+              async apply(target: any, thisArg: any, argArray?: any): Promise<any> {
+                const result = await target.bind(thisArg)(...argArray) // execute actual method "Create, Update, Publish, ..."
+                setImmediate(async () => {
+                  // make sure event gets executed in the next event loop
+                  try {
+                    logger('server').info('emitting event for %s', methodName)
+                    ;(mtp.eventEmitter as TypedEmitter<PublishableModelEvents<unknown>>).emit(
+                      method,
+                      await contextFromRequest(null, opts),
+                      result
+                    ) // execute event emitter
+                  } catch (error) {
+                    logger('server').error(
+                      error as object,
+                      'error during emitting event for %s',
+                      methodName
+                    )
+                  }
+                })
+                return result // return actual result "Article, Page, User, ..."
               }
-            )
+            })
           } else {
             logger('server').warn('%s does not exist in dbAdapter[%s]', methodName, mtp.key)
           }

--- a/packages/editor/__tests__/specs/__snapshots__/authorEditPanel.tsx.snap
+++ b/packages/editor/__tests__/specs/__snapshots__/authorEditPanel.tsx.snap
@@ -289,12 +289,14 @@ exports[`Author Edit Panel should allow a new author to be created  1`] = `
                                       disabled={true}
                                       name="authors.panels.jobTitle"
                                       onChange={[Function]}
+                                      value=""
                                     >
                                       <FormControlWrapper
                                         classPrefix="rs-form-control"
                                         disabled={true}
                                         name="authors.panels.jobTitle"
                                         onChange={[Function]}
+                                        value=""
                                       >
                                         <FormControl
                                           accepter={
@@ -337,6 +339,7 @@ exports[`Author Edit Panel should allow a new author to be created  1`] = `
                                           name="authors.panels.jobTitle"
                                           onChange={[Function]}
                                           plaintextDefaultValue="--"
+                                          value=""
                                         >
                                           <div
                                             className="rs-form-control-wrapper"
@@ -349,6 +352,7 @@ exports[`Author Edit Panel should allow a new author to be created  1`] = `
                                               onBlur={[Function]}
                                               onChange={[Function]}
                                               type="text"
+                                              value=""
                                             >
                                               <defaultProps(Input)
                                                 className=""
@@ -359,6 +363,7 @@ exports[`Author Edit Panel should allow a new author to be created  1`] = `
                                                 onBlur={[Function]}
                                                 onChange={[Function]}
                                                 type="text"
+                                                value=""
                                               >
                                                 <Input
                                                   className=""
@@ -369,6 +374,7 @@ exports[`Author Edit Panel should allow a new author to be created  1`] = `
                                                   onBlur={[Function]}
                                                   onChange={[Function]}
                                                   type="text"
+                                                  value=""
                                                 >
                                                   <input
                                                     className="rs-input"
@@ -378,6 +384,7 @@ exports[`Author Edit Panel should allow a new author to be created  1`] = `
                                                     onChange={[Function]}
                                                     onKeyDown={[Function]}
                                                     type="text"
+                                                    value=""
                                                   />
                                                 </Input>
                                               </defaultProps(Input)>
@@ -3254,12 +3261,14 @@ exports[`Author Edit Panel should fill the link field 1`] = `
                                       disabled={false}
                                       name="authors.panels.jobTitle"
                                       onChange={[Function]}
+                                      value=""
                                     >
                                       <FormControlWrapper
                                         classPrefix="rs-form-control"
                                         disabled={false}
                                         name="authors.panels.jobTitle"
                                         onChange={[Function]}
+                                        value=""
                                       >
                                         <FormControl
                                           accepter={
@@ -3302,6 +3311,7 @@ exports[`Author Edit Panel should fill the link field 1`] = `
                                           name="authors.panels.jobTitle"
                                           onChange={[Function]}
                                           plaintextDefaultValue="--"
+                                          value=""
                                         >
                                           <div
                                             className="rs-form-control-wrapper"
@@ -3314,6 +3324,7 @@ exports[`Author Edit Panel should fill the link field 1`] = `
                                               onBlur={[Function]}
                                               onChange={[Function]}
                                               type="text"
+                                              value=""
                                             >
                                               <defaultProps(Input)
                                                 className=""
@@ -3324,6 +3335,7 @@ exports[`Author Edit Panel should fill the link field 1`] = `
                                                 onBlur={[Function]}
                                                 onChange={[Function]}
                                                 type="text"
+                                                value=""
                                               >
                                                 <Input
                                                   className=""
@@ -3334,6 +3346,7 @@ exports[`Author Edit Panel should fill the link field 1`] = `
                                                   onBlur={[Function]}
                                                   onChange={[Function]}
                                                   type="text"
+                                                  value=""
                                                 >
                                                   <input
                                                     className="rs-input"
@@ -3343,6 +3356,7 @@ exports[`Author Edit Panel should fill the link field 1`] = `
                                                     onChange={[Function]}
                                                     onKeyDown={[Function]}
                                                     type="text"
+                                                    value=""
                                                   />
                                                 </Input>
                                               </defaultProps(Input)>
@@ -6209,12 +6223,14 @@ exports[`Author Edit Panel should render 1`] = `
                                       disabled={false}
                                       name="authors.panels.jobTitle"
                                       onChange={[Function]}
+                                      value=""
                                     >
                                       <FormControlWrapper
                                         classPrefix="rs-form-control"
                                         disabled={false}
                                         name="authors.panels.jobTitle"
                                         onChange={[Function]}
+                                        value=""
                                       >
                                         <FormControl
                                           accepter={
@@ -6257,6 +6273,7 @@ exports[`Author Edit Panel should render 1`] = `
                                           name="authors.panels.jobTitle"
                                           onChange={[Function]}
                                           plaintextDefaultValue="--"
+                                          value=""
                                         >
                                           <div
                                             className="rs-form-control-wrapper"
@@ -6269,6 +6286,7 @@ exports[`Author Edit Panel should render 1`] = `
                                               onBlur={[Function]}
                                               onChange={[Function]}
                                               type="text"
+                                              value=""
                                             >
                                               <defaultProps(Input)
                                                 className=""
@@ -6279,6 +6297,7 @@ exports[`Author Edit Panel should render 1`] = `
                                                 onBlur={[Function]}
                                                 onChange={[Function]}
                                                 type="text"
+                                                value=""
                                               >
                                                 <Input
                                                   className=""
@@ -6289,6 +6308,7 @@ exports[`Author Edit Panel should render 1`] = `
                                                   onBlur={[Function]}
                                                   onChange={[Function]}
                                                   type="text"
+                                                  value=""
                                                 >
                                                   <input
                                                     className="rs-input"
@@ -6298,6 +6318,7 @@ exports[`Author Edit Panel should render 1`] = `
                                                     onChange={[Function]}
                                                     onKeyDown={[Function]}
                                                     type="text"
+                                                    value=""
                                                   />
                                                 </Input>
                                               </defaultProps(Input)>
@@ -9166,12 +9187,14 @@ exports[`Author Edit Panel should render with ID 1`] = `
                                       disabled={false}
                                       name="authors.panels.jobTitle"
                                       onChange={[Function]}
+                                      value=""
                                     >
                                       <FormControlWrapper
                                         classPrefix="rs-form-control"
                                         disabled={false}
                                         name="authors.panels.jobTitle"
                                         onChange={[Function]}
+                                        value=""
                                       >
                                         <FormControl
                                           accepter={
@@ -9214,6 +9237,7 @@ exports[`Author Edit Panel should render with ID 1`] = `
                                           name="authors.panels.jobTitle"
                                           onChange={[Function]}
                                           plaintextDefaultValue="--"
+                                          value=""
                                         >
                                           <div
                                             className="rs-form-control-wrapper"
@@ -9226,6 +9250,7 @@ exports[`Author Edit Panel should render with ID 1`] = `
                                               onBlur={[Function]}
                                               onChange={[Function]}
                                               type="text"
+                                              value=""
                                             >
                                               <defaultProps(Input)
                                                 className=""
@@ -9236,6 +9261,7 @@ exports[`Author Edit Panel should render with ID 1`] = `
                                                 onBlur={[Function]}
                                                 onChange={[Function]}
                                                 type="text"
+                                                value=""
                                               >
                                                 <Input
                                                   className=""
@@ -9246,6 +9272,7 @@ exports[`Author Edit Panel should render with ID 1`] = `
                                                   onBlur={[Function]}
                                                   onChange={[Function]}
                                                   type="text"
+                                                  value=""
                                                 >
                                                   <input
                                                     className="rs-input"
@@ -9255,6 +9282,7 @@ exports[`Author Edit Panel should render with ID 1`] = `
                                                     onChange={[Function]}
                                                     onKeyDown={[Function]}
                                                     type="text"
+                                                    value=""
                                                   />
                                                 </Input>
                                               </defaultProps(Input)>
@@ -9312,6 +9340,7 @@ exports[`Author Edit Panel should render with ID 1`] = `
                         <ChooseEditImage
                           disabled={false}
                           header=""
+                          image={null}
                           left={0}
                           openChooseModalOpen={[Function]}
                           openEditModalOpen={[Function]}

--- a/packages/editor/__tests__/specs/__snapshots__/userEditPanel.tsx.snap
+++ b/packages/editor/__tests__/specs/__snapshots__/userEditPanel.tsx.snap
@@ -125,12 +125,14 @@ exports[`User Edit Panel should allow a new user to be created 1`] = `
                                 disabled={true}
                                 name="userList.panels.firstName"
                                 onChange={[Function]}
+                                value=""
                               >
                                 <FormControlWrapper
                                   classPrefix="rs-form-control"
                                   disabled={true}
                                   name="userList.panels.firstName"
                                   onChange={[Function]}
+                                  value=""
                                 >
                                   <FormControl
                                     accepter={
@@ -173,6 +175,7 @@ exports[`User Edit Panel should allow a new user to be created 1`] = `
                                     name="userList.panels.firstName"
                                     onChange={[Function]}
                                     plaintextDefaultValue="--"
+                                    value=""
                                   >
                                     <div
                                       className="rs-form-control-wrapper"
@@ -185,6 +188,7 @@ exports[`User Edit Panel should allow a new user to be created 1`] = `
                                         onBlur={[Function]}
                                         onChange={[Function]}
                                         type="text"
+                                        value=""
                                       >
                                         <defaultProps(Input)
                                           className=""
@@ -195,6 +199,7 @@ exports[`User Edit Panel should allow a new user to be created 1`] = `
                                           onBlur={[Function]}
                                           onChange={[Function]}
                                           type="text"
+                                          value=""
                                         >
                                           <Input
                                             className=""
@@ -205,6 +210,7 @@ exports[`User Edit Panel should allow a new user to be created 1`] = `
                                             onBlur={[Function]}
                                             onChange={[Function]}
                                             type="text"
+                                            value=""
                                           >
                                             <input
                                               className="rs-input"
@@ -214,6 +220,7 @@ exports[`User Edit Panel should allow a new user to be created 1`] = `
                                               onChange={[Function]}
                                               onKeyDown={[Function]}
                                               type="text"
+                                              value=""
                                             />
                                           </Input>
                                         </defaultProps(Input)>
@@ -426,12 +433,14 @@ exports[`User Edit Panel should allow a new user to be created 1`] = `
                                 disabled={true}
                                 name="userList.panels.preferredName"
                                 onChange={[Function]}
+                                value=""
                               >
                                 <FormControlWrapper
                                   classPrefix="rs-form-control"
                                   disabled={true}
                                   name="userList.panels.preferredName"
                                   onChange={[Function]}
+                                  value=""
                                 >
                                   <FormControl
                                     accepter={
@@ -474,6 +483,7 @@ exports[`User Edit Panel should allow a new user to be created 1`] = `
                                     name="userList.panels.preferredName"
                                     onChange={[Function]}
                                     plaintextDefaultValue="--"
+                                    value=""
                                   >
                                     <div
                                       className="rs-form-control-wrapper"
@@ -486,6 +496,7 @@ exports[`User Edit Panel should allow a new user to be created 1`] = `
                                         onBlur={[Function]}
                                         onChange={[Function]}
                                         type="text"
+                                        value=""
                                       >
                                         <defaultProps(Input)
                                           className=""
@@ -496,6 +507,7 @@ exports[`User Edit Panel should allow a new user to be created 1`] = `
                                           onBlur={[Function]}
                                           onChange={[Function]}
                                           type="text"
+                                          value=""
                                         >
                                           <Input
                                             className=""
@@ -506,6 +518,7 @@ exports[`User Edit Panel should allow a new user to be created 1`] = `
                                             onBlur={[Function]}
                                             onChange={[Function]}
                                             type="text"
+                                            value=""
                                           >
                                             <input
                                               className="rs-input"
@@ -515,6 +528,7 @@ exports[`User Edit Panel should allow a new user to be created 1`] = `
                                               onChange={[Function]}
                                               onKeyDown={[Function]}
                                               type="text"
+                                              value=""
                                             />
                                           </Input>
                                         </defaultProps(Input)>
@@ -2895,12 +2909,14 @@ exports[`User Edit Panel should allow user role to be added 1`] = `
                                 disabled={false}
                                 name="userList.panels.firstName"
                                 onChange={[Function]}
+                                value=""
                               >
                                 <FormControlWrapper
                                   classPrefix="rs-form-control"
                                   disabled={false}
                                   name="userList.panels.firstName"
                                   onChange={[Function]}
+                                  value=""
                                 >
                                   <FormControl
                                     accepter={
@@ -2943,6 +2959,7 @@ exports[`User Edit Panel should allow user role to be added 1`] = `
                                     name="userList.panels.firstName"
                                     onChange={[Function]}
                                     plaintextDefaultValue="--"
+                                    value=""
                                   >
                                     <div
                                       className="rs-form-control-wrapper"
@@ -2955,6 +2972,7 @@ exports[`User Edit Panel should allow user role to be added 1`] = `
                                         onBlur={[Function]}
                                         onChange={[Function]}
                                         type="text"
+                                        value=""
                                       >
                                         <defaultProps(Input)
                                           className=""
@@ -2965,6 +2983,7 @@ exports[`User Edit Panel should allow user role to be added 1`] = `
                                           onBlur={[Function]}
                                           onChange={[Function]}
                                           type="text"
+                                          value=""
                                         >
                                           <Input
                                             className=""
@@ -2975,6 +2994,7 @@ exports[`User Edit Panel should allow user role to be added 1`] = `
                                             onBlur={[Function]}
                                             onChange={[Function]}
                                             type="text"
+                                            value=""
                                           >
                                             <input
                                               className="rs-input"
@@ -2984,6 +3004,7 @@ exports[`User Edit Panel should allow user role to be added 1`] = `
                                               onChange={[Function]}
                                               onKeyDown={[Function]}
                                               type="text"
+                                              value=""
                                             />
                                           </Input>
                                         </defaultProps(Input)>
@@ -3196,12 +3217,14 @@ exports[`User Edit Panel should allow user role to be added 1`] = `
                                 disabled={false}
                                 name="userList.panels.preferredName"
                                 onChange={[Function]}
+                                value=""
                               >
                                 <FormControlWrapper
                                   classPrefix="rs-form-control"
                                   disabled={false}
                                   name="userList.panels.preferredName"
                                   onChange={[Function]}
+                                  value=""
                                 >
                                   <FormControl
                                     accepter={
@@ -3244,6 +3267,7 @@ exports[`User Edit Panel should allow user role to be added 1`] = `
                                     name="userList.panels.preferredName"
                                     onChange={[Function]}
                                     plaintextDefaultValue="--"
+                                    value=""
                                   >
                                     <div
                                       className="rs-form-control-wrapper"
@@ -3256,6 +3280,7 @@ exports[`User Edit Panel should allow user role to be added 1`] = `
                                         onBlur={[Function]}
                                         onChange={[Function]}
                                         type="text"
+                                        value=""
                                       >
                                         <defaultProps(Input)
                                           className=""
@@ -3266,6 +3291,7 @@ exports[`User Edit Panel should allow user role to be added 1`] = `
                                           onBlur={[Function]}
                                           onChange={[Function]}
                                           type="text"
+                                          value=""
                                         >
                                           <Input
                                             className=""
@@ -3276,6 +3302,7 @@ exports[`User Edit Panel should allow user role to be added 1`] = `
                                             onBlur={[Function]}
                                             onChange={[Function]}
                                             type="text"
+                                            value=""
                                           >
                                             <input
                                               className="rs-input"
@@ -3285,6 +3312,7 @@ exports[`User Edit Panel should allow user role to be added 1`] = `
                                               onChange={[Function]}
                                               onKeyDown={[Function]}
                                               type="text"
+                                              value=""
                                             />
                                           </Input>
                                         </defaultProps(Input)>
@@ -6537,12 +6565,14 @@ exports[`User Edit Panel should allow user role to be removed 1`] = `
                                 disabled={false}
                                 name="userList.panels.firstName"
                                 onChange={[Function]}
+                                value="Peter"
                               >
                                 <FormControlWrapper
                                   classPrefix="rs-form-control"
                                   disabled={false}
                                   name="userList.panels.firstName"
                                   onChange={[Function]}
+                                  value="Peter"
                                 >
                                   <FormControl
                                     accepter={
@@ -6585,6 +6615,7 @@ exports[`User Edit Panel should allow user role to be removed 1`] = `
                                     name="userList.panels.firstName"
                                     onChange={[Function]}
                                     plaintextDefaultValue="--"
+                                    value="Peter"
                                   >
                                     <div
                                       className="rs-form-control-wrapper"
@@ -6597,6 +6628,7 @@ exports[`User Edit Panel should allow user role to be removed 1`] = `
                                         onBlur={[Function]}
                                         onChange={[Function]}
                                         type="text"
+                                        value="Peter"
                                       >
                                         <defaultProps(Input)
                                           className=""
@@ -6607,6 +6639,7 @@ exports[`User Edit Panel should allow user role to be removed 1`] = `
                                           onBlur={[Function]}
                                           onChange={[Function]}
                                           type="text"
+                                          value="Peter"
                                         >
                                           <Input
                                             className=""
@@ -6617,6 +6650,7 @@ exports[`User Edit Panel should allow user role to be removed 1`] = `
                                             onBlur={[Function]}
                                             onChange={[Function]}
                                             type="text"
+                                            value="Peter"
                                           >
                                             <input
                                               className="rs-input"
@@ -6626,6 +6660,7 @@ exports[`User Edit Panel should allow user role to be removed 1`] = `
                                               onChange={[Function]}
                                               onKeyDown={[Function]}
                                               type="text"
+                                              value="Peter"
                                             />
                                           </Input>
                                         </defaultProps(Input)>
@@ -6684,14 +6719,14 @@ exports[`User Edit Panel should allow user role to be removed 1`] = `
                                 disabled={false}
                                 name="userList.panels.name"
                                 onChange={[Function]}
-                                value="Peter Parker"
+                                value="Parker"
                               >
                                 <FormControlWrapper
                                   classPrefix="rs-form-control"
                                   disabled={false}
                                   name="userList.panels.name"
                                   onChange={[Function]}
-                                  value="Peter Parker"
+                                  value="Parker"
                                 >
                                   <FormControl
                                     accepter={
@@ -6734,7 +6769,7 @@ exports[`User Edit Panel should allow user role to be removed 1`] = `
                                     name="userList.panels.name"
                                     onChange={[Function]}
                                     plaintextDefaultValue="--"
-                                    value="Peter Parker"
+                                    value="Parker"
                                   >
                                     <div
                                       className="rs-form-control-wrapper"
@@ -6747,7 +6782,7 @@ exports[`User Edit Panel should allow user role to be removed 1`] = `
                                         onBlur={[Function]}
                                         onChange={[Function]}
                                         type="text"
-                                        value="Peter Parker"
+                                        value="Parker"
                                       >
                                         <defaultProps(Input)
                                           className=""
@@ -6758,7 +6793,7 @@ exports[`User Edit Panel should allow user role to be removed 1`] = `
                                           onBlur={[Function]}
                                           onChange={[Function]}
                                           type="text"
-                                          value="Peter Parker"
+                                          value="Parker"
                                         >
                                           <Input
                                             className=""
@@ -6769,7 +6804,7 @@ exports[`User Edit Panel should allow user role to be removed 1`] = `
                                             onBlur={[Function]}
                                             onChange={[Function]}
                                             type="text"
-                                            value="Peter Parker"
+                                            value="Parker"
                                           >
                                             <input
                                               className="rs-input"
@@ -6779,7 +6814,7 @@ exports[`User Edit Panel should allow user role to be removed 1`] = `
                                               onChange={[Function]}
                                               onKeyDown={[Function]}
                                               type="text"
-                                              value="Peter Parker"
+                                              value="Parker"
                                             />
                                           </Input>
                                         </defaultProps(Input)>
@@ -6838,12 +6873,14 @@ exports[`User Edit Panel should allow user role to be removed 1`] = `
                                 disabled={false}
                                 name="userList.panels.preferredName"
                                 onChange={[Function]}
+                                value="Peter Parker"
                               >
                                 <FormControlWrapper
                                   classPrefix="rs-form-control"
                                   disabled={false}
                                   name="userList.panels.preferredName"
                                   onChange={[Function]}
+                                  value="Peter Parker"
                                 >
                                   <FormControl
                                     accepter={
@@ -6886,6 +6923,7 @@ exports[`User Edit Panel should allow user role to be removed 1`] = `
                                     name="userList.panels.preferredName"
                                     onChange={[Function]}
                                     plaintextDefaultValue="--"
+                                    value="Peter Parker"
                                   >
                                     <div
                                       className="rs-form-control-wrapper"
@@ -6898,6 +6936,7 @@ exports[`User Edit Panel should allow user role to be removed 1`] = `
                                         onBlur={[Function]}
                                         onChange={[Function]}
                                         type="text"
+                                        value="Peter Parker"
                                       >
                                         <defaultProps(Input)
                                           className=""
@@ -6908,6 +6947,7 @@ exports[`User Edit Panel should allow user role to be removed 1`] = `
                                           onBlur={[Function]}
                                           onChange={[Function]}
                                           type="text"
+                                          value="Peter Parker"
                                         >
                                           <Input
                                             className=""
@@ -6918,6 +6958,7 @@ exports[`User Edit Panel should allow user role to be removed 1`] = `
                                             onBlur={[Function]}
                                             onChange={[Function]}
                                             type="text"
+                                            value="Peter Parker"
                                           >
                                             <input
                                               className="rs-input"
@@ -6927,6 +6968,7 @@ exports[`User Edit Panel should allow user role to be removed 1`] = `
                                               onChange={[Function]}
                                               onKeyDown={[Function]}
                                               type="text"
+                                              value="Peter Parker"
                                             />
                                           </Input>
                                         </defaultProps(Input)>
@@ -8017,17 +8059,20 @@ exports[`User Edit Panel should allow user role to be removed 1`] = `
                                 </ControlLabel>
                               </defaultProps(ControlLabel)>
                               <withStyleProps(defaultProps(Toggle))
+                                checked={false}
                                 classPrefix="rs-btn-toggle"
                                 disabled={false}
                                 onChange={[Function]}
                               >
                                 <defaultProps(Toggle)
+                                  checked={false}
                                   className=""
                                   classPrefix="rs-btn-toggle"
                                   disabled={false}
                                   onChange={[Function]}
                                 >
                                   <Toggle
+                                    checked={false}
                                     className=""
                                     classPrefix="rs-btn-toggle"
                                     disabled={false}
@@ -8036,6 +8081,7 @@ exports[`User Edit Panel should allow user role to be removed 1`] = `
                                     <span
                                       aria-disabled={false}
                                       aria-label={null}
+                                      aria-pressed={false}
                                       className="rs-btn-toggle"
                                       onClick={[Function]}
                                       role="button"
@@ -10397,12 +10443,14 @@ exports[`User Edit Panel should render 1`] = `
                                 disabled={false}
                                 name="userList.panels.firstName"
                                 onChange={[Function]}
+                                value=""
                               >
                                 <FormControlWrapper
                                   classPrefix="rs-form-control"
                                   disabled={false}
                                   name="userList.panels.firstName"
                                   onChange={[Function]}
+                                  value=""
                                 >
                                   <FormControl
                                     accepter={
@@ -10445,6 +10493,7 @@ exports[`User Edit Panel should render 1`] = `
                                     name="userList.panels.firstName"
                                     onChange={[Function]}
                                     plaintextDefaultValue="--"
+                                    value=""
                                   >
                                     <div
                                       className="rs-form-control-wrapper"
@@ -10457,6 +10506,7 @@ exports[`User Edit Panel should render 1`] = `
                                         onBlur={[Function]}
                                         onChange={[Function]}
                                         type="text"
+                                        value=""
                                       >
                                         <defaultProps(Input)
                                           className=""
@@ -10467,6 +10517,7 @@ exports[`User Edit Panel should render 1`] = `
                                           onBlur={[Function]}
                                           onChange={[Function]}
                                           type="text"
+                                          value=""
                                         >
                                           <Input
                                             className=""
@@ -10477,6 +10528,7 @@ exports[`User Edit Panel should render 1`] = `
                                             onBlur={[Function]}
                                             onChange={[Function]}
                                             type="text"
+                                            value=""
                                           >
                                             <input
                                               className="rs-input"
@@ -10486,6 +10538,7 @@ exports[`User Edit Panel should render 1`] = `
                                               onChange={[Function]}
                                               onKeyDown={[Function]}
                                               type="text"
+                                              value=""
                                             />
                                           </Input>
                                         </defaultProps(Input)>
@@ -10698,12 +10751,14 @@ exports[`User Edit Panel should render 1`] = `
                                 disabled={false}
                                 name="userList.panels.preferredName"
                                 onChange={[Function]}
+                                value=""
                               >
                                 <FormControlWrapper
                                   classPrefix="rs-form-control"
                                   disabled={false}
                                   name="userList.panels.preferredName"
                                   onChange={[Function]}
+                                  value=""
                                 >
                                   <FormControl
                                     accepter={
@@ -10746,6 +10801,7 @@ exports[`User Edit Panel should render 1`] = `
                                     name="userList.panels.preferredName"
                                     onChange={[Function]}
                                     plaintextDefaultValue="--"
+                                    value=""
                                   >
                                     <div
                                       className="rs-form-control-wrapper"
@@ -10758,6 +10814,7 @@ exports[`User Edit Panel should render 1`] = `
                                         onBlur={[Function]}
                                         onChange={[Function]}
                                         type="text"
+                                        value=""
                                       >
                                         <defaultProps(Input)
                                           className=""
@@ -10768,6 +10825,7 @@ exports[`User Edit Panel should render 1`] = `
                                           onBlur={[Function]}
                                           onChange={[Function]}
                                           type="text"
+                                          value=""
                                         >
                                           <Input
                                             className=""
@@ -10778,6 +10836,7 @@ exports[`User Edit Panel should render 1`] = `
                                             onBlur={[Function]}
                                             onChange={[Function]}
                                             type="text"
+                                            value=""
                                           >
                                             <input
                                               className="rs-input"
@@ -10787,6 +10846,7 @@ exports[`User Edit Panel should render 1`] = `
                                               onChange={[Function]}
                                               onKeyDown={[Function]}
                                               type="text"
+                                              value=""
                                             />
                                           </Input>
                                         </defaultProps(Input)>
@@ -13002,12 +13062,14 @@ exports[`User Edit Panel should render with ID 1`] = `
                                 disabled={false}
                                 name="userList.panels.firstName"
                                 onChange={[Function]}
+                                value="Peter"
                               >
                                 <FormControlWrapper
                                   classPrefix="rs-form-control"
                                   disabled={false}
                                   name="userList.panels.firstName"
                                   onChange={[Function]}
+                                  value="Peter"
                                 >
                                   <FormControl
                                     accepter={
@@ -13050,6 +13112,7 @@ exports[`User Edit Panel should render with ID 1`] = `
                                     name="userList.panels.firstName"
                                     onChange={[Function]}
                                     plaintextDefaultValue="--"
+                                    value="Peter"
                                   >
                                     <div
                                       className="rs-form-control-wrapper"
@@ -13062,6 +13125,7 @@ exports[`User Edit Panel should render with ID 1`] = `
                                         onBlur={[Function]}
                                         onChange={[Function]}
                                         type="text"
+                                        value="Peter"
                                       >
                                         <defaultProps(Input)
                                           className=""
@@ -13072,6 +13136,7 @@ exports[`User Edit Panel should render with ID 1`] = `
                                           onBlur={[Function]}
                                           onChange={[Function]}
                                           type="text"
+                                          value="Peter"
                                         >
                                           <Input
                                             className=""
@@ -13082,6 +13147,7 @@ exports[`User Edit Panel should render with ID 1`] = `
                                             onBlur={[Function]}
                                             onChange={[Function]}
                                             type="text"
+                                            value="Peter"
                                           >
                                             <input
                                               className="rs-input"
@@ -13091,6 +13157,7 @@ exports[`User Edit Panel should render with ID 1`] = `
                                               onChange={[Function]}
                                               onKeyDown={[Function]}
                                               type="text"
+                                              value="Peter"
                                             />
                                           </Input>
                                         </defaultProps(Input)>
@@ -13149,14 +13216,14 @@ exports[`User Edit Panel should render with ID 1`] = `
                                 disabled={false}
                                 name="userList.panels.name"
                                 onChange={[Function]}
-                                value="Peter Parker"
+                                value="Parker"
                               >
                                 <FormControlWrapper
                                   classPrefix="rs-form-control"
                                   disabled={false}
                                   name="userList.panels.name"
                                   onChange={[Function]}
-                                  value="Peter Parker"
+                                  value="Parker"
                                 >
                                   <FormControl
                                     accepter={
@@ -13199,7 +13266,7 @@ exports[`User Edit Panel should render with ID 1`] = `
                                     name="userList.panels.name"
                                     onChange={[Function]}
                                     plaintextDefaultValue="--"
-                                    value="Peter Parker"
+                                    value="Parker"
                                   >
                                     <div
                                       className="rs-form-control-wrapper"
@@ -13212,7 +13279,7 @@ exports[`User Edit Panel should render with ID 1`] = `
                                         onBlur={[Function]}
                                         onChange={[Function]}
                                         type="text"
-                                        value="Peter Parker"
+                                        value="Parker"
                                       >
                                         <defaultProps(Input)
                                           className=""
@@ -13223,7 +13290,7 @@ exports[`User Edit Panel should render with ID 1`] = `
                                           onBlur={[Function]}
                                           onChange={[Function]}
                                           type="text"
-                                          value="Peter Parker"
+                                          value="Parker"
                                         >
                                           <Input
                                             className=""
@@ -13234,7 +13301,7 @@ exports[`User Edit Panel should render with ID 1`] = `
                                             onBlur={[Function]}
                                             onChange={[Function]}
                                             type="text"
-                                            value="Peter Parker"
+                                            value="Parker"
                                           >
                                             <input
                                               className="rs-input"
@@ -13244,7 +13311,7 @@ exports[`User Edit Panel should render with ID 1`] = `
                                               onChange={[Function]}
                                               onKeyDown={[Function]}
                                               type="text"
-                                              value="Peter Parker"
+                                              value="Parker"
                                             />
                                           </Input>
                                         </defaultProps(Input)>
@@ -13303,12 +13370,14 @@ exports[`User Edit Panel should render with ID 1`] = `
                                 disabled={false}
                                 name="userList.panels.preferredName"
                                 onChange={[Function]}
+                                value="Peter Parker"
                               >
                                 <FormControlWrapper
                                   classPrefix="rs-form-control"
                                   disabled={false}
                                   name="userList.panels.preferredName"
                                   onChange={[Function]}
+                                  value="Peter Parker"
                                 >
                                   <FormControl
                                     accepter={
@@ -13351,6 +13420,7 @@ exports[`User Edit Panel should render with ID 1`] = `
                                     name="userList.panels.preferredName"
                                     onChange={[Function]}
                                     plaintextDefaultValue="--"
+                                    value="Peter Parker"
                                   >
                                     <div
                                       className="rs-form-control-wrapper"
@@ -13363,6 +13433,7 @@ exports[`User Edit Panel should render with ID 1`] = `
                                         onBlur={[Function]}
                                         onChange={[Function]}
                                         type="text"
+                                        value="Peter Parker"
                                       >
                                         <defaultProps(Input)
                                           className=""
@@ -13373,6 +13444,7 @@ exports[`User Edit Panel should render with ID 1`] = `
                                           onBlur={[Function]}
                                           onChange={[Function]}
                                           type="text"
+                                          value="Peter Parker"
                                         >
                                           <Input
                                             className=""
@@ -13383,6 +13455,7 @@ exports[`User Edit Panel should render with ID 1`] = `
                                             onBlur={[Function]}
                                             onChange={[Function]}
                                             type="text"
+                                            value="Peter Parker"
                                           >
                                             <input
                                               className="rs-input"
@@ -13392,6 +13465,7 @@ exports[`User Edit Panel should render with ID 1`] = `
                                               onChange={[Function]}
                                               onKeyDown={[Function]}
                                               type="text"
+                                              value="Peter Parker"
                                             />
                                           </Input>
                                         </defaultProps(Input)>
@@ -14482,17 +14556,20 @@ exports[`User Edit Panel should render with ID 1`] = `
                                 </ControlLabel>
                               </defaultProps(ControlLabel)>
                               <withStyleProps(defaultProps(Toggle))
+                                checked={false}
                                 classPrefix="rs-btn-toggle"
                                 disabled={false}
                                 onChange={[Function]}
                               >
                                 <defaultProps(Toggle)
+                                  checked={false}
                                   className=""
                                   classPrefix="rs-btn-toggle"
                                   disabled={false}
                                   onChange={[Function]}
                                 >
                                   <Toggle
+                                    checked={false}
                                     className=""
                                     classPrefix="rs-btn-toggle"
                                     disabled={false}
@@ -14501,6 +14578,7 @@ exports[`User Edit Panel should render with ID 1`] = `
                                     <span
                                       aria-disabled={false}
                                       aria-label={null}
+                                      aria-pressed={false}
                                       className="rs-btn-toggle"
                                       onClick={[Function]}
                                       role="button"

--- a/packages/editor/__tests__/specs/authorEditPanel.tsx
+++ b/packages/editor/__tests__/specs/authorEditPanel.tsx
@@ -35,7 +35,13 @@ describe('Author Edit Panel', () => {
             author: {
               __typename: 'Author',
               id: 'fakeId2',
-              name: 'Douglas Cole'
+              name: 'Douglas Cole',
+              slug: '',
+              links: null,
+              bio: '',
+              createdAt: '',
+              jobTitle: '',
+              image: null
             }
           }
         })

--- a/packages/editor/__tests__/specs/peerEditPanel.tsx
+++ b/packages/editor/__tests__/specs/peerEditPanel.tsx
@@ -39,7 +39,8 @@ describe('Peer Edit Panel', () => {
                 id: 'peerId1',
                 name: 'Test Peer Name',
                 slug: 'test-peer-name',
-                hostURL: 'https://test-url.ch/'
+                hostURL: 'https://test-url.ch/',
+                profile: {}
               }
             }
           }

--- a/packages/editor/__tests__/specs/userEditPanel.tsx
+++ b/packages/editor/__tests__/specs/userEditPanel.tsx
@@ -40,7 +40,9 @@ const userRoleListDocumentQuery = {
           ],
           pageInfo: {
             hasNextPage: false,
-            hasPreviousPage: false
+            hasPreviousPage: false,
+            startCursor: null,
+            endCursor: null
           },
           totalCount: 2
         }
@@ -61,8 +63,12 @@ const userDocumentQuery = {
       user: {
         __typename: 'User',
         id: 'fakeId3',
-        name: 'Peter Parker',
+        firstName: 'Peter',
+        name: 'Parker',
+        preferredName: 'Peter Parker',
         email: 'peter@parker.com',
+        address: null,
+        active: false,
         roles: [
           {
             __typename: 'UserRole',
@@ -72,7 +78,12 @@ const userDocumentQuery = {
             systemRole: false,
             permissions: []
           }
-        ]
+        ],
+        properties: [],
+        emailVerifiedAt: null,
+        lastLogin: null,
+        createdAt: null,
+        modifiedAt: null
       }
     }
   })

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -59,6 +59,7 @@
     "array-move": "^2.2.1",
     "browser-image-compression": "^1.0.16",
     "core-js": "^3.4.8",
+    "csstype": "^3.0.11",
     "date-fns": "^2.24.0",
     "emoji-mart": "^3.0.0",
     "exifr": "^7.1.3",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -51,7 +51,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@apollo/client": "^3.6.2",
+    "@apollo/client": "^3.3.21",
     "@karma.run/react": "^0.1.3",
     "@karma.run/webpack": "^0.0.3",
     "@wepublish/karma.run-react": "^0.2.0",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -59,7 +59,7 @@
     "array-move": "^2.2.1",
     "browser-image-compression": "^1.0.16",
     "core-js": "^3.4.8",
-    "csstype": "^3.0.11",
+    "csstype": "^3.0.2",
     "date-fns": "^2.24.0",
     "emoji-mart": "^3.0.0",
     "exifr": "^7.1.3",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -51,7 +51,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@apollo/client": "^3.3.21",
+    "@apollo/client": "^3.6.2",
     "@karma.run/react": "^0.1.3",
     "@karma.run/webpack": "^0.0.3",
     "@wepublish/karma.run-react": "^0.2.0",

--- a/packages/editor/src/client/atoms/typography.tsx
+++ b/packages/editor/src/client/atoms/typography.tsx
@@ -93,9 +93,9 @@ export function marginForTypographySpacing(spacing: TypographySpacing): string {
 }
 
 export interface TypographyVariantCSS {
-  readonly fontSize?: CSS.Property.FontSize
-  readonly fontWeight?: CSS.Property.FontWeight
-  readonly fontStyle?: CSS.Property.FontStyle
+  readonly fontSize?: CSS.Properties['fontSize']
+  readonly fontWeight?: CSS.Properties['fontWeight']
+  readonly fontStyle?: CSS.Properties['fontStyle']
 }
 
 export function stylesForTypographyVariant(style: TypographyVariant): TypographyVariantCSS {

--- a/packages/editor/src/client/atoms/typography.tsx
+++ b/packages/editor/src/client/atoms/typography.tsx
@@ -93,9 +93,9 @@ export function marginForTypographySpacing(spacing: TypographySpacing): string {
 }
 
 export interface TypographyVariantCSS {
-  readonly fontSize?: CSS.Properties['fontSize']
-  readonly fontWeight?: CSS.Properties['fontWeight']
-  readonly fontStyle?: CSS.Properties['fontStyle']
+  readonly fontSize?: CSS.Property.FontSize
+  readonly fontWeight?: CSS.Property.FontWeight
+  readonly fontStyle?: CSS.Property.FontStyle
 }
 
 export function stylesForTypographyVariant(style: TypographyVariant): TypographyVariantCSS {

--- a/packages/editor/src/client/base.tsx
+++ b/packages/editor/src/client/base.tsx
@@ -24,6 +24,8 @@ import {
 } from './route'
 
 import {useTranslation} from 'react-i18next'
+import {ComponentType} from 'react'
+import {LinkHOCCompatibleProps} from '@wepublish/karma.run-react'
 
 export interface BaseProps {
   children?: ReactNode
@@ -41,12 +43,8 @@ const iconStyles = {
   lineHeight: '56px',
   textAlign: 'center' as const
 }
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-const NavItemLink = routeLink(Nav.Item)
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-const DropdownItemLink = routeLink(Dropdown.Item)
+const NavItemLink = routeLink(Nav.Item as ComponentType<LinkHOCCompatibleProps>)
+const DropdownItemLink = routeLink(Dropdown.Item as ComponentType<LinkHOCCompatibleProps>)
 
 function useStickyState(defaultValue: string, key: string) {
   const [value, setValue] = useState(() => {

--- a/packages/editor/src/client/base.tsx
+++ b/packages/editor/src/client/base.tsx
@@ -1,7 +1,18 @@
 import {LinkHOCCompatibleProps} from '@wepublish/karma.run-react'
 import React, {ComponentType, ReactNode, useEffect, useState} from 'react'
 import {useTranslation} from 'react-i18next'
-import {Container, Dropdown, Icon, IconButton, Nav, Navbar, Sidebar, Sidenav} from 'rsuite'
+import {
+  Container,
+  Dropdown,
+  DropdownProps,
+  Icon,
+  IconButton,
+  Nav,
+  Navbar,
+  NavProps,
+  Sidebar,
+  Sidenav
+} from 'rsuite'
 import {
   ArticleListRoute,
   AuthorListRoute,
@@ -39,8 +50,10 @@ const iconStyles = {
   lineHeight: '56px',
   textAlign: 'center' as const
 }
-const NavItemLink = routeLink(Nav.Item as ComponentType<LinkHOCCompatibleProps>)
-const DropdownItemLink = routeLink(Dropdown.Item as ComponentType<LinkHOCCompatibleProps>)
+const NavItemLink = routeLink(Nav.Item as ComponentType<NavProps & LinkHOCCompatibleProps>)
+const DropdownItemLink = routeLink(
+  Dropdown.Item as ComponentType<DropdownProps & LinkHOCCompatibleProps>
+)
 
 function useStickyState(defaultValue: string, key: string) {
   const [value, setValue] = useState(() => {

--- a/packages/editor/src/client/base.tsx
+++ b/packages/editor/src/client/base.tsx
@@ -1,31 +1,27 @@
-import React, {ReactNode, useEffect, useState} from 'react'
-
-import {Container, Sidebar, Sidenav, Nav, Navbar, Icon, Dropdown, IconButton} from 'rsuite'
-
+import {LinkHOCCompatibleProps} from '@wepublish/karma.run-react'
+import React, {ComponentType, ReactNode, useEffect, useState} from 'react'
+import {useTranslation} from 'react-i18next'
+import {Container, Dropdown, Icon, IconButton, Nav, Navbar, Sidebar, Sidenav} from 'rsuite'
 import {
   ArticleListRoute,
-  CommentListRoute,
-  useRoute,
-  RouteType,
-  PageListRoute,
-  routeLink,
   AuthorListRoute,
+  CommentListRoute,
   ImageListRoute,
-  UserListRoute,
-  UserRoleListRoute,
-  PeerListRoute,
-  TokenListRoute,
+  LogoutRoute,
   MemberPlanListRoute,
-  PaymentMethodListRoute,
   NavigationListRoute,
+  PageListRoute,
+  PaymentMethodListRoute,
   PeerArticleListRoute,
+  PeerListRoute,
+  routeLink,
+  RouteType,
   SubscriptionListRoute,
-  LogoutRoute
+  TokenListRoute,
+  UserListRoute,
+  useRoute,
+  UserRoleListRoute
 } from './route'
-
-import {useTranslation} from 'react-i18next'
-import {ComponentType} from 'react'
-import {LinkHOCCompatibleProps} from '@wepublish/karma.run-react'
 
 export interface BaseProps {
   children?: ReactNode

--- a/packages/editor/src/client/blocks/richTextBlock/richTextBlock.tsx
+++ b/packages/editor/src/client/blocks/richTextBlock/richTextBlock.tsx
@@ -169,8 +169,6 @@ export const RichTextBlock = memo(function RichTextBlock({
           setLocation(editor.selection)
         }}
         onKeyDown={e => {
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore FIXME: fix this asap
           if (e.ctrlKey || e.metaKey) activateHotkey(e)
         }}
       />

--- a/packages/editor/src/client/index.tsx
+++ b/packages/editor/src/client/index.tsx
@@ -100,8 +100,6 @@ const onDOMContentLoaded = async () => {
   const mainLink = createUploadLink({uri: adminAPIURL})
 
   const client = new ApolloClient({
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     link: authLink.concat(authErrorLink).concat(mainLink),
     cache: new InMemoryCache({
       possibleTypes: await fetchIntrospectionQueryResultData(adminAPIURL)

--- a/packages/editor/src/client/panel/authorEditPanel.tsx
+++ b/packages/editor/src/client/panel/authorEditPanel.tsx
@@ -78,7 +78,7 @@ export function AuthorEditPanel({id, onClose, onSave}: AuthorEditPanelProps) {
     if (data?.author) {
       setName(data.author.name)
       setSlug(data.author.slug)
-      setJobTitle(data.author.jobTitle)
+      setJobTitle(data.author.jobTitle ?? '')
       setImage(data.author.image)
       setBio(data.author.bio ? data.author.bio : createDefaultValue())
       setLinks(

--- a/packages/editor/src/client/panel/authorEditPanel.tsx
+++ b/packages/editor/src/client/panel/authorEditPanel.tsx
@@ -48,7 +48,7 @@ export interface AuthorEditPanelProps {
 export function AuthorEditPanel({id, onClose, onSave}: AuthorEditPanelProps) {
   const [name, setName] = useState('')
   const [slug, setSlug] = useState('')
-  const [jobTitle, setJobTitle] = useState<Maybe<string>>()
+  const [jobTitle, setJobTitle] = useState('')
   const [image, setImage] = useState<Maybe<ImageRefFragment>>()
   const [bio, setBio] = useState<RichTextBlockValue>(createDefaultValue())
   const [links, setLinks] = useState<ListValue<AuthorLink>[]>([

--- a/packages/editor/src/client/panel/userEditPanel.tsx
+++ b/packages/editor/src/client/panel/userEditPanel.tsx
@@ -109,8 +109,8 @@ export function UserEditPanel({id, onClose, onSave}: UserEditPanelProps) {
   useEffect(() => {
     if (data?.user) {
       setName(data.user.name)
-      setPreferredName(data.user.preferredName ?? undefined)
-      setFirstName(data.user.firstName ?? undefined)
+      setPreferredName(data.user.preferredName ?? '')
+      setFirstName(data.user.firstName ?? '')
       setEmail(data.user.email)
       setEmailVerifiedAt(data.user.emailVerifiedAt ? new Date(data.user.emailVerifiedAt) : null)
       setActive(data.user.active)

--- a/packages/editor/src/client/panel/userEditPanel.tsx
+++ b/packages/editor/src/client/panel/userEditPanel.tsx
@@ -67,8 +67,8 @@ function updateAddressObject(
 
 export function UserEditPanel({id, onClose, onSave}: UserEditPanelProps) {
   const [name, setName] = useState('')
-  const [firstName, setFirstName] = useState<string | undefined>()
-  const [preferredName, setPreferredName] = useState<string | undefined>()
+  const [firstName, setFirstName] = useState('')
+  const [preferredName, setPreferredName] = useState('')
   const [email, setEmail] = useState('')
   const [emailVerifiedAt, setEmailVerifiedAt] = useState<Date | null>(null)
   const [password, setPassword] = useState('')
@@ -79,11 +79,7 @@ export function UserEditPanel({id, onClose, onSave}: UserEditPanelProps) {
 
   const [isResetUserPasswordOpen, setIsResetUserPasswordOpen] = useState(false)
 
-  const {
-    data,
-    loading: isLoading,
-    error: loadError
-  } = useUserQuery({
+  const {data, loading: isLoading, error: loadError} = useUserQuery({
     variables: {id: id!},
     fetchPolicy: 'network-only',
     skip: id === undefined

--- a/packages/editor/src/client/routes/peerList.tsx
+++ b/packages/editor/src/client/routes/peerList.tsx
@@ -12,6 +12,7 @@ import {
   Icon,
   IconButton,
   List,
+  ListProps,
   Modal
 } from 'rsuite'
 import {
@@ -38,7 +39,7 @@ import {
   useRouteDispatch
 } from '../route'
 
-const ListItemLink = routeLink(List.Item as ComponentType<LinkHOCCompatibleProps>)
+const ListItemLink = routeLink(List.Item as ComponentType<ListProps & LinkHOCCompatibleProps>)
 const ButtonLink = routeLink(Button)
 
 type Peer = NonNullable<PeerListQuery['peers']>[number]

--- a/packages/editor/src/client/routes/peerList.tsx
+++ b/packages/editor/src/client/routes/peerList.tsx
@@ -1,49 +1,42 @@
-import React, {useState, useEffect} from 'react'
-
 import {LinkHOCCompatibleProps, RouteActionType} from '@wepublish/karma.run-react'
-
-import {
-  RouteType,
-  useRoute,
-  useRouteDispatch,
-  PeerListRoute,
-  PeerCreateRoute,
-  PeerEditRoute,
-  routeLink,
-  PeerInfoEditRoute,
-  IconButtonLink
-} from '../route'
-
-import {
-  usePeerListQuery,
-  usePeerProfileQuery,
-  useDeletePeerMutation,
-  PeerListDocument,
-  PeerListQuery
-} from '../api'
-
-import {IconButtonTooltip} from '../atoms/iconButtonTooltip'
-
-import {PeerEditPanel} from '../panel/peerEditPanel'
-
+import React, {ComponentType, useEffect, useState} from 'react'
 import {Trans, useTranslation} from 'react-i18next'
 import {
-  Drawer,
-  FlexboxGrid,
-  List,
+  Alert,
   Avatar,
-  Icon,
-  IconButton,
   Button,
   Divider,
-  Modal,
-  Alert,
-  HelpBlock
+  Drawer,
+  FlexboxGrid,
+  HelpBlock,
+  Icon,
+  IconButton,
+  List,
+  Modal
 } from 'rsuite'
+import {
+  PeerListDocument,
+  PeerListQuery,
+  useDeletePeerMutation,
+  usePeerListQuery,
+  usePeerProfileQuery
+} from '../api'
 import {DescriptionList, DescriptionListItem} from '../atoms/descriptionList'
+import {IconButtonTooltip} from '../atoms/iconButtonTooltip'
 import {NavigationBar} from '../atoms/navigationBar'
+import {PeerEditPanel} from '../panel/peerEditPanel'
 import {PeerInfoEditPanel} from '../panel/peerProfileEditPanel'
-import {ComponentType} from 'react'
+import {
+  IconButtonLink,
+  PeerCreateRoute,
+  PeerEditRoute,
+  PeerInfoEditRoute,
+  PeerListRoute,
+  routeLink,
+  RouteType,
+  useRoute,
+  useRouteDispatch
+} from '../route'
 
 const ListItemLink = routeLink(List.Item as ComponentType<LinkHOCCompatibleProps>)
 const ButtonLink = routeLink(Button)

--- a/packages/editor/src/client/routes/peerList.tsx
+++ b/packages/editor/src/client/routes/peerList.tsx
@@ -1,6 +1,6 @@
 import React, {useState, useEffect} from 'react'
 
-import {RouteActionType} from '@wepublish/karma.run-react'
+import {LinkHOCCompatibleProps, RouteActionType} from '@wepublish/karma.run-react'
 
 import {
   RouteType,
@@ -43,10 +43,9 @@ import {
 import {DescriptionList, DescriptionListItem} from '../atoms/descriptionList'
 import {NavigationBar} from '../atoms/navigationBar'
 import {PeerInfoEditPanel} from '../panel/peerProfileEditPanel'
+import {ComponentType} from 'react'
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-const ListItemLink = routeLink(List.Item)
+const ListItemLink = routeLink(List.Item as ComponentType<LinkHOCCompatibleProps>)
 const ButtonLink = routeLink(Button)
 
 type Peer = NonNullable<PeerListQuery['peers']>[number]

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,25 +22,6 @@
     tslib "^1.10.0"
     zen-observable "^0.8.14"
 
-"@apollo/client@^3.3.21":
-  version "3.3.21"
-  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.3.21.tgz#2862baa4e1ced8c5e89ebe6fc52877fc64a726aa"
-  integrity sha512-RAmZReFuKCKx0Rs5C0nVJwKomAHUHn+gGP/YvbEsXQWu0sXoncEUZa71UqlfCPVXa/0MkYOIbCXSQdOcuRrHgw==
-  dependencies:
-    "@graphql-typed-document-node/core" "^3.0.0"
-    "@types/zen-observable" "^0.8.0"
-    "@wry/context" "^0.6.0"
-    "@wry/equality" "^0.5.0"
-    fast-json-stable-stringify "^2.0.0"
-    graphql-tag "^2.12.0"
-    hoist-non-react-statics "^3.3.2"
-    optimism "^0.16.0"
-    prop-types "^15.7.2"
-    symbol-observable "^4.0.0"
-    ts-invariant "^0.8.0"
-    tslib "^1.10.0"
-    zen-observable "^0.8.14"
-
 "@apollo/client@^3.3.7":
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.3.7.tgz#f15bf961dc0c2bee37a47bf86b8881fdc6183810"
@@ -59,6 +40,25 @@
     ts-invariant "^0.6.0"
     tslib "^1.10.0"
     zen-observable "^0.8.14"
+
+"@apollo/client@^3.6.2":
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.6.2.tgz#0418bfa6358dd117894c8af396706cfa2b186032"
+  integrity sha512-DNWyl+NNU2VsfHtXwOr4rV9hnQFPkl2/dNXeouhk9q7bXCWdEh3K8YTt/frULGVKbQjtnlPmz8C+LFI/JZ2N3w==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.1.1"
+    "@wry/context" "^0.6.0"
+    "@wry/equality" "^0.5.0"
+    "@wry/trie" "^0.3.0"
+    graphql-tag "^2.12.6"
+    hoist-non-react-statics "^3.3.2"
+    optimism "^0.16.1"
+    prop-types "^15.7.2"
+    symbol-observable "^4.0.0"
+    ts-invariant "^0.10.0"
+    tslib "^2.3.0"
+    use-sync-external-store "^1.0.0"
+    zen-observable-ts "^1.2.0"
 
 "@apollo/protobufjs@1.2.2":
   version "1.2.2"
@@ -3211,6 +3211,11 @@
   resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.0.tgz#0eee6373e11418bfe0b5638f654df7a4ca6a3950"
   integrity sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==
 
+"@graphql-typed-document-node/core@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.1.tgz#076d78ce99822258cf813ecc1e7fa460fa74d052"
+  integrity sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==
+
 "@grpc/grpc-js@~1.2.0":
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.2.3.tgz#35dcbca3cb7415ef5ac6e73d44080ebcb44a4be5"
@@ -5241,15 +5246,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
-  version "16.9.34"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.34.tgz#f7d5e331c468f53affed17a8a4d488cd44ea9349"
-  integrity sha512-8AJlYMOfPe1KGLKyHpflCg5z46n0b5DbRfqDksxBLBTUpB75ypDBAO9eCUcjNwE6LCUslwTz00yyG/X9gaVtow==
-  dependencies:
-    "@types/prop-types" "*"
-    csstype "^2.2.0"
-
-"@types/react@^17.0.14":
+"@types/react@*", "@types/react@^17.0.14":
   version "17.0.14"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.14.tgz#f0629761ca02945c4e8fea99b8177f4c5c61fb0f"
   integrity sha512-0WwKHUbWuQWOce61UexYuWTGuGY/8JvtUe/dtQ6lR4sZ3UiylHotJeWpf3ArP9+DSGUoLY3wbU59VyMrJps5VQ==
@@ -8687,7 +8684,7 @@ cssstyle@^2.2.0:
   dependencies:
     cssom "~0.3.6"
 
-csstype@^2.2.0, csstype@^2.5.5, csstype@^2.6.6:
+csstype@^2.5.5, csstype@^2.6.6:
   version "2.6.10"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.10.tgz#e63af50e66d7c266edb6b32909cfd0aabe03928b"
   integrity sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==
@@ -11571,10 +11568,10 @@ graphql-tag@^2.11.0:
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.11.0.tgz#1deb53a01c46a7eb401d6cb59dec86fa1cccbffd"
   integrity sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA==
 
-graphql-tag@^2.12.0:
-  version "2.12.5"
-  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.5.tgz#5cff974a67b417747d05c8d9f5f3cb4495d0db8f"
-  integrity sha512-5xNhP4063d16Pz3HBtKprutsPrmHZi5IdUGOWRxA2B6VF7BIRGOHZ5WQvDmJXZuPcBg7rYwaFxvQYjqkSdR3TQ==
+graphql-tag@^2.12.6:
+  version "2.12.6"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.6.tgz#d441a569c1d2537ef10ca3d1633b48725329b5f1"
+  integrity sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==
   dependencies:
     tslib "^2.1.0"
 
@@ -16077,7 +16074,7 @@ optimism@^0.14.0:
     "@wry/context" "^0.5.2"
     "@wry/trie" "^0.2.1"
 
-optimism@^0.16.0:
+optimism@^0.16.1:
   version "0.16.1"
   resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.16.1.tgz#7c8efc1f3179f18307b887e18c15c5b7133f6e7d"
   integrity sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==
@@ -20373,6 +20370,13 @@ truncate-utf8-bytes@^1.0.0:
   dependencies:
     utf8-byte-length "^1.0.1"
 
+ts-invariant@^0.10.0:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.10.1.tgz#df002059ffcc3f94b5064fa74e32796434cd1b06"
+  integrity sha512-dOmY3naALBtNyK+nrVGzD8DVxSJ9OIHragItZ3XvxGORNAZL6uszgQYaD3PW+TPh2NWNsOpuQUxznuvTkmcdqw==
+  dependencies:
+    tslib "^2.1.0"
+
 ts-invariant@^0.4.0, ts-invariant@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.4.4.tgz#97a523518688f93aafad01b0e80eb803eb2abd86"
@@ -20388,13 +20392,6 @@ ts-invariant@^0.6.0:
     "@types/ungap__global-this" "^0.3.1"
     "@ungap/global-this" "^0.4.2"
     tslib "^1.9.3"
-
-ts-invariant@^0.8.0:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.8.2.tgz#62af654ebfb8b1eeb55bc9adc2f40c6b93b0ff7e"
-  integrity sha512-VI1ZSMW8soizP5dU8DsMbj/TncHf7bIUqavuE7FTeYeQat454HHurJ8wbfCnVWcDOMkyiBUWOW2ytew3xUxlRw==
-  dependencies:
-    tslib "^2.1.0"
 
 ts-jest@^26.3.0:
   version "26.4.0"
@@ -20481,6 +20478,11 @@ tslib@^2.0.3, tslib@^2.1.0, tslib@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
   integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
+
+tslib@^2.3.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tslib@~2.2.0:
   version "2.2.0"
@@ -20887,6 +20889,11 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-sync-external-store@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.1.0.tgz#3343c3fe7f7e404db70f8c687adf5c1652d34e82"
+  integrity sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ==
 
 use@^3.1.0:
   version "3.1.1"
@@ -21816,7 +21823,14 @@ zen-observable-ts@^0.8.21:
     tslib "^1.9.3"
     zen-observable "^0.8.0"
 
-zen-observable@^0.8.0, zen-observable@^0.8.14:
+zen-observable-ts@^1.2.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-1.2.3.tgz#c2f5ccebe812faf0cfcde547e6004f65b1a6d769"
+  integrity sha512-hc/TGiPkAWpByykMwDcem3SdUgA4We+0Qb36bItSuJC9xD0XVBZoFHYoadAomDSNf64CG8Ydj0Qb8Od8BUWz5g==
+  dependencies:
+    zen-observable "0.8.15"
+
+zen-observable@0.8.15, zen-observable@^0.8.0, zen-observable@^0.8.14:
   version "0.8.15"
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -8602,6 +8602,11 @@ csstype@^2.5.5, csstype@^2.6.6:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.10.tgz#e63af50e66d7c266edb6b32909cfd0aabe03928b"
   integrity sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==
 
+csstype@^3.0.11:
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.11.tgz#d66700c5eacfac1940deb4e3ee5642792d85cd33"
+  integrity sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw==
+
 csstype@^3.0.2:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.4.tgz#b156d7be03b84ff425c9a0a4b1e5f4da9c5ca888"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8602,11 +8602,6 @@ csstype@^2.5.5, csstype@^2.6.6:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.10.tgz#e63af50e66d7c266edb6b32909cfd0aabe03928b"
   integrity sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==
 
-csstype@^3.0.11:
-  version "3.0.11"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.11.tgz#d66700c5eacfac1940deb4e3ee5642792d85cd33"
-  integrity sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw==
-
 csstype@^3.0.2:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.4.tgz#b156d7be03b84ff425c9a0a4b1e5f4da9c5ca888"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,46 +2,7 @@
 # yarn lockfile v1
 
 
-"@apollo/client@^3.1.3":
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.2.1.tgz#178dfcc1eb3a35052df8f2bd44be195b78f56e93"
-  integrity sha512-w1EdCf3lvSwsxG2zbn8Rm31nPh9gQrB7u61BnU1QCM5BNIfOxiuuldzGNMHi5kI9KleisFvZl/9OA7pEkVg/yw==
-  dependencies:
-    "@graphql-typed-document-node/core" "^3.0.0"
-    "@types/zen-observable" "^0.8.0"
-    "@wry/context" "^0.5.2"
-    "@wry/equality" "^0.2.0"
-    fast-json-stable-stringify "^2.0.0"
-    graphql-tag "^2.11.0"
-    hoist-non-react-statics "^3.3.2"
-    optimism "^0.12.1"
-    prop-types "^15.7.2"
-    symbol-observable "^2.0.0"
-    terser "^5.2.0"
-    ts-invariant "^0.4.4"
-    tslib "^1.10.0"
-    zen-observable "^0.8.14"
-
-"@apollo/client@^3.3.7":
-  version "3.3.7"
-  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.3.7.tgz#f15bf961dc0c2bee37a47bf86b8881fdc6183810"
-  integrity sha512-Cb0OqqvlehlRHtHIXRIS/Pe5WYU4hHl1FznXTRSxBAN42WmBUM3zy/Unvw183RdWMyV6Kc2pFKOEuaG1K7JTAQ==
-  dependencies:
-    "@graphql-typed-document-node/core" "^3.0.0"
-    "@types/zen-observable" "^0.8.0"
-    "@wry/context" "^0.5.2"
-    "@wry/equality" "^0.3.0"
-    fast-json-stable-stringify "^2.0.0"
-    graphql-tag "^2.11.0"
-    hoist-non-react-statics "^3.3.2"
-    optimism "^0.14.0"
-    prop-types "^15.7.2"
-    symbol-observable "^2.0.0"
-    ts-invariant "^0.6.0"
-    tslib "^1.10.0"
-    zen-observable "^0.8.14"
-
-"@apollo/client@^3.6.2":
+"@apollo/client@^3.1.3", "@apollo/client@^3.3.21", "@apollo/client@^3.3.7":
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.6.2.tgz#0418bfa6358dd117894c8af396706cfa2b186032"
   integrity sha512-DNWyl+NNU2VsfHtXwOr4rV9hnQFPkl2/dNXeouhk9q7bXCWdEh3K8YTt/frULGVKbQjtnlPmz8C+LFI/JZ2N3w==
@@ -3206,11 +3167,6 @@
     is-promise "4.0.0"
     tslib "~2.0.1"
 
-"@graphql-typed-document-node/core@^3.0.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.0.tgz#0eee6373e11418bfe0b5638f654df7a4ca6a3950"
-  integrity sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==
-
 "@graphql-typed-document-node/core@^3.1.1":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.1.tgz#076d78ce99822258cf813ecc1e7fa460fa74d052"
@@ -5307,11 +5263,6 @@
   dependencies:
     source-map "^0.6.1"
 
-"@types/ungap__global-this@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@types/ungap__global-this/-/ungap__global-this-0.3.1.tgz#18ce9f657da556037a29d50604335614ce703f4c"
-  integrity sha512-+/DsiV4CxXl6ZWefwHZDXSe1Slitz21tom38qPCaG0DYCS1NnDPIQDTKcmQ/tvK/edJUKkmuIDBJbmKDiB0r/g==
-
 "@types/webpack-dev-server@^2.9.4":
   version "2.9.6"
   resolved "https://registry.yarnpkg.com/@types/webpack-dev-server/-/webpack-dev-server-2.9.6.tgz#423d96ae2a0956543b18cb399a0841bf20f77b24"
@@ -5388,11 +5339,6 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@types/zen-observable@^0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.0.tgz#8b63ab7f1aa5321248aad5ac890a485656dcea4d"
-  integrity sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==
-
 "@typescript-eslint/eslint-plugin@^4.2.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.2.0.tgz#a3d5c11b377b7e18f3cd9c4e87d465fe9432669b"
@@ -5462,11 +5408,6 @@
   dependencies:
     "@typescript-eslint/types" "4.2.0"
     eslint-visitor-keys "^2.0.0"
-
-"@ungap/global-this@^0.4.2":
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/@ungap/global-this/-/global-this-0.4.4.tgz#8a1b2cfcd3e26e079a847daba879308c924dd695"
-  integrity sha512-mHkm6FvepJECMNthFuIgpAEFmPOk71UyXuIxYfjytvFTnSDBIz7jmViO+LfHI/AjrazWije0PnSP3+/NlwzqtA==
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -5649,13 +5590,6 @@
     object.fromentries "^2.0.0"
     prop-types "^15.7.0"
 
-"@wry/context@^0.5.2":
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.5.2.tgz#f2a5d5ab9227343aa74c81e06533c1ef84598ec7"
-  integrity sha512-B/JLuRZ/vbEKHRUiGj6xiMojST1kHhu4WcreLfNN7q9DqQFrb97cWgf/kiYsPSUCAMVN0HzfFc8XjJdzgZzfjw==
-  dependencies:
-    tslib "^1.9.3"
-
 "@wry/context@^0.6.0":
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.6.0.tgz#f903eceb89d238ef7e8168ed30f4511f92d83e06"
@@ -5670,33 +5604,12 @@
   dependencies:
     tslib "^1.9.3"
 
-"@wry/equality@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.2.0.tgz#a312d1b6a682d0909904c2bcd355b02303104fb7"
-  integrity sha512-Y4d+WH6hs+KZJUC8YKLYGarjGekBrhslDbf/R20oV+AakHPINSitHfDRQz3EGcEWc1luXYNUvMhawWtZVWNGvQ==
-  dependencies:
-    tslib "^1.9.3"
-
-"@wry/equality@^0.3.0":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.3.1.tgz#81080cdc2e0d8265cd303faa0c64b38a77884e06"
-  integrity sha512-8/Ftr3jUZ4EXhACfSwPIfNsE8V6WKesdjp+Dxi78Bej6qlasAxiz0/F8j0miACRj9CL4vC5Y5FsfwwEYAuhWbg==
-  dependencies:
-    tslib "^1.14.1"
-
 "@wry/equality@^0.5.0":
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.5.1.tgz#b22e4e1674d7bf1439f8ccdccfd6a785f6de68b0"
   integrity sha512-FZKbdpbcVcbDxQrKcaBClNsQaMg9nof1RKM7mReJe5DKUzM5u8S7T+PqwNqvib5O2j2xxF1R4p5O3+b6baTrbw==
   dependencies:
     tslib "^2.1.0"
-
-"@wry/trie@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@wry/trie/-/trie-0.2.1.tgz#4191e1d4a85dd77dfede383d65563138ed82fc47"
-  integrity sha512-sYkuXZqArky2MLQCv4tLW6hX3N8AfTZ5ZMBc8jC6Yy35WYr82UYLLtjS7k/uRGHOA0yTSjuNadG6QQ6a5CS5hQ==
-  dependencies:
-    tslib "^1.14.1"
 
 "@wry/trie@^0.3.0":
   version "0.3.0"
@@ -16059,21 +15972,6 @@ opn@^5.5.0:
   dependencies:
     is-wsl "^1.1.0"
 
-optimism@^0.12.1:
-  version "0.12.2"
-  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.12.2.tgz#de9dc3d2c914d7b34e08957a768967c0605beda9"
-  integrity sha512-k7hFhlmfLl6HNThIuuvYMQodC1c+q6Uc6V9cLVsMWyW514QuaxVJH/khPu2vLRIoDTpFdJ5sojlARhg1rzyGbg==
-  dependencies:
-    "@wry/context" "^0.5.2"
-
-optimism@^0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.14.0.tgz#256fb079a3428585b40a3a8462f907e0abd2fc49"
-  integrity sha512-ygbNt8n4DOCVpkwiLF+IrKKeNHOjtr9aXLWGP9HNJGoblSGsnVbJLstcH6/nE9Xy5ZQtlkSioFQNnthmENW6FQ==
-  dependencies:
-    "@wry/context" "^0.5.2"
-    "@wry/trie" "^0.2.1"
-
 optimism@^0.16.1:
   version "0.16.1"
   resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.16.1.tgz#7c8efc1f3179f18307b887e18c15c5b7133f6e7d"
@@ -19035,7 +18933,7 @@ source-map-support@^0.5.16:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
-source-map-support@^0.5.17, source-map-support@^0.5.6, source-map-support@~0.5.12, source-map-support@~0.5.19:
+source-map-support@^0.5.17, source-map-support@^0.5.6, source-map-support@~0.5.12:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
@@ -19065,7 +18963,7 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-source-map@^0.7.3, source-map@~0.7.2:
+source-map@^0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
@@ -19660,11 +19558,6 @@ symbol-observable@^1.0.4, symbol-observable@^1.1.0:
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
-symbol-observable@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-2.0.1.tgz#ce66c36a04ed0f3056e7293184749a6fdd7063ea"
-  integrity sha512-QrfHrrEUMadQCgMijc3YpfA4ncwgqGv58Xgvdu3JZVQB7iY7cAkiqobZEZbaA863jof8AdpR01CPnZ5UWeqZBQ==
-
 symbol-observable@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-4.0.0.tgz#5b425f192279e87f2f9b937ac8540d1984b39205"
@@ -19807,15 +19700,6 @@ terser@^4.1.2:
     commander "^2.20.0"
     source-map "~0.6.1"
     source-map-support "~0.5.12"
-
-terser@^5.2.0:
-  version "5.3.3"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.3.3.tgz#2592a1cf079df55101fe2b2cb2330f951863860b"
-  integrity sha512-vRQDIlD+2Pg8YMwVK9kMM3yGylG95EIwzBai1Bw7Ot4OBfn3VP1TZn3EWx4ep2jERN/AmnVaTiGuelZSN7ds/A==
-  dependencies:
-    commander "^2.20.0"
-    source-map "~0.7.2"
-    source-map-support "~0.5.19"
 
 test-exclude@^6.0.0:
   version "6.0.0"
@@ -20384,15 +20268,6 @@ ts-invariant@^0.4.0, ts-invariant@^0.4.4:
   dependencies:
     tslib "^1.9.3"
 
-ts-invariant@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.6.0.tgz#44066ecfeb7a806ff1c3b0b283408a337a885412"
-  integrity sha512-caoafsfgb8QxdrKzFfjKt627m4i8KTtfAiji0DYJfWI4A/S9ORNNpzYuD9br64kyKFgxn9UNaLLbSupam84mCA==
-  dependencies:
-    "@types/ungap__global-this" "^0.3.1"
-    "@ungap/global-this" "^0.4.2"
-    tslib "^1.9.3"
-
 ts-jest@^26.3.0:
   version "26.4.0"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.4.0.tgz#903c7827f3d3bc33efc2f91be294b164400c32e3"
@@ -20463,11 +20338,6 @@ tslib@^1.11.1, tslib@^1.9.0:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
-
-tslib@^1.14.1:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
-  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tslib@^2.0.0, tslib@~2.0.0, tslib@~2.0.1:
   version "2.0.1"
@@ -21830,7 +21700,7 @@ zen-observable-ts@^1.2.0:
   dependencies:
     zen-observable "0.8.15"
 
-zen-observable@0.8.15, zen-observable@^0.8.0, zen-observable@^0.8.14:
+zen-observable@0.8.15, zen-observable@^0.8.0:
   version "0.8.15"
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==


### PR DESCRIPTION
A few fixes for ts-ignores, there should be comments to any of the changes.

For the `yarn.lock` changes:

Updating `@types/react` fixes the mismatch between `<root>/node_modules/@types/react` and `<root/packages/editor/node_modules/@types/react`
Updating `@apollo/client` fixes the missmatch between `<root>/packages/editor/node_modules/@apollo/client` and `<root>/packages/editor/node_modules/apollo-upload-client/node_modules/@apollo/client`


While upgrading @apollo/client so that all libraries/dependencies use the same version the tests started to fail.
The errors were that they tried to write a field but it did not exist in the result. This seems to be related to this: https://github.com/apollographql/apollo-client/issues/8677. I don't know if this is a bug by apollo, but it seems like it.

Another error encountered was that `value` that was given to FormControls switched from undefined to string. This should not happen according to https://reactjs.org/docs/forms.html#controlled-components and they should always be strings.


fixes #76
