### PR TITLE
Release 8.2.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "8.1.1",
+  "version": "8.2.0-alpha.0",
   "changelog": {
     "repo": "wepublish/wepublish",
     "cacheDir": ".changelog",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wepublish/api",
-  "version": "8.1.1",
+  "version": "8.2.0-alpha.0",
   "description": "API core for we.publish.",
   "keywords": [
     "api",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wepublish/editor",
-  "version": "8.1.1",
+  "version": "8.2.0-alpha.0",
   "description": "We.publish CMS Editor",
   "keywords": [
     "editor",


### PR DESCRIPTION
## 8.2.0-alpha.0 (2022-12-08)

#### :house: Internal
* Other
  * [#780](https://github.com/wepublish/wepublish/pull/780) chore(deps): bump decode-uri-component from 0.2.0 to 0.2.2 ([@dependabot[bot]](https://github.com/apps/dependabot))
  * [#785](https://github.com/wepublish/wepublish/pull/785) chore(deps): bump express from 4.17.1 to 4.17.3 ([@dependabot[bot]](https://github.com/apps/dependabot))
  * [#783](https://github.com/wepublish/wepublish/pull/783) chore(deps): bump qs from 6.9.3 to 6.9.7 ([@dependabot[bot]](https://github.com/apps/dependabot))
* `api`, `oauth2`
  * [#728](https://github.com/wepublish/wepublish/pull/728) Remove Oauth2 service, example, package ([@tomaszdurka](https://github.com/tomaszdurka))

#### Committers: 3
- Itrulia ([@Itrulia](https://github.com/Itrulia))
- Kamil Antkiewicz ([@antkiewiczk](https://github.com/antkiewiczk))
- Tomasz Durka ([@tomaszdurka](https://github.com/tomaszdurka))
