### PR TITLE
fix for the mongodb adpater to use the skip function for getInvoices

### DIFF
--- a/packages/api-db-mongodb/src/db/invoice.ts
+++ b/packages/api-db-mongodb/src/db/invoice.ts
@@ -167,6 +167,7 @@ export class MongoDBInvoiceAdapter implements DBInvoiceAdapter {
         .match(textFilter)
         .match(cursorFilter)
         .sort({[sortField]: sortDirection, _id: sortDirection})
+        .skip(limit.skip ?? 0)
         .limit(limitCount + 1)
         .toArray()
     ])


### PR DESCRIPTION
This PR fixes the `getInvoices()` method in the api-db-mongodb adapter. The method arguments and the graphQL query behind it allow for the skip parameter to be passed. But the actual call to the mongo db ignores it.