### PR TITLE
fix/apollo-fires-mutation-twice-on-error

### DIFF
--- a/packages/editor/src/client/index.tsx
+++ b/packages/editor/src/client/index.tsx
@@ -91,9 +91,8 @@ const onDOMContentLoaded = async () => {
           // TODO: implement this handling console.warn()
         }
       })
-      // if (networkError) console.log(`[Network error]: ${networkError}`)
     }
-    return forward(operation)
+    forward(operation)
   })
 
   const mainLink = createUploadLink({uri: adminAPIURL})


### PR DESCRIPTION
The unnecessary return statement causes mutations to be called twice in case of an error.