### PR TITLE
bugfix: added missing canceledAt field in graphQL publicInvoice

### DIFF
--- a/packages/api/src/graphql/invoice.ts
+++ b/packages/api/src/graphql/invoice.ts
@@ -67,6 +67,7 @@ export const GraphQLPublicInvoice = new GraphQLObjectType<Invoice, Context>({
 
     description: {type: GraphQLString},
     paidAt: {type: GraphQLDateTime},
+    canceledAt: {type: GraphQLDateTime},
     items: {type: GraphQLNonNull(GraphQLList(GraphQLNonNull(GraphQLInvoiceItem)))},
     subscriptionID: {type: GraphQLNonNull(GraphQLID)},
     total: {


### PR DESCRIPTION
This PR adds the `canceledAt` field to the graphQL type publicInvoice. Without this field it's not possible to know in the frontend if a invoice has been canceled.