### PR TITLE
fix(editor): editing peers required the token by accident

### DIFF
--- a/packages/editor/__tests__/specs/__snapshots__/peerEditPanel.tsx.snap
+++ b/packages/editor/__tests__/specs/__snapshots__/peerEditPanel.tsx.snap
@@ -375,7 +375,7 @@ exports[`Peer Edit Panel should render with ID 1`] = `
               for="token"
               id="token-control-label"
             >
-              peerList.panels.token*
+              peerList.panels.token
             </label>
             <div
               class="rs-form-control rs-form-control-wrapper"

--- a/packages/editor/__tests__/specs/__snapshots__/toggleRequiredLabel.test.ts.snap
+++ b/packages/editor/__tests__/specs/__snapshots__/toggleRequiredLabel.test.ts.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should add the required symbol by default 1`] = `"foobar*"`;
+
+exports[`should add the required symbol if required is set to true 1`] = `"foobar*"`;
+
+exports[`should not add the required symbol if required is set to false 1`] = `"foobar"`;

--- a/packages/editor/__tests__/specs/toggleRequiredLabel.test.ts
+++ b/packages/editor/__tests__/specs/toggleRequiredLabel.test.ts
@@ -1,0 +1,19 @@
+import {toggleRequiredLabel} from '../../src/client/toggleRequiredLabel'
+
+test('should add the required symbol by default', () => {
+  const result = toggleRequiredLabel('foobar', true)
+
+  expect(result).toMatchSnapshot()
+})
+
+test('should add the required symbol if required is set to true', () => {
+  const result = toggleRequiredLabel('foobar', true)
+
+  expect(result).toMatchSnapshot()
+})
+
+test('should not add the required symbol if required is set to false', () => {
+  const result = toggleRequiredLabel('foobar', false)
+
+  expect(result).toMatchSnapshot()
+})

--- a/packages/editor/src/client/atoms/user/editUserPassword.tsx
+++ b/packages/editor/src/client/atoms/user/editUserPassword.tsx
@@ -4,6 +4,7 @@ import {useTranslation} from 'react-i18next'
 import {FullUserFragment, useSendWebsiteLoginMutation} from '../../api'
 import {Reload, Send} from '@rsuite/icons'
 import {ResetUserPasswordForm} from './resetUserPasswordForm'
+import {toggleRequiredLabel} from '../../toggleRequiredLabel'
 
 interface CreateOrUpdateuserPasswordProps {
   user?: FullUserFragment | null
@@ -80,7 +81,10 @@ export function EditUserPassword({
     // create new password form
     return (
       <Form.Group controlId="password">
-        <Form.ControlLabel>{t('userCreateOrEditView.password') + '*'}</Form.ControlLabel>
+        <Form.ControlLabel>
+          {toggleRequiredLabel(t('userCreateOrEditView.password'))}
+        </Form.ControlLabel>
+
         <Form.Control
           type="password"
           name="password"

--- a/packages/editor/src/client/panel/authorEditPanel.tsx
+++ b/packages/editor/src/client/panel/authorEditPanel.tsx
@@ -36,6 +36,7 @@ import {RichTextBlockValue} from '../blocks/types'
 import {useTranslation} from 'react-i18next'
 import {ChooseEditImage} from '../atoms/chooseEditImage'
 import LinkIcon from '@rsuite/icons/legacy/Link'
+import {toggleRequiredLabel} from '../toggleRequiredLabel'
 
 export interface AuthorEditPanelProps {
   id?: string
@@ -181,7 +182,10 @@ export function AuthorEditPanel({id, onClose, onSave}: AuthorEditPanelProps) {
           <PanelGroup>
             <Panel>
               <Form.Group controlId="name">
-                <Form.ControlLabel>{t('authors.panels.name') + '*'}</Form.ControlLabel>
+                <Form.ControlLabel>
+                  {toggleRequiredLabel(t('authors.panels.name'))}
+                </Form.ControlLabel>
+
                 <Form.Control
                   name="name"
                   value={name}

--- a/packages/editor/src/client/panel/memberPlanEditPanel.tsx
+++ b/packages/editor/src/client/panel/memberPlanEditPanel.tsx
@@ -44,6 +44,7 @@ import {RichTextBlockValue} from '../blocks/types'
 import {useTranslation} from 'react-i18next'
 import {ChooseEditImage} from '../atoms/chooseEditImage'
 import {CurrencyInput} from '../atoms/currencyInput'
+import {toggleRequiredLabel} from '../toggleRequiredLabel'
 
 export interface MemberPlanEditPanelProps {
   id?: string
@@ -229,7 +230,7 @@ export function MemberPlanEditPanel({id, onClose, onSave}: MemberPlanEditPanelPr
         <Drawer.Body>
           <Panel>
             <Form.Group>
-              <Form.ControlLabel>{t('memberPlanList.name') + '*'}</Form.ControlLabel>
+              <Form.ControlLabel>{toggleRequiredLabel(t('memberPlanList.name'))}</Form.ControlLabel>
               <Form.Control
                 name="name"
                 value={name}
@@ -265,7 +266,7 @@ export function MemberPlanEditPanel({id, onClose, onSave}: MemberPlanEditPanelPr
 
             <Form.Group>
               <Form.ControlLabel>
-                {t('memberPlanList.minimumMonthlyAmount') + '*'}
+                {toggleRequiredLabel(t('memberPlanList.minimumMonthlyAmount'))}
               </Form.ControlLabel>
               <CurrencyInput
                 name="currency"

--- a/packages/editor/src/client/panel/paymentMethodEditPanel.tsx
+++ b/packages/editor/src/client/panel/paymentMethodEditPanel.tsx
@@ -13,6 +13,7 @@ import {
 
 import {useTranslation} from 'react-i18next'
 import {slugify} from '../utility'
+import {toggleRequiredLabel} from '../toggleRequiredLabel'
 
 export interface PaymentMethodEditPanelProps {
   id?: string
@@ -166,7 +167,9 @@ export function PaymentMethodEditPanel({id, onClose, onSave}: PaymentMethodEditP
         <Drawer.Body>
           <Panel>
             <Form.Group>
-              <Form.ControlLabel>{t('paymentMethodList.name') + '*'}</Form.ControlLabel>
+              <Form.ControlLabel>
+                {toggleRequiredLabel(t('paymentMethodList.name'))}
+              </Form.ControlLabel>
               <Form.Control
                 name="name"
                 value={name}
@@ -187,7 +190,9 @@ export function PaymentMethodEditPanel({id, onClose, onSave}: PaymentMethodEditP
               <Form.HelpText>{t('paymentMethodList.activeDescription')}</Form.HelpText>
             </Form.Group>
             <Form.Group>
-              <Form.ControlLabel>{t('paymentMethodList.adapter') + '*'}</Form.ControlLabel>
+              <Form.ControlLabel>
+                {toggleRequiredLabel(t('paymentMethodList.adapter'))}
+              </Form.ControlLabel>
               <Form.Control
                 name="paymentProvider"
                 virtualized

--- a/packages/editor/src/client/panel/peerEditPanel.tsx
+++ b/packages/editor/src/client/panel/peerEditPanel.tsx
@@ -17,6 +17,7 @@ import {slugify, getOperationNameFromDocument} from '../utility'
 import {useTranslation} from 'react-i18next'
 import {DescriptionList, DescriptionListItem} from '../atoms/descriptionList'
 import {RichTextBlock} from '../blocks/richTextBlock/richTextBlock'
+import {toggleRequiredLabel} from '../toggleRequiredLabel'
 
 export interface PeerEditPanelProps {
   id?: string
@@ -130,7 +131,7 @@ export function PeerEditPanel({id, hostURL, onClose, onSave}: PeerEditPanelProps
     url: StringType()
       .isRequired(t('errorMessages.noUrlErrorMessage'))
       .isURL(t('errorMessages.invalidUrlErrorMessage')),
-    token: StringType().isRequired(t('errorMessages.noTokenErrorMessage'))
+    token: id ? StringType() : StringType().isRequired(t('errorMessages.noTokenErrorMessage'))
   })
 
   return (
@@ -163,7 +164,10 @@ export function PeerEditPanel({id, hostURL, onClose, onSave}: PeerEditPanelProps
         <Drawer.Body>
           <Panel>
             <Form.Group controlId="name">
-              <Form.ControlLabel>{t('peerList.panels.name') + '*'}</Form.ControlLabel>
+              <Form.ControlLabel>
+                {toggleRequiredLabel(t('peerList.panels.name'))}
+              </Form.ControlLabel>
+
               <Form.Control
                 value={name}
                 name="name"
@@ -174,7 +178,7 @@ export function PeerEditPanel({id, hostURL, onClose, onSave}: PeerEditPanelProps
               />
             </Form.Group>
             <Form.Group controlId="url">
-              <Form.ControlLabel>{t('peerList.panels.URL') + '*'}</Form.ControlLabel>
+              <Form.ControlLabel>{toggleRequiredLabel(t('peerList.panels.URL'))}</Form.ControlLabel>
               <Form.Control
                 value={urlString}
                 name="url"
@@ -184,7 +188,10 @@ export function PeerEditPanel({id, hostURL, onClose, onSave}: PeerEditPanelProps
               />
             </Form.Group>
             <Form.Group controlId="token">
-              <Form.ControlLabel>{t('peerList.panels.token') + '*'}</Form.ControlLabel>
+              <Form.ControlLabel>
+                {toggleRequiredLabel(t('peerList.panels.token'), !id)}
+              </Form.ControlLabel>
+
               <Form.Control
                 value={token}
                 name="token"

--- a/packages/editor/src/client/panel/peerProfileEditPanel.tsx
+++ b/packages/editor/src/client/panel/peerProfileEditPanel.tsx
@@ -21,6 +21,7 @@ import {RichTextBlockValue} from '../blocks/types'
 import {ColorPicker} from '../atoms/colorPicker'
 import {useTranslation} from 'react-i18next'
 import {FormInstance} from 'rsuite/esm/Form'
+import {toggleRequiredLabel} from '../toggleRequiredLabel'
 
 type PeerProfileImage = NonNullable<PeerProfileQuery['peerProfile']>['logo']
 
@@ -158,7 +159,7 @@ export function PeerInfoEditPanel({onClose, onSave}: ImageEditPanelProps) {
         </Drawer.Header>
 
         <Drawer.Body>
-          <Panel bodyFill header={t('peerList.panels.image') + '*'}>
+          <Panel bodyFill header={toggleRequiredLabel(t('peerList.panels.image'))}>
             <ChooseEditImage
               image={logoImage}
               header={''}
@@ -188,7 +189,9 @@ export function PeerInfoEditPanel({onClose, onSave}: ImageEditPanelProps) {
 
           <Panel header={t('peerList.panels.information')}>
             <Form.Group>
-              <Form.ControlLabel>{t('peerList.panels.name') + '*'}</Form.ControlLabel>
+              <Form.ControlLabel>
+                {toggleRequiredLabel(t('peerList.panels.name'))}
+              </Form.ControlLabel>
               <Form.Control name="name" value={name} onChange={(value: string) => setName(value)} />
             </Form.Group>
             <Form.Group>
@@ -237,7 +240,9 @@ export function PeerInfoEditPanel({onClose, onSave}: ImageEditPanelProps) {
               </Form.Group>
             </div>
             <br />
-            <Form.ControlLabel>{t('peerList.panels.callToActionImage') + '*'}</Form.ControlLabel>
+            <Form.ControlLabel>
+              {toggleRequiredLabel(t('peerList.panels.callToActionImage'))}
+            </Form.ControlLabel>
             <div
               style={{
                 border: 'solid 1px #cad5e4',
@@ -246,7 +251,9 @@ export function PeerInfoEditPanel({onClose, onSave}: ImageEditPanelProps) {
                 marginTop: '4px'
               }}>
               <Form.Group>
-                <Form.ControlLabel>{t('peerList.panels.image') + '*'}</Form.ControlLabel>
+                <Form.ControlLabel>
+                  {toggleRequiredLabel(t('peerList.panels.image'))}
+                </Form.ControlLabel>
                 <ChooseEditImage
                   image={callToActionImage}
                   header={''}

--- a/packages/editor/src/client/panel/subscriptionEditPanel.tsx
+++ b/packages/editor/src/client/panel/subscriptionEditPanel.tsx
@@ -1,7 +1,7 @@
+import FileIcon from '@rsuite/icons/legacy/File'
 import React, {useEffect, useState} from 'react'
-
+import {useTranslation} from 'react-i18next'
 import {
-  toaster,
   Button,
   DatePicker,
   Drawer,
@@ -12,9 +12,10 @@ import {
   Panel,
   Schema,
   SelectPicker,
+  toaster,
   Toggle
 } from 'rsuite'
-
+import FormControlLabel from 'rsuite/FormControlLabel'
 import {
   DeactivationFragment,
   FullMemberPlanFragment,
@@ -32,15 +33,13 @@ import {
   useSubscriptionQuery,
   useUpdateSubscriptionMutation
 } from '../api'
-import {useTranslation} from 'react-i18next'
-import {DescriptionList, DescriptionListItem} from '../atoms/descriptionList'
-import {ALL_PAYMENT_PERIODICITIES} from '../utility'
-import {UserSubscriptionDeactivatePanel} from './userSubscriptionDeactivatePanel'
 import {CurrencyInput} from '../atoms/currencyInput'
-import {InvoiceListPanel} from './invoiceListPanel'
-import FormControlLabel from 'rsuite/FormControlLabel'
-import FileIcon from '@rsuite/icons/legacy/File'
+import {DescriptionList, DescriptionListItem} from '../atoms/descriptionList'
 import {UserSearch} from '../atoms/searchAndFilter/userSearch'
+import {toggleRequiredLabel} from '../toggleRequiredLabel'
+import {ALL_PAYMENT_PERIODICITIES} from '../utility'
+import {InvoiceListPanel} from './invoiceListPanel'
+import {UserSubscriptionDeactivatePanel} from './userSubscriptionDeactivatePanel'
 
 export interface SubscriptionEditPanelProps {
   id?: string
@@ -312,10 +311,12 @@ export function SubscriptionEditPanel({id, onClose, onSave}: SubscriptionEditPan
       <Form.Group>
         <FormControlLabel>
           {t('userSubscriptionEdit.payedUntil')}
+
           <Button appearance="link" onClick={() => setIsInvoiceListOpen(true)}>
             ({t('invoice.seeInvoiceHistory')})
           </Button>
         </FormControlLabel>
+
         <DatePicker block value={paidUntil ?? undefined} disabled />
       </Form.Group>
     )
@@ -337,6 +338,7 @@ export function SubscriptionEditPanel({id, onClose, onSave}: SubscriptionEditPan
             {t('invoice.panel.invoiceHistory')} ({unpaidInvoices} {t('invoice.unpaid')})
           </Button>
         </FlexboxGrid.Item>
+
         <FlexboxGrid.Item>
           <Button
             appearance="ghost"
@@ -377,6 +379,7 @@ export function SubscriptionEditPanel({id, onClose, onSave}: SubscriptionEditPan
             <Button appearance="primary" disabled={isDisabled || isDeactivated} type="submit">
               {id ? t('save') : t('create')}
             </Button>
+
             <Button appearance={'subtle'} onClick={() => onClose?.()}>
               {t('close')}
             </Button>
@@ -398,8 +401,9 @@ export function SubscriptionEditPanel({id, onClose, onSave}: SubscriptionEditPan
           <Panel>
             <Form.Group>
               <Form.ControlLabel>
-                {t('userSubscriptionEdit.selectMemberPlan') + '*'}
+                {toggleRequiredLabel(t('userSubscriptionEdit.selectMemberPlan'))}
               </Form.ControlLabel>
+
               <Form.Control
                 block
                 name="memberPlan"
@@ -410,6 +414,7 @@ export function SubscriptionEditPanel({id, onClose, onSave}: SubscriptionEditPan
                 onChange={(value: any) => setMemberPlan(memberPlans.find(mp => mp.id === value))}
                 accepter={SelectPicker}
               />
+
               {memberPlan && (
                 <Form.HelpText>
                   <DescriptionList>
@@ -420,8 +425,12 @@ export function SubscriptionEditPanel({id, onClose, onSave}: SubscriptionEditPan
                 </Form.HelpText>
               )}
             </Form.Group>
+
             <Form.Group>
-              <Form.ControlLabel>{t('userSubscriptionEdit.selectUser') + '*'}</Form.ControlLabel>
+              <Form.ControlLabel>
+                {toggleRequiredLabel(t('userSubscriptionEdit.selectUser'))}
+              </Form.ControlLabel>
+
               <UserSearch
                 name="user"
                 user={user}
@@ -430,8 +439,12 @@ export function SubscriptionEditPanel({id, onClose, onSave}: SubscriptionEditPan
                 }}
               />
             </Form.Group>
+
             <Form.Group>
-              <Form.ControlLabel>{t('userSubscriptionEdit.monthlyAmount') + '*'}</Form.ControlLabel>
+              <Form.ControlLabel>
+                {toggleRequiredLabel(t('userSubscriptionEdit.monthlyAmount'))}
+              </Form.ControlLabel>
+
               <CurrencyInput
                 name="currency"
                 currency="CHF"
@@ -442,10 +455,12 @@ export function SubscriptionEditPanel({id, onClose, onSave}: SubscriptionEditPan
                 disabled={isDisabled || hasNoMemberPlanSelected || isDeactivated}
               />
             </Form.Group>
+
             <Form.Group>
               <Form.ControlLabel>
-                {t('memberPlanList.paymentPeriodicities') + '*'}
+                {toggleRequiredLabel(t('memberPlanList.paymentPeriodicities'))}
               </Form.ControlLabel>
+
               <Form.Control
                 virtualized
                 value={paymentPeriodicity}
@@ -460,15 +475,19 @@ export function SubscriptionEditPanel({id, onClose, onSave}: SubscriptionEditPan
                 accepter={SelectPicker}
               />
             </Form.Group>
+
             <Form.Group>
               <Form.ControlLabel>{t('userSubscriptionEdit.autoRenew')}</Form.ControlLabel>
+
               <Toggle
                 checked={autoRenew}
                 disabled={isDisabled || hasNoMemberPlanSelected || isDeactivated}
                 onChange={value => setAutoRenew(value)}
               />
+
               <Form.HelpText>{t('userSubscriptionEdit.autoRenewDescription')}</Form.HelpText>
             </Form.Group>
+
             <Form.Group>
               <Form.ControlLabel>{t('userSubscriptionEdit.startsAt')}</Form.ControlLabel>
               <DatePicker
@@ -479,16 +498,23 @@ export function SubscriptionEditPanel({id, onClose, onSave}: SubscriptionEditPan
                 onChange={value => setStartsAt(value!)}
               />
             </Form.Group>
+
             {subscriptionActionsViewLink()}
+
             <Form.Group>
               <FormControlLabel>{t('userSubscriptionEdit.paymentMethod')}</FormControlLabel>
             </Form.Group>
+
             <Form.Group>
               <Form.ControlLabel>{t('userSubscriptionEdit.payedUntil')}</Form.ControlLabel>
               <DatePicker block value={paidUntil ?? undefined} disabled />
             </Form.Group>
+
             <Form.Group>
-              <Form.ControlLabel>{t('userSubscriptionEdit.paymentMethod') + '*'}</Form.ControlLabel>
+              <Form.ControlLabel>
+                {toggleRequiredLabel(t('userSubscriptionEdit.paymentMethod'))}
+              </Form.ControlLabel>
+
               <Form.Control
                 name="paymentMethod"
                 block

--- a/packages/editor/src/client/panel/userRoleEditPanel.tsx
+++ b/packages/editor/src/client/panel/userRoleEditPanel.tsx
@@ -12,6 +12,7 @@ import {
 } from '../api'
 
 import {useTranslation} from 'react-i18next'
+import {toggleRequiredLabel} from '../toggleRequiredLabel'
 
 export interface UserRoleEditPanelProps {
   id?: string
@@ -146,7 +147,7 @@ export function UserRoleEditPanel({id, onClose, onSave}: UserRoleEditPanelProps)
 
         <Drawer.Body>
           <Form.Group controlId="name">
-            <Form.ControlLabel>{t('userRoles.panels.name') + '*'}</Form.ControlLabel>
+            <Form.ControlLabel>{toggleRequiredLabel(t('userRoles.panels.name'))}</Form.ControlLabel>
             <Form.Control
               name="name"
               value={name}

--- a/packages/editor/src/client/routes/userEditView.tsx
+++ b/packages/editor/src/client/routes/userEditView.tsx
@@ -36,6 +36,7 @@ import {EditUserPassword} from '../atoms/user/editUserPassword'
 import {RouteActionType} from '@wepublish/karma.run-react'
 import {UserSubscriptionsList} from '../atoms/user/userSubscriptionsList'
 import {ArrowLeftLine} from '@rsuite/icons'
+import {toggleRequiredLabel} from '../toggleRequiredLabel'
 
 export function UserEditView() {
   const {t} = useTranslation()
@@ -369,8 +370,9 @@ export function UserEditView() {
                     <Col xs={12}>
                       <Form.Group controlId="name">
                         <Form.ControlLabel>
-                          {t('userCreateOrEditView.name') + '*'}
+                          {toggleRequiredLabel(t('userCreateOrEditView.name'))}
                         </Form.ControlLabel>
+
                         <Form.Control
                           name="name"
                           value={name || ''}
@@ -399,8 +401,9 @@ export function UserEditView() {
                     <Col xs={12}>
                       <Form.Group controlId="email">
                         <Form.ControlLabel>
-                          {t('userCreateOrEditView.email') + '*'}
+                          {toggleRequiredLabel(t('userCreateOrEditView.email'))}
                         </Form.ControlLabel>
+
                         <Form.Control
                           name="email"
                           value={email}

--- a/packages/editor/src/client/toggleRequiredLabel.ts
+++ b/packages/editor/src/client/toggleRequiredLabel.ts
@@ -1,0 +1,3 @@
+export const toggleRequiredLabel = (label: string, required = true) => {
+  return label + (required ? '*' : '')
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -414,6 +414,15 @@
     "@jridgewell/gen-mapping" "^0.3.2"
     jsesc "^2.5.1"
 
+"@babel/generator@^7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.18.9.tgz#68337e9ea8044d6ddc690fb29acae39359cca0a5"
+  integrity sha512-wt5Naw6lJrL1/SGkipMiFxJjtyczUWTP38deiP1PO60HsBjDeKk08CGC3S8iVuvf0FmTdgKwU1KIXzSKL1G0Ug==
+  dependencies:
+    "@babel/types" "^7.18.9"
+    "@jridgewell/gen-mapping" "^0.3.2"
+    jsesc "^2.5.1"
+
 "@babel/generator@^7.9.0", "@babel/generator@^7.9.5":
   version "7.9.5"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.9.5.tgz#27f0917741acc41e6eaaced6d68f96c3fa9afaf9"
@@ -568,6 +577,19 @@
     "@babel/helper-replace-supers" "^7.15.4"
     "@babel/helper-split-export-declaration" "^7.15.4"
 
+"@babel/helper-create-class-features-plugin@^7.18.0":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.18.9.tgz#d802ee16a64a9e824fcbf0a2ffc92f19d58550ce"
+  integrity sha512-WvypNAYaVh23QcjpMR24CwZY2Nz6hqdOcFdPbNpV56hL5H6KiFheO7Xm1aPdlLQ7d5emYZX7VZwPp9x3z+2opw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.18.6"
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-function-name" "^7.18.9"
+    "@babel/helper-member-expression-to-functions" "^7.18.9"
+    "@babel/helper-optimise-call-expression" "^7.18.6"
+    "@babel/helper-replace-supers" "^7.18.9"
+    "@babel/helper-split-export-declaration" "^7.18.6"
+
 "@babel/helper-create-class-features-plugin@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.18.6.tgz#6f15f8459f3b523b39e00a99982e2c040871ed72"
@@ -581,7 +603,7 @@
     "@babel/helper-replace-supers" "^7.18.6"
     "@babel/helper-split-export-declaration" "^7.18.6"
 
-"@babel/helper-create-class-features-plugin@^7.5.5", "@babel/helper-create-class-features-plugin@^7.8.3":
+"@babel/helper-create-class-features-plugin@^7.5.5":
   version "7.9.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.9.5.tgz#79753d44017806b481017f24b02fd4113c7106ea"
   integrity sha512-IipaxGaQmW4TfWoXdqjY0TzoXQ1HRS0kPpEgvjosb3u7Uedcq297xFqDQiCcQtRRwzIMif+N1MLVI8C5a4/PAA==
@@ -665,6 +687,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.6.tgz#b7eee2b5b9d70602e59d1a6cad7dd24de7ca6cd7"
   integrity sha512-8n6gSfn2baOY+qlp+VSzsosjCVGFqWKmDF0cCWOybh52Dw3SEyoWR1KrhMJASjLwIEkkAufZ0xvr+SxLHSpy2Q==
 
+"@babel/helper-environment-visitor@^7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz#0c0cee9b35d2ca190478756865bb3528422f51be"
+  integrity sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==
+
 "@babel/helper-explode-assignable-expression@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.14.5.tgz#8aa72e708205c7bb643e45c73b4386cdf2a1f645"
@@ -729,6 +756,14 @@
   dependencies:
     "@babel/template" "^7.18.6"
     "@babel/types" "^7.18.6"
+
+"@babel/helper-function-name@^7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz#940e6084a55dee867d33b4e487da2676365e86b0"
+  integrity sha512-fJgWlZt7nxGksJS9a0XdSaI4XvpExnNIgRP+rVefWh5U7BL8pPuir6SJUmFKRfjWQ51OtWSzwOxhaH/EBWWc0A==
+  dependencies:
+    "@babel/template" "^7.18.6"
+    "@babel/types" "^7.18.9"
 
 "@babel/helper-function-name@^7.8.3", "@babel/helper-function-name@^7.9.5":
   version "7.9.5"
@@ -829,6 +864,13 @@
   integrity sha512-CeHxqwwipekotzPDUuJOfIMtcIHBuc7WAzLmTYWctVigqS5RktNMQ5bEwQSuGewzYnCtTWa3BARXeiLxDTv+Ng==
   dependencies:
     "@babel/types" "^7.18.6"
+
+"@babel/helper-member-expression-to-functions@^7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.18.9.tgz#1531661e8375af843ad37ac692c132841e2fd815"
+  integrity sha512-RxifAh2ZoVU67PyKIO4AMi1wTenGfMR/O/ae0CCRqwgBAt5v7xjdtRw7UoSbsreKrQn5t7r89eruK/9JjYHuDg==
+  dependencies:
+    "@babel/types" "^7.18.9"
 
 "@babel/helper-member-expression-to-functions@^7.8.3":
   version "7.8.3"
@@ -1107,6 +1149,17 @@
     "@babel/helper-optimise-call-expression" "^7.18.6"
     "@babel/traverse" "^7.18.6"
     "@babel/types" "^7.18.6"
+
+"@babel/helper-replace-supers@^7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.18.9.tgz#1092e002feca980fbbb0bd4d51b74a65c6a500e6"
+  integrity sha512-dNsWibVI4lNT6HiuOIBr1oyxo40HvIVmbwPUm3XZ7wMh4k2WxrxTqZwSqw/eEmXDS9np0ey5M2bz9tBmO9c+YQ==
+  dependencies:
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-member-expression-to-functions" "^7.18.9"
+    "@babel/helper-optimise-call-expression" "^7.18.6"
+    "@babel/traverse" "^7.18.9"
+    "@babel/types" "^7.18.9"
 
 "@babel/helper-replace-supers@^7.8.3", "@babel/helper-replace-supers@^7.8.6":
   version "7.8.6"
@@ -1439,6 +1492,11 @@
   version "7.18.8"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.8.tgz#822146080ac9c62dac0823bb3489622e0bc1cbdf"
   integrity sha512-RSKRfYX20dyH+elbJK2uqAkVyucL+xXzhqlMD5/ZXx+dAAwpyB7HsvnHe/ZUGOF+xLr5Wx9/JoXVTj6BQE2/oA==
+
+"@babel/parser@^7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.9.tgz#f2dde0c682ccc264a9a8595efd030a5cc8fd2539"
+  integrity sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg==
 
 "@babel/parser@^7.6.0", "@babel/parser@^7.9.6":
   version "7.14.8"
@@ -3416,6 +3474,22 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
+"@babel/traverse@^7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.18.9.tgz#deeff3e8f1bad9786874cb2feda7a2d77a904f98"
+  integrity sha512-LcPAnujXGwBgv3/WHv01pHtb2tihcyW1XuL9wd7jqh1Z8AQkTd+QVjMrMijrln0T7ED3UXLIy36P9Ao7W75rYg==
+  dependencies:
+    "@babel/code-frame" "^7.18.6"
+    "@babel/generator" "^7.18.9"
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-function-name" "^7.18.9"
+    "@babel/helper-hoist-variables" "^7.18.6"
+    "@babel/helper-split-export-declaration" "^7.18.6"
+    "@babel/parser" "^7.18.9"
+    "@babel/types" "^7.18.9"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
 "@babel/traverse@^7.8.3", "@babel/traverse@^7.8.6", "@babel/traverse@^7.9.0":
   version "7.9.5"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.9.5.tgz#6e7c56b44e2ac7011a948c21e283ddd9d9db97a2"
@@ -3494,6 +3568,14 @@
   version "7.18.8"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.18.8.tgz#c5af199951bf41ba4a6a9a6d0d8ad722b30cd42f"
   integrity sha512-qwpdsmraq0aJ3osLJRApsc2ouSJCdnMeZwB0DhbtHAtRpZNZCdlbRnHIgcRKzdE1g0iOGg644fzjOBcdOz9cPw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.18.6"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.18.9.tgz#7148d64ba133d8d73a41b3172ac4b83a1452205f"
+  integrity sha512-WwMLAg2MvJmt/rKEVQBBhIVffMmnilX4oe0sRe7iPOHIGsqpruFHHdrfj4O1CMMtgMtCU4oPafZjDPCRgO57Wg==
   dependencies:
     "@babel/helper-validator-identifier" "^7.18.6"
     to-fast-properties "^2.0.0"


### PR DESCRIPTION
Created a new function called toggleRequiredLabel to add the required symbol to labels.
This allows to have an easy way to toggle if it's required or not (adding/editing) and gives us a central way to change the icon if ever desired
