### PR TITLE
fix(api): use canonical url in runserver if exists for public articles

### DIFF
--- a/packages/api/src/runServer.ts
+++ b/packages/api/src/runServer.ts
@@ -37,6 +37,10 @@ class WepublishURLAdapter implements URLAdapter {
   }
 
   getPublicArticleURL(article: PublicArticle): string {
+    if (article.canonicalUrl) {
+      return article.canonicalUrl
+    }
+
     return `${this.websiteURL}/a/${article.id}/${article.slug}`
   }
 


### PR DESCRIPTION
fixes that vybe articles on bajour for example are linked correctly.
