### PR TITLE
chore: add git hooks to rebuild prisma when switching or merging branches

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,9 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "pretty-quick --staged --pattern \"{examples,packages,services}/**/*.{js,ts,tsx,json}\""
+      "pre-commit": "pretty-quick --staged --pattern \"{examples,packages,services}/**/*.{js,ts,tsx,json}\"",
+      "post-checkout": "prisma generate",
+      "post-merge": "prisma generate"
     }
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -93,8 +93,8 @@
   "husky": {
     "hooks": {
       "pre-commit": "pretty-quick --staged --pattern \"{examples,packages,services}/**/*.{js,ts,tsx,json}\"",
-      "post-checkout": "prisma generate",
-      "post-merge": "prisma generate"
+      "post-checkout": "prisma generate &",
+      "post-merge": "prisma generate &"
     }
   },
   "eslintConfig": {


### PR DESCRIPTION
automatically regenerates the prisma schema in case you switch branch or merge. Different branches or merges can cause a different schema so one has to regenerate it to fix build issues.