### PR TITLE
Remove extra scrollbars

### DIFF
--- a/apps/editor/src/app/base.tsx
+++ b/apps/editor/src/app/base.tsx
@@ -86,6 +86,7 @@ const Sidebar = styled(RSidebar)`
 
 const Sidenav = styled(RSidenav)`
   flex: 1 1 auto;
+  overflow-y: auto;
 `
 
 const IconButton = styled(RIconButton)`
@@ -121,7 +122,7 @@ const Navigation = styled(Nav)`
 
 const ChildrenContainer = styled(Container)`
   padding: 60px 40px 40px 40px;
-  overflow-y: scroll;
+  overflow-y: auto;
 `
 
 export function Base({children}: BaseProps) {


### PR DESCRIPTION
WPC-1001: This fixes a bug where extra vertical and horizontal scrollbars appear in the editor when the sidenav menu overflows by having scroll on the navbar itself.