### PR TITLE
Release 8.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,16 @@
 - [@michael-scheurer](https://github.com/michael-scheurer)
 
 
+## 4.1.2 (2022-11-21)
+
+#### :bug: Bug Fix
+* `api`
+  * [#767](https://github.com/wepublish/wepublish/pull/767) Backport patch: Fix subscription csv download ([@michael-scheurer](https://github.com/michael-scheurer))
+
+#### Committers: 1
+- [@michael-scheurer](https://github.com/michael-scheurer)
+
+
 ## 8.0.0 (2022-11-07)
 
 #### :boom: Breaking Change
@@ -223,6 +233,7 @@
 #### Committers: 2
 - Itrulia ([@Itrulia](https://github.com/Itrulia))
 - Tomasz Durka ([@tomaszdurka](https://github.com/tomaszdurka))
+
 
 ## 4.1.1 (2022-08-16)
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "8.1.0",
+  "version": "8.1.1-alpha.0",
   "changelog": {
     "repo": "wepublish/wepublish",
     "cacheDir": ".changelog",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wepublish/api",
-  "version": "8.1.0",
+  "version": "8.1.1-alpha.0",
   "description": "API core for we.publish.",
   "keywords": [
     "api",

--- a/packages/api/src/utility.ts
+++ b/packages/api/src/utility.ts
@@ -65,20 +65,20 @@ export function mapSubscriptionsAsCsv(
     csvStr +=
       [
         user?.id,
-        `${user?.firstName ?? ''}`,
-        `${user?.name ?? ''}`,
-        `${user?.preferredName ?? ''}`,
+        `${sanitizeCsvContent(user?.firstName)}`,
+        `${sanitizeCsvContent(user?.name)}`,
+        `${sanitizeCsvContent(user?.preferredName)}`,
         `${user?.email ?? ''}`,
         user?.active,
         user?.createdAt ? formatISO(user.createdAt, {representation: 'date'}) : '',
         user?.modifiedAt ? formatISO(user.modifiedAt, {representation: 'date'}) : '',
-        `${user?.address?.company ?? ''}`,
-        `${user?.address?.streetAddress ?? ''}`,
-        `${user?.address?.streetAddress2 ?? ''}`,
-        `${user?.address?.zipCode ?? ''}`,
-        `${user?.address?.city ?? ''}`,
-        `${user?.address?.country ?? ''}`,
-        memberPlan?.name ?? '',
+        `${sanitizeCsvContent(user?.address?.company)}`,
+        `${sanitizeCsvContent(user?.address?.streetAddress)}`,
+        `${sanitizeCsvContent(user?.address?.streetAddress2)}`,
+        `${sanitizeCsvContent(user?.address?.zipCode)}`,
+        `${sanitizeCsvContent(user?.address?.city)}`,
+        `${sanitizeCsvContent(user?.address?.country)}`,
+        sanitizeCsvContent(memberPlan?.name),
         subscription?.memberPlanID ?? '',
         subscription?.paymentPeriodicity ?? '',
         subscription?.monthlyAmount ?? '',
@@ -87,7 +87,7 @@ export function mapSubscriptionsAsCsv(
         subscription?.paidUntil
           ? formatISO(subscription.paidUntil, {representation: 'date'})
           : 'no pay',
-        paymentMethod?.name ?? '',
+        sanitizeCsvContent(paymentMethod?.name),
         subscription?.paymentMethodID ?? '',
         subscription?.deactivation
           ? formatISO(subscription.deactivation.date, {representation: 'date'})
@@ -97,6 +97,18 @@ export function mapSubscriptionsAsCsv(
   }
 
   return csvStr
+}
+
+/**
+ * according to rfc 4180
+ * https://www.ietf.org/rfc/rfc4180.txt
+ * @param input
+ */
+function sanitizeCsvContent(input: string | undefined) {
+  // according rfc 4180 2.7.
+  const escapeDoubleQuotes = (input || '').toString().replace(/[#"]/g, '""')
+  // according rfc 4180 2.5. / 2.6.
+  return `"${escapeDoubleQuotes}"`
 }
 
 // https://gist.github.com/mathewbyrne/1280286#gistcomment-2588056

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wepublish/editor",
-  "version": "8.1.0",
+  "version": "8.1.1-alpha.0",
   "description": "We.publish CMS Editor",
   "keywords": [
     "editor",

--- a/packages/oauth2/package.json
+++ b/packages/oauth2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wepublish/oauth2",
-  "version": "8.1.0",
+  "version": "8.1.1-alpha.0",
   "description": "OAuth2 Provider for we.publish",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## v8.1.1-alpha (2022-11-21)

#### :bug: Bug Fix
* `api`
  * [#767](https://github.com/wepublish/wepublish/pull/767) Backport patch: Fix subscription csv download ([@michael-scheurer](https://github.com/michael-scheurer))
* `editor`
  * [#764](https://github.com/wepublish/wepublish/pull/764) feat(editor): only allow published page/article as a teaser ([@antkiewiczk](https://github.com/antkiewiczk))
  * [#757](https://github.com/wepublish/wepublish/pull/757) Properly handle checkbox ([@antkiewiczk](https://github.com/antkiewiczk))

#### :house: Internal
* `api`
  * [#749](https://github.com/wepublish/wepublish/pull/749) fix: regenerated api test definitions ([@Itrulia](https://github.com/Itrulia))

#### Committers: 3
- Itrulia ([@Itrulia](https://github.com/Itrulia))
- Kamil Antkiewicz ([@antkiewiczk](https://github.com/antkiewiczk))
- [@michael-scheurer](https://github.com/michael-scheurer)
