### PR TITLE
Revert "chore: add git hooks to rebuild prisma when switching or merging branches"

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,9 +92,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "pretty-quick --staged --pattern \"{examples,packages,services}/**/*.{js,ts,tsx,json}\"",
-      "post-checkout": "prisma generate &",
-      "post-merge": "prisma generate &"
+      "pre-commit": "pretty-quick --staged --pattern \"{examples,packages,services}/**/*.{js,ts,tsx,json}\""
     }
   },
   "eslintConfig": {


### PR DESCRIPTION
@Itrulia that's rather irritating feature tbh. Especially as I switch from branch to branch a lot. What about rather having watch command or regenerate with dev command.