### PR TITLE
fix(editor): gif or other unsupported images by exfir upload broken

### DIFF
--- a/packages/editor/src/client/atoms/imageMetaData.tsx
+++ b/packages/editor/src/client/atoms/imageMetaData.tsx
@@ -30,7 +30,6 @@ function findNestedMetaFields(tags: any, tag: string) {
 }
 
 export async function readImageMetaData(data: File): Promise<ImageMetaData> {
-  const tags = await exifr.parse(data, true)
   const fields: ImageMetaData = {
     title: '',
     description: '',
@@ -38,20 +37,20 @@ export async function readImageMetaData(data: File): Promise<ImageMetaData> {
     link: '',
     licence: ''
   }
-  for (const field in DEFAULT_META_TAG_MAP) {
-    for (const tag of DEFAULT_META_TAG_MAP[field]) {
-      const foundTag = findNestedMetaFields(tags, tag)
-      if (foundTag) {
-        fields[field] = foundTag
-        break
+
+  try {
+    const tags = await exifr.parse(data, true)
+
+    for (const field in DEFAULT_META_TAG_MAP) {
+      for (const tag of DEFAULT_META_TAG_MAP[field]) {
+        const foundTag = findNestedMetaFields(tags, tag)
+        if (foundTag) {
+          fields[field] = foundTag
+          break
+        }
       }
     }
-  }
-  return {
-    title: fields.title,
-    description: fields.description,
-    source: fields.source,
-    link: fields.link,
-    licence: fields.licence
-  }
+  } catch {}
+
+  return fields
 }


### PR DESCRIPTION
ignore metadata of images not supported by exifr

they only support a few file formats: https://github.com/MikeKovarik/exifr/tree/8ba7df23f8f58e7b817ef84e6dbb9c47a53e2315/src/file-parsers
