### PR TITLE
feat(api): allow admins to create and edit comments

### DIFF
--- a/packages/api/__tests__/specs/__snapshots__/userRole.ts.snap
+++ b/packages/api/__tests__/specs/__snapshots__/userRole.ts.snap
@@ -250,6 +250,11 @@ Object {
         },
         Object {
           "deprecated": false,
+          "description": "Allows to update a comment",
+          "id": "CAN_UPDATE_COMMENTS",
+        },
+        Object {
+          "deprecated": false,
           "description": "Allows to create a member plan",
           "id": "CAN_CREATE_MEMBER_PLAN",
         },
@@ -669,6 +674,11 @@ Object {
           "deprecated": false,
           "description": "Allows to get all comments",
           "id": "CAN_GET_COMMENTS",
+        },
+        Object {
+          "deprecated": false,
+          "description": "Allows to update a comment",
+          "id": "CAN_UPDATE_COMMENTS",
         },
         Object {
           "deprecated": false,
@@ -1104,6 +1114,11 @@ Object {
         "deprecated": false,
         "description": "Allows to get all comments",
         "id": "CAN_GET_COMMENTS",
+      },
+      Object {
+        "deprecated": false,
+        "description": "Allows to update a comment",
+        "id": "CAN_UPDATE_COMMENTS",
       },
       Object {
         "deprecated": false,

--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -208,7 +208,6 @@ model Comment {
   createdAt  DateTime @default(now())
   modifiedAt DateTime @updatedAt
 
-  userID          String?
   itemID          String
   itemType        CommentItemType
   parentID        String?
@@ -218,7 +217,9 @@ model Comment {
   authorType      CommentAuthorType
   guestUsername   String?
 
-  user User?            @relation(fields: [userID], references: [id])
+  user   User?   @relation(fields: [userID], references: [id])
+  userID String?
+
   tags TaggedComments[]
 
   @@index([createdAt])

--- a/packages/api/src/graphql/comment/comment.private-mutation.ts
+++ b/packages/api/src/graphql/comment/comment.private-mutation.ts
@@ -1,6 +1,12 @@
-import {Prisma, PrismaClient} from '@prisma/client'
+import {
+  Prisma,
+  PrismaClient,
+  CommentItemType,
+  CommentState,
+  CommentAuthorType
+} from '@prisma/client'
 import {Context} from '../../context'
-import {authorise, CanTakeActionOnComment} from '../permissions'
+import {authorise, CanTakeActionOnComment, CanUpdateComments} from '../permissions'
 
 export const takeActionOnComment = (
   id: string,
@@ -14,6 +20,88 @@ export const takeActionOnComment = (
   return comment.update({
     where: {id},
     data: input,
+    include: {
+      revisions: true
+    }
+  })
+}
+
+export const updateComment = async (
+  commentId: string,
+  text: string | undefined,
+  tagIds: string[] | undefined,
+  authenticate: Context['authenticate'],
+  commentClient: PrismaClient['comment']
+) => {
+  const {roles} = authenticate()
+  authorise(CanUpdateComments, roles)
+
+  return commentClient.update({
+    where: {id: commentId},
+    data: {
+      revisions: text
+        ? {
+            create: {
+              text
+            }
+          }
+        : undefined,
+      tags: tagIds
+        ? {
+            connectOrCreate: tagIds.map(tagId => ({
+              where: {
+                commentId_tagId: {
+                  commentId,
+                  tagId
+                }
+              },
+              create: {
+                tagId
+              }
+            })),
+            deleteMany: {
+              commentId,
+              tagId: {
+                notIn: tagIds
+              }
+            }
+          }
+        : undefined
+    },
+    include: {
+      revisions: true
+    }
+  })
+}
+
+export const createAdminComment = async (
+  itemId: string,
+  itemType: CommentItemType,
+  text: string,
+  tagIds: string[] | undefined,
+  authenticate: Context['authenticate'],
+  commentClient: PrismaClient['comment']
+) => {
+  const {roles} = authenticate()
+  authorise(CanUpdateComments, roles)
+
+  return commentClient.create({
+    data: {
+      state: CommentState.approved,
+      authorType: CommentAuthorType.team,
+      itemID: itemId,
+      itemType,
+      revisions: {
+        create: {
+          text
+        }
+      },
+      tags: {
+        create: tagIds?.map(tagId => ({
+          tagId
+        }))
+      }
+    },
     include: {
       revisions: true
     }

--- a/packages/api/src/graphql/comment/comment.ts
+++ b/packages/api/src/graphql/comment/comment.ts
@@ -23,6 +23,7 @@ import {getPublicChildrenCommentsByParentId} from './comment.public-queries'
 import {GraphQLPageInfo} from '../common'
 import {GraphQLRichText} from '../richText'
 import {GraphQLPublicUser, GraphQLUser} from '../user'
+import {GraphQLTag} from '../tag/tag'
 
 export const GraphQLCommentState = new GraphQLEnumType({
   name: 'CommentState',
@@ -149,6 +150,21 @@ export const GraphQLComment: GraphQLObjectType<Comment, Context> = new GraphQLOb
             })
           : null
       )
+    },
+    tags: {
+      type: GraphQLList(GraphQLTag),
+      resolve: createProxyingResolver(async ({id}, _, {prisma: {taggedComments}}) => {
+        const tags = await taggedComments.findMany({
+          where: {
+            commentId: id
+          },
+          include: {
+            tag: true
+          }
+        })
+
+        return tags.map(({tag}) => tag)
+      })
     },
     authorType: {type: GraphQLNonNull(GraphQLCommentAuthorType)},
     itemID: {type: GraphQLNonNull(GraphQLID)},

--- a/packages/api/src/graphql/comment/comment.ts
+++ b/packages/api/src/graphql/comment/comment.ts
@@ -152,7 +152,7 @@ export const GraphQLComment: GraphQLObjectType<Comment, Context> = new GraphQLOb
       )
     },
     tags: {
-      type: GraphQLList(GraphQLTag),
+      type: GraphQLList(GraphQLNonNull(GraphQLTag)),
       resolve: createProxyingResolver(async ({id}, _, {prisma: {taggedComments}}) => {
         const tags = await taggedComments.findMany({
           where: {

--- a/packages/api/src/graphql/mutation.private.ts
+++ b/packages/api/src/graphql/mutation.private.ts
@@ -27,8 +27,16 @@ import {
 import {GraphQLAuthor, GraphQLAuthorInput} from './author'
 import {createAuthor, deleteAuthorById, updateAuthor} from './author/author.private-mutation'
 import {GraphQLBlockInput, GraphQLTeaserInput} from './blocks'
-import {GraphQLComment, GraphQLCommentRejectionReason} from './comment/comment'
-import {takeActionOnComment} from './comment/comment.private-mutation'
+import {
+  GraphQLComment,
+  GraphQLCommentItemType,
+  GraphQLCommentRejectionReason
+} from './comment/comment'
+import {
+  createAdminComment,
+  takeActionOnComment,
+  updateComment
+} from './comment/comment.private-mutation'
 import {GraphQLImage, GraphQLUpdateImageInput, GraphQLUploadImageInput} from './image'
 import {createImage, deleteImageById, updateImage} from './image/image.private-mutation'
 import {GraphQLInvoice, GraphQLInvoiceInput} from './invoice'
@@ -72,6 +80,7 @@ import {
 import {upsertPeerProfile} from './peer-profile/peer-profile.private-mutation'
 import {createPeer, deletePeerById, updatePeer} from './peer/peer.private-mutation'
 import {authorise, CanSendJWTLogin} from './permissions'
+import {GraphQLRichText} from './richText'
 import {GraphQLSession, GraphQLSessionWithToken} from './session'
 import {
   createJWTSession,
@@ -824,6 +833,31 @@ export const GraphQLAdminMutation = new GraphQLObjectType<undefined, Context>({
       },
       resolve: (root, {id}, {authenticate, prisma: {invoice}}) =>
         deleteInvoiceById(id, authenticate, invoice)
+    },
+
+    updateComment: {
+      type: GraphQLNonNull(GraphQLComment),
+      args: {
+        id: {type: GraphQLNonNull(GraphQLID)},
+        text: {type: GraphQLRichText},
+        tagIds: {type: GraphQLList(GraphQLNonNull(GraphQLID))}
+      },
+      resolve: (root, {id, text, tagIds}, {authenticate, prisma: {comment}}) =>
+        updateComment(id, text, tagIds, authenticate, comment)
+    },
+
+    createComment: {
+      type: GraphQLNonNull(GraphQLComment),
+      args: {
+        text: {type: GraphQLRichText},
+        tagIds: {type: GraphQLList(GraphQLNonNull(GraphQLID))},
+        itemID: {type: GraphQLNonNull(GraphQLID)},
+        itemType: {
+          type: GraphQLNonNull(GraphQLCommentItemType)
+        }
+      },
+      resolve: (root, {text, tagIds, itemID, itemType}, {authenticate, prisma: {comment}}) =>
+        createAdminComment(itemID, itemType, text, tagIds, authenticate, comment)
     },
 
     approveComment: {

--- a/packages/api/src/graphql/permissions.ts
+++ b/packages/api/src/graphql/permissions.ts
@@ -177,6 +177,12 @@ export const CanGetComments: Permission = {
   deprecated: false
 }
 
+export const CanUpdateComments: Permission = {
+  id: 'CAN_UPDATE_COMMENTS',
+  description: 'Allows to update a comment',
+  deprecated: false
+}
+
 export const CanCreatePage: Permission = {
   id: 'CAN_CREATE_PAGE',
   description: 'Allows to create Pages',
@@ -556,6 +562,7 @@ export const AllPermissions: Permission[] = [
   CanGetPermission,
   CanGetPermissions,
   CanGetComments,
+  CanUpdateComments,
   CanCreateMemberPlan,
   CanGetMemberPlan,
   CanGetMemberPlans,
@@ -589,6 +596,7 @@ export const AllPermissions: Permission[] = [
 
 export const EditorPermissions: Permission[] = [
   CanGetComments,
+  CanUpdateComments,
   CanTakeActionOnComment,
   CanCreateAuthor,
   CanGetAuthor,


### PR DESCRIPTION
```graphql
mutation createComment(
	$itemID: ID!
	$itemType: CommentItemType!
	$text: RichText!
	$tagIds: [ID!]
) {
	createComment(
		itemID: $itemID
		itemType: $itemType
		text: $text
		tagIds: $tagIds
	) {
		id
		revisions {
			text
		}
		tags {
			id
			tag
		}
	}
}

// vars
{
  "itemID": "cl7673h4u1158mspx2rpytjvk",
  "itemType": "Article",
  "tagIds": ["cl7672l4e0839mspxi0bfzhpc"],
  "text": [
    {
      "type": "paragraph",
      "children": [
        {
          "text": "Haha"
        }
      ]
    }
  ]
}
```

```graphql
mutation updateComment($id: ID!, $text: RichText, $tagIds: [ID!]) {
	updateComment(id: $id, text: $text, tagIds: $tagIds) {
		id
		revisions {
			text
		}
		tags {
			id
			tag
		}
	}
}

// vars
{
  "id":"cl7679xnq02287fpxggyvj0n4",
  "tagIds": ["cl767aneo05387fpx76u8lcwy", "cl7672l4e0839mspxi0bfzhpc"],
  "text": [
    {
      "type": "paragraph",
      "children": [
        {
          "text": "Haha2"
        }
      ]
    }
  ]
}
```
