### PR TITLE
ci: use init containers to fix permissions of postgres volume

### DIFF
--- a/config/create-gke-manifest.js
+++ b/config/create-gke-manifest.js
@@ -1449,7 +1449,7 @@ async function applyPostgres() {
             {
               name: 'postgres-data-permission-fix',
               image: 'busybox',
-              command: ['/bin/chmod', '-R', '777', '/bitnami/postgresql'],
+              command: ['/bin/chmod', '-R', '755', '/bitnami/postgresql'],
               volumeMounts: [
                 {
                   name: 'postgres-volume',

--- a/config/create-gke-manifest.js
+++ b/config/create-gke-manifest.js
@@ -1445,6 +1445,19 @@ async function applyPostgres() {
               ]
             }
           ],
+          initContainers: [
+            {
+              name: 'postgres-data-permission-fix',
+              image: 'busybox',
+              command: ['/bin/chmod', '-R', '777', '/bitnami/postgresql'],
+              volumeMounts: [
+                {
+                  name: 'postgres-volume',
+                  mountPath: '/bitnami/postgresql'
+                }
+              ]
+            }
+          ],
           dnsPolicy: 'ClusterFirst',
           restartPolicy: 'Always',
           schedulerName: 'default-scheduler',


### PR DESCRIPTION
```bash
❯ kubectl logs master-postgres-production-654f7764f8-7f27r --namespace=wepublish
W0913 14:03:44.345641   65445 gcp.go:120] WARNING: the gcp auth plugin is deprecated in v1.22+, unavailable in v1.25+; use gcloud instead.
To learn more, consult https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
postgresql 12:00:53.54
postgresql 12:00:53.56 Welcome to the Bitnami postgresql container
postgresql 12:00:53.56 Subscribe to project updates by watching https://github.com/bitnami/containers
postgresql 12:00:53.57 Submit issues and feature requests at https://github.com/bitnami/containers/issues
postgresql 12:00:53.57
postgresql 12:00:53.74 INFO  ==> ** Starting PostgreSQL setup **
postgresql 12:00:53.78 INFO  ==> Validating settings in POSTGRESQL_* env vars..
postgresql 12:00:53.78 WARN  ==> You set the environment variable ALLOW_EMPTY_PASSWORD=yes. For safety reasons, do not use this flag in a production environment.
postgresql 12:00:53.80 INFO  ==> Loading custom pre-init scripts...
postgresql 12:00:53.83 INFO  ==> Initializing PostgreSQL database...
mkdir: cannot create directory '/bitnami/postgresql/data': Permission denied
```