### PR TITLE
bugfix for tables disappearing in richtext block

### DIFF
--- a/apps/editor/src/app/blocks/richTextBlock/editor/render.tsx
+++ b/apps/editor/src/app/blocks/richTextBlock/editor/render.tsx
@@ -3,9 +3,17 @@ import {RenderElementProps, RenderLeafProps} from 'slate-react'
 
 import {BlockFormat, InlineFormat, TextFormat} from './formats'
 
+const Table = styled.table`
+  white-space: pre-wrap;
+  width: 100%;
+  margin: 10px;
+  table-layout: fixed;
+`
+
 const TD = styled.td<{borderColor: string}>`
-  border-color: ${({borderColor}) =>
-    borderColor === 'transparent' ? 'rgba(0, 0, 0, 0.1)' : borderColor};
+  border: ${({borderColor}) =>
+    borderColor === 'transparent' ? '1px solid rgba(0, 0, 0, 0.1)' : `1px solid ${borderColor}`};
+  padding: 8px;
 `
 
 export function renderElement({attributes, children, element}: RenderElementProps) {
@@ -30,9 +38,9 @@ export function renderElement({attributes, children, element}: RenderElementProp
 
     case BlockFormat.Table:
       return (
-        <table>
+        <Table>
           <tbody {...attributes}>{children}</tbody>
-        </table>
+        </Table>
       )
 
     case BlockFormat.TableRow:

--- a/apps/editor/src/app/blocks/richTextBlock/toolbar/tableMenu.tsx
+++ b/apps/editor/src/app/blocks/richTextBlock/toolbar/tableMenu.tsx
@@ -165,21 +165,6 @@ export function TableMenu() {
 
   return (
     <>
-      <Global
-        styles={css`
-          table {
-            white-space: pre-wrap;
-            width: 100%;
-            margin: 10px;
-            table-layout: fixed;
-          }
-
-          td {
-            border: 1px solid;
-            padding: 8px;
-          }
-        `}
-      />
       <Row>
         <Col xs={24}>
           <IconButton icon={<MdClose />} onClick={() => closeMenu()} />

--- a/apps/editor/src/app/blocks/richTextBlock/toolbar/tableMenu.tsx
+++ b/apps/editor/src/app/blocks/richTextBlock/toolbar/tableMenu.tsx
@@ -1,4 +1,3 @@
-import {css, Global} from '@emotion/react'
 import styled from '@emotion/styled'
 import {useContext, useEffect, useState} from 'react'
 import {useTranslation} from 'react-i18next'


### PR DESCRIPTION
WPC-1024: Tables were only visible when table menu was open, this fixes this issue by moving the tables styling out of the richtext menu into the general tables styles.