### PR TITLE
Preview page with token or slug

### DIFF
--- a/packages/api/src/graphql/query.private.ts
+++ b/packages/api/src/graphql/query.private.ts
@@ -893,7 +893,7 @@ export const GraphQLQuery = new GraphQLObjectType<undefined, Context>({
         }
       }
     },
-
+    // TODO
     articlePreviewLink: {
       type: GraphQLString,
       args: {id: {type: GraphQLNonNull(GraphQLID)}, hours: {type: GraphQLNonNull(GraphQLInt)}},

--- a/packages/api/src/graphql/query.private.ts
+++ b/packages/api/src/graphql/query.private.ts
@@ -893,7 +893,7 @@ export const GraphQLQuery = new GraphQLObjectType<undefined, Context>({
         }
       }
     },
-    // TODO
+
     articlePreviewLink: {
       type: GraphQLString,
       args: {id: {type: GraphQLNonNull(GraphQLID)}, hours: {type: GraphQLNonNull(GraphQLInt)}},

--- a/packages/api/src/graphql/query.public.ts
+++ b/packages/api/src/graphql/query.public.ts
@@ -181,6 +181,7 @@ export const GraphQLPublicQuery = new GraphQLObjectType<undefined, Context>({
         if (session?.type === SessionType.Token) {
           return article?.shared ? article : null
         }
+        if (!article) throw new NotFound('Article', id ?? slug ?? token)
 
         return article
       }
@@ -284,6 +285,7 @@ export const GraphQLPublicQuery = new GraphQLObjectType<undefined, Context>({
             )
           }
         }
+        if (!page) throw new NotFound('Page', id ?? slug ?? token)
 
         return page
       }

--- a/packages/api/src/graphql/query.public.ts
+++ b/packages/api/src/graphql/query.public.ts
@@ -259,7 +259,7 @@ export const GraphQLPublicQuery = new GraphQLObjectType<undefined, Context>({
       async resolve(root, {id, slug, token}, {session, loaders, verifyJWT}) {
         let page = id ? await loaders.publicPagesByID.load(id) : null
 
-        if (!page) {
+        if (!page && slug !== undefined) {
           // slug can be empty string
           page = await loaders.publicPagesBySlug.load(slug)
         }


### PR DESCRIPTION
WPC-695: fix page query to work with preview token as param without slug.

[Public API](https://api.fwpc695to.wepublish.dev/)
[Private API](https://api.fwpc695to.wepublish.dev/admin)