### PR TITLE
bugfix for missing variable in the sendMail command

### DIFF
--- a/packages/api/src/memberContext.ts
+++ b/packages/api/src/memberContext.ts
@@ -557,6 +557,7 @@ export class MemberContext implements MemberContext {
             recipient: invoice.mail,
             data: {
               user,
+              ...(user ? {loginURL: this.getLoginUrlForUser(user)} : {}),
               invoice,
               paymentProviderID: paymentMethod.paymentProviderID,
               errorCode: 'customer_missing',
@@ -646,6 +647,7 @@ export class MemberContext implements MemberContext {
         recipient: invoice.mail,
         data: {
           user,
+          ...(user ? {loginURL: this.getLoginUrlForUser(user)} : {}),
           invoice,
           paymentProviderID: paymentProvider.id,
           errorCode: intent.errorCode


### PR DESCRIPTION
In the memberContext the `sendMail` command should provide the `loginURL` through the data. This way the email templates can work with that loginURL to allow users to be authenticated directly. This already happens in the sendMail for invoice reminders. This PR also generates the `loginURL` for off session mails.