### PR TITLE
Release 5.0.0 (prisma)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## 5.0.1 (2022-09-14)
+
+#### :bug: Bug Fix
+* `api`
+  * [#672](https://github.com/wepublish/wepublish/pull/672) fix(api): navigation link missing relations ([@Itrulia](https://github.com/Itrulia))
+  * [#661](https://github.com/wepublish/wepublish/pull/661) fix(api): userlist filter missing address filter due to merge conflict ([@Itrulia](https://github.com/Itrulia))
+
+#### Committers: 1
+
+
 ## 5.0.0 (2022-09-01)
 
 #### :boom: Breaking Change

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.1.1",
+  "version": "5.0.0-alpha.0",
   "changelog": {
     "repo": "wepublish/wepublish",
     "cacheDir": ".changelog",
@@ -19,9 +19,17 @@
       "allowBranch": "master"
     },
     "publish": {
-      "ignoreChanges": ["*.md", "*.txt"],
+      "ignoreChanges": [
+        "*.md",
+        "*.txt"
+      ],
       "message": "chore(release): publish %s"
     }
   },
-  "packages": ["packages/api", "packages/api-media-karma", "packages/editor", "packages/oauth2"]
+  "packages": [
+    "packages/api",
+    "packages/api-media-karma",
+    "packages/editor",
+    "packages/oauth2"
+  ]
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.0.0",
+  "version": "5.0.1",
   "changelog": {
     "repo": "wepublish/wepublish",
     "cacheDir": ".changelog",

--- a/packages/api-media-karma/package.json
+++ b/packages/api-media-karma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wepublish/api-media-karma",
-  "version": "4.1.1",
+  "version": "5.0.0-alpha.0",
   "description": "We.publish media service",
   "keywords": [
     "images",

--- a/packages/api-media-karma/package.json
+++ b/packages/api-media-karma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wepublish/api-media-karma",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "We.publish media service",
   "keywords": [
     "images",

--- a/packages/api/__tests__/specs/__snapshots__/navigation.ts.snap
+++ b/packages/api/__tests__/specs/__snapshots__/navigation.ts.snap
@@ -61,21 +61,18 @@ Object {
     "updateNavigation": Object {
       "id": Any<String>,
       "key": Any<String>,
-      "links": Array [
-        Object {
-          "__typename": "ExternalNavigationLink",
+      "links": ArrayContaining [
+        ObjectContaining {
           "label": "New External Label",
           "url": "newlinkurl.ch/",
         },
-        Object {
-          "__typename": "ArticleNavigationLink",
-          "article": null,
-          "label": "New Article Label",
-        },
-        Object {
-          "__typename": "PageNavigationLink",
+        ObjectContaining {
           "label": "New Page Label",
-          "page": null,
+          "page": Any<Object>,
+        },
+        ObjectContaining {
+          "article": Any<Object>,
+          "label": "New Article Label",
         },
       ],
       "name": "Updated Navigation Name",

--- a/packages/api/__tests__/specs/navigation.ts
+++ b/packages/api/__tests__/specs/navigation.ts
@@ -173,6 +173,45 @@ describe('Navigations', () => {
 
     test('can be updated', async () => {
       const {mutate} = testClientPrivate
+
+      const articleInput: ArticleInput = {
+        title: '',
+        slug: generateRandomString(),
+        shared: false,
+        tags: [],
+        breaking: true,
+        lead: '',
+        preTitle: '',
+        hideAuthor: false,
+        properties: [],
+        authorIDs: [],
+        socialMediaTitle: '',
+        socialMediaAuthorIDs: [],
+        socialMediaDescription: '',
+        socialMediaImageID: '',
+        blocks: []
+      }
+      const articleRes = await mutate({
+        mutation: CreateArticle,
+        variables: {
+          input: articleInput
+        }
+      })
+
+      const pageInput: PageInput = {
+        title: '',
+        slug: generateRandomString(),
+        tags: [],
+        properties: [],
+        blocks: []
+      }
+      const pageRes = await mutate({
+        mutation: CreatePage,
+        variables: {
+          input: pageInput
+        }
+      })
+
       const res = await mutate({
         mutation: UpdateNavigation,
         variables: {
@@ -181,8 +220,8 @@ describe('Navigations', () => {
             key: generateRandomString(),
             links: [
               {external: {label: 'New External Label', url: 'newlinkurl.ch/'}},
-              {article: {label: 'New Article Label', articleID: 'newID'}},
-              {page: {label: 'New Page Label', pageID: 'newID'}}
+              {article: {label: 'New Article Label', articleID: articleRes.data.createArticle.id}},
+              {page: {label: 'New Page Label', pageID: pageRes.data.createPage.id}}
             ]
           },
           id: ids[0]
@@ -193,7 +232,21 @@ describe('Navigations', () => {
         data: {
           updateNavigation: {
             id: expect.any(String),
-            key: expect.any(String)
+            key: expect.any(String),
+            links: expect.arrayContaining([
+              expect.objectContaining({
+                label: 'New External Label',
+                url: 'newlinkurl.ch/'
+              }),
+              expect.objectContaining({
+                label: 'New Page Label',
+                page: expect.any(Object)
+              }),
+              expect.objectContaining({
+                label: 'New Article Label',
+                article: expect.any(Object)
+              })
+            ])
           }
         }
       })

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wepublish/api",
-  "version": "4.1.1",
+  "version": "5.0.0-alpha.0",
   "description": "API core for we.publish.",
   "keywords": [
     "api",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wepublish/api",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "API core for we.publish.",
   "keywords": [
     "api",

--- a/packages/api/prisma/migrations/20220823071824_add_relations_navigationlink/migration.sql
+++ b/packages/api/prisma/migrations/20220823071824_add_relations_navigationlink/migration.sql
@@ -1,0 +1,5 @@
+-- AddForeignKey
+ALTER TABLE "navigations.links" ADD CONSTRAINT "navigations.links_articleID_fkey" FOREIGN KEY ("articleID") REFERENCES "articles"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "navigations.links" ADD CONSTRAINT "navigations.links_pageID_fkey" FOREIGN KEY ("pageID") REFERENCES "pages"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -89,6 +89,8 @@ model Article {
 
   shared Boolean
 
+  navigations NavigationLink[]
+
   @@index([createdAt])
   @@index([modifiedAt])
   @@map("articles")
@@ -339,13 +341,17 @@ model NavigationLink {
   createdAt  DateTime @default(now())
   modifiedAt DateTime @updatedAt
 
-  label     String
-  type      String
-  url       String?
-  pageID    String?
+  label String
+  type  String
+  url   String?
+
+  page   Page?   @relation(fields: [pageID], references: [id], onDelete: Cascade)
+  pageID String?
+
+  article   Article? @relation(fields: [articleID], references: [id], onDelete: Cascade)
   articleID String?
 
-  Navigation   Navigation? @relation(fields: [navigationId], references: [id], onDelete: Cascade)
+  navigation   Navigation? @relation(fields: [navigationId], references: [id], onDelete: Cascade)
   navigationId String?
 
   @@map("navigations.links")
@@ -408,6 +414,8 @@ model Page {
 
   draftId String?       @unique
   draft   PageRevision? @relation("draftPageRevision", fields: [draftId], references: [id], onDelete: SetNull)
+
+  navigations NavigationLink[]
 
   @@index([createdAt])
   @@index([modifiedAt])

--- a/packages/api/src/graphql/user/user.queries.ts
+++ b/packages/api/src/graphql/user/user.queries.ts
@@ -72,6 +72,30 @@ const createTextFilter = (filter: Partial<UserFilter>): Prisma.UserWhereInput =>
             contains: filter.text,
             mode: 'insensitive'
           }
+        },
+        {
+          address: {
+            OR: [
+              {
+                streetAddress: {
+                  contains: filter.text,
+                  mode: 'insensitive'
+                }
+              },
+              {
+                zipCode: {
+                  contains: filter.text,
+                  mode: 'insensitive'
+                }
+              },
+              {
+                city: {
+                  contains: filter.text,
+                  mode: 'insensitive'
+                }
+              }
+            ]
+          }
         }
       ]
     }

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wepublish/editor",
-  "version": "4.1.1",
+  "version": "5.0.0-alpha.0",
   "description": "We.publish CMS Editor",
   "keywords": [
     "editor",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wepublish/editor",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "We.publish CMS Editor",
   "keywords": [
     "editor",

--- a/packages/oauth2/package.json
+++ b/packages/oauth2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wepublish/oauth2",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "OAuth2 Provider for we.publish",
   "publishConfig": {
     "access": "public"

--- a/packages/oauth2/package.json
+++ b/packages/oauth2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wepublish/oauth2",
-  "version": "4.1.1",
+  "version": "5.0.0-alpha.0",
   "description": "OAuth2 Provider for we.publish",
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7110,6 +7110,44 @@
     "@jonkoops/matomo-tracker" "^0.7.0"
     typescript "^4.7.4"
 
+"@wepublish/api-media-karma@*":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@wepublish/api-media-karma/-/api-media-karma-4.1.1.tgz#d6bca6deaf429255ec7bb64e852753795766f8e5"
+  integrity sha512-YfHBC9pFC+UVK7mR/vkrFXpRdOBnnWWQxDBWi7Eq2bqv7uFayL+DY1CXPVSec0dDVoIjyq98RPhU6pOsatnDRw==
+  dependencies:
+    form-data "^3.0.0"
+    node-fetch "^2.6.0"
+
+"@wepublish/api@*":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@wepublish/api/-/api-4.1.1.tgz#efbd6fb2665804391c32c645564d230de81185bf"
+  integrity sha512-fadibGfIvgjJseWnlpPRpi1DDYO6E1z7gXGp0BFLdo4a6e0d1hjebePTXXfNQE/vfl1FsemoFw32EvI3lCJ7+w==
+  dependencies:
+    "@karma.run/utility" "^0.1.0"
+    abort-controller "^3.0.0"
+    algebraic-captcha "^1.0.1"
+    apollo-server-express "2.25.3"
+    body-parser "^1.19.0"
+    dataloader "^2.0.0"
+    date-fns "^2.28.0"
+    email-templates "^8.0.7"
+    express "^4.17.1"
+    form-data "^3.0.0"
+    graphql "^14.6.0"
+    graphql-iso-date "^3.6.1"
+    graphql-tag "^2.11.0"
+    graphql-tools "^5.0.0"
+    jsonwebtoken "^8.5.1"
+    mandrill-api "^1.0.45"
+    node-cache "^5.1.2"
+    node-fetch "^2.6.0"
+    openid-client "^3.14.0"
+    pino "^6.11.0"
+    pino-http "^5.3.0"
+    pug "^3.0.2"
+    qs "^6.9.1"
+    stripe "^8.126.0"
+
 "@wepublish/karma.run-react@^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@wepublish/karma.run-react/-/karma.run-react-0.2.0.tgz#159f364e3a91cce08ec61a03b773cb03f29eb2e3"
@@ -7120,6 +7158,15 @@
     fela "^10.6.1"
     fela-dom "^10.6.1"
     path-to-regexp "^3.0.0"
+
+"@wepublish/oauth2@*":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@wepublish/oauth2/-/oauth2-4.1.1.tgz#00f3697ab594ae3fd88e103d6035eae31d043ee7"
+  integrity sha512-hnzmSdaYmPi1+2x4DoCFC6IaUaaBrsqy7RBNRmBA1KIYDMVRpP6wkcEoJhpIo+xMrlyOQzVdFAsPln4kxkTVAQ==
+  dependencies:
+    express "^4.17.1"
+    lodash "^4.17.19"
+    oidc-provider "^6.23.4"
 
 "@wry/context@^0.6.0":
   version "0.6.0"


### PR DESCRIPTION
## 5.0.0-alpha.0 (2022-08-16)

#### :boom: Breaking Change
* `api-db-mongodb`, `api-media-karma`, `api`, `editor`, `oauth2`
  * [#640](https://github.com/wepublish/wepublish/pull/640) Prisma & Postgresql instead of MongoDB ([@Itrulia](https://github.com/Itrulia))

#### :heart: New Feature
* `api-db-mongodb`, `api-media-karma`, `api`, `editor`, `oauth2`
  * [#640](https://github.com/wepublish/wepublish/pull/640) Prisma & Postgresql instead of MongoDB ([@Itrulia](https://github.com/Itrulia))

#### :house: Internal
* [#658](https://github.com/wepublish/wepublish/pull/658) Npm publish only on tags push ([@tomaszdurka](https://github.com/tomaszdurka))

#### Committers: 2
- Itrulia ([@Itrulia](https://github.com/Itrulia))
- Tomasz Durka ([@tomaszdurka](https://github.com/tomaszdurka))

---

## BREAKING CHANGES LIST
BREAKING CHANGE: ArticleList pagination rewritten, now takes a cursor & take argument instead of first/last & before/after. Cursor is not base64 encoded anymore and skip argument is now the amount of items not pages.

BREAKING CHANGE: AuthorList pagination rewritten. Now takes a cursor & take argument instead of first/last & before/after. Cursor is not base64 encoded anymore and skip argument is now the amount of items not pages.

BREAKING CHANGE: CommentList pagination rewritten. Now takes a cursor & take argument instead of first/last & before/after. Cursor is not base64 encoded anymore and skip argument is now the amount of items not pages. CommentList is also not sorted by state anymore.

BREAKING CHANGE: ImageList pagination rewritten. Now takes a cursor & take argument instead of first/last & before/after. Cursor is not base64 encoded anymore and skip argument is now the amount of items not pages.

BREAKING CHANGE: InvoiceList pagination rewritten. Now takes a cursor & take argument instead of first/last & before/after. Cursor is not base64 encoded anymore and skip argument is now the amount of items not pages.

BREAKING CHANGE: UserList pagination rewritten. Now takes a cursor & take argument instead of first/last & before/after. Cursor is not base64 encoded anymore and skip argument is now the amount of items not pages.

BREAKING CHANGE: UserRoleList pagination rewritten. Now takes a cursor & take argument instead of first/last & before/after. Cursor is not base64 encoded anymore and skip argument is now the amount of items not pages.

BREAKING CHANGE: PageList pagination rewritten. Now takes a cursor & take argument instead of first/last & before/after. Cursor is not base64 encoded anymore and skip argument is now the amount of items not pages.

BREAKING CHANGE: SubscriptionList pagination rewritten. Now takes a cursor & take argument instead of first/last & before/after. Cursor is not base64 encoded anymore and skip argument is now the amount of items not pages.

BREAKING CHANGE: SubscriptionList removed filter for startsAt, paidUntil and deactivationDate

BREAKING CHANGE: SubscriptionDeactivationReason is not an enum of integer anymore but is now an enum of string with the values none (used to be 0), userSelfDeactivated (used to be 1) and invoiceNotPaid (used to be 2)

BREAKING CHANGE: PaymentList pagination rewritten. Now takes a cursor & take argument instead of first/last & before/after. Cursor is not base64 encoded anymore and skip argument is now the amount of items not pages.

BREAKING CHANGE: MemberPlanList pagination rewritten. Now takes a cursor & take argument instead of first/last & before/after. Cursor is not base64 encoded anymore and skip argument is now the amount of items not pages.

BREAKING CHANGE: sessionTTL is now an option on the WepublishServer
BREAKING CHANGE: hashCostFactor is now an option on the WepublishServer

BREAKING CHANGE: Removed articleModelEvents, use Prisma Middleware instead
BREAKING CHANGE: Removed pageModelEvents, use Prisma Middleware instead
BREAKING CHANGE: Removed subscriptionModelEvents, use Prisma Middleware instead
BREAKING CHANGE: Removed userModelEvents, use Prisma Middleware instead
BREAKING CHANGE: Removed peerModelEvents, use Prisma Middleware instead
BREAKING CHANGE: Removed imageModelEvents, use Prisma Middleware instead
BREAKING CHANGE: Removed paymentModelEvents, use Prisma Middleware instead
BREAKING CHANGE: Removed paymentMethodModelEvents, use Prisma Middleware instead
BREAKING CHANGE: Removed memberPlanModelEvents, use Prisma Middleware instead
BREAKING CHANGE: Removed authorModelEvents, use Prisma Middleware instead
BREAKING CHANGE: Removed mailLogModelEvents, use Prisma Middleware instead
BREAKING CHANGE: Removed invoiceModelEvents, use Prisma Middleware instead
BREAKING CHANGE: Removed navigationModelEvents, use Prisma Middleware instead
BREAKING CHANGE: Removed userRoleModelEvents, use Prisma Middleware instead

BREAKING CHANGE: @wepublish/api is now using Postgres instead of MongoDB. Schema changes has been done accordingly.

