### PR TITLE
Display dashboard actions in correct order

### DIFF
--- a/libs/api/src/lib/graphql/action/action.private-queries.ts
+++ b/libs/api/src/lib/graphql/action/action.private-queries.ts
@@ -138,5 +138,5 @@ export const getActions = async (
     await Promise.all([articles, pages, comments, authors, subscriptions, polls, users, events])
   ).flat()
 
-  return actions.sort((v1: Action, v2: Action) => v2.date.getDate() - v1.date.getDate())
+  return actions.sort((v1: Action, v2: Action) => v2.date.getTime() - v1.date.getTime())
 }


### PR DESCRIPTION
WPC-1118: Dashboard action were displaying in wrong order. This fixes where the sort order in the api wasn't working properly.