### PR TITLE
bug fix do not return canceled invoices in renewSubscriptionForUser

### DIFF
--- a/packages/api/src/memberContext.ts
+++ b/packages/api/src/memberContext.ts
@@ -242,7 +242,12 @@ export class MemberContext implements MemberContext {
           (paidUntil !== null && periods[periods.length - 1].endsAt > paidUntil))
       ) {
         const period = periods[periods.length - 1]
-        return await this.loaders.invoicesByID.load(period.id)
+        const invoice = await this.dbAdapter.invoice.getInvoiceByID(period.invoiceID)
+        // only return the invoice if it hasn't been canceled. Otherwise
+        // create a new period and a new invoice
+        if (!invoice?.canceledAt) {
+          return invoice
+        }
       }
 
       const startDate = new Date(


### PR DESCRIPTION
This PR fixes a critical bug in the subscription renewal. If the user updates the subscription the api will check if it needs to generate new periods and/or a new invoice. If there are subscription periods that have an ending date in the future the the api didn't check if the corresponding invoice was canceled. This fix checks for canceled invoices and if true will create a new period and a new invoice.

@michael-scheurer and @elias-summermatter not sure if this applies to Bajour and Hauptstadt but i think it's a critical bug.