### PR TITLE
ci: added code coverage & reworked generate commands

### DIFF
--- a/apps/editor/project.json
+++ b/apps/editor/project.json
@@ -164,16 +164,6 @@
           "buildTarget": "editor:server:production"
         }
       }
-    },
-    "generate-api": {
-      "executor": "nx:run-commands",
-      "options": {
-        "commands": [
-          {
-            "command": "npx graphql-codegen -r dotenv/config --config codegen.yml"
-          }
-        ]
-      }
     }
   },
   "tags": []

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,7 +38,7 @@ Prerequisite: In the API (packages/api) exists a corresponding GraphQL endpoint.
 
 1. In `editor/src/app/api` you have to create a corresponding graphql file or define your mutation or query in an existing one.
 2. Start the API (`npm run watch`)
-3. Navigate in your terminal to `apps/editor` and run `npx nx generate-api editor`
+3. In your terminal run `npx nx generate-api`
 4. Now the file `index.ts` will be generated automatically in `apps/editor/src/app/api`
 5. Now you can import your desired endpoint in your .tsx file. See for example `subscriptionEditPanel.tsx`
 

--- a/jest.preset.js
+++ b/jest.preset.js
@@ -2,5 +2,6 @@ const nxPreset = require('@nx/jest/preset').default
 
 module.exports = {
   ...nxPreset,
-  globalSetup: `${__dirname}/jest.setup.ts`
+  globalSetup: `${__dirname}/jest.setup.ts`,
+  coverageReporters: [...nxPreset.coverageReporters, 'text', 'json']
 }

--- a/jest.preset.js
+++ b/jest.preset.js
@@ -3,5 +3,7 @@ const nxPreset = require('@nx/jest/preset').default
 module.exports = {
   ...nxPreset,
   globalSetup: `${__dirname}/jest.setup.ts`,
-  coverageReporters: [...nxPreset.coverageReporters, 'text', 'json']
+  coverageReporters: [...nxPreset.coverageReporters, 'text'],
+  reporters: ['default', ['github-actions', {silent: false}]],
+  watchPlugins: ['jest-watch-typeahead/filename', 'jest-watch-typeahead/testname']
 }

--- a/libs/api/jest.config.ts
+++ b/libs/api/jest.config.ts
@@ -15,5 +15,6 @@ export default {
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../coverage/libs/api',
   setupFilesAfterEnv: ['./__tests__/setup.ts'],
-  globalSetup: '<rootDir>/__tests__/setup-database.js'
+  globalSetup: '<rootDir>/__tests__/setup-database.js',
+  collectCoverageFrom: ['!**/*']
 }

--- a/libs/api/project.json
+++ b/libs/api/project.json
@@ -38,16 +38,6 @@
         "buildableProjectDepsInPackageJsonType": "dependencies",
         "rootDir": "."
       }
-    },
-    "generate-api": {
-      "executor": "nx:run-commands",
-      "options": {
-        "commands": [
-          {
-            "command": "npx graphql-codegen -r dotenv/config --config codegen.yml"
-          }
-        ]
-      }
     }
   },
   "tags": []

--- a/package.json
+++ b/package.json
@@ -16,13 +16,17 @@
     "watch:editor": "nx serve editor",
     "watch:api-example": "nx serve api-example",
     "watch:website-example": "nx serve website-example",
-    "generate:api:api": "nx generate-api api",
-    "generate:editor:api": "nx generate-api editor",
+    "generate-api": "graphql-codegen -r dotenv/config --config codegen.yml",
     "changelog": "node -r dotenv/config ./node_modules/.bin/lerna-changelog",
     "publish": "lerna publish from-package --ignore-scripts --no-verify-access",
     "start:docker": "docker-compose up --detach database pgadmin media",
     "prettier": "prettier --write \"{packages,services}/**/*.{js,ts,tsx,json}\"",
     "prepare": "prisma generate"
+  },
+  "nx": {
+    "includedScripts": [
+      "generate-api"
+    ]
   },
   "devDependencies": {
     "@babel/core": "7.12.13",

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "jest": "29.4.3",
     "jest-environment-jsdom": "29.4.3",
     "jest-fetch-mock": "^3.0.3",
+    "jest-watch-typeahead": "^2.2.2",
     "jsdom": "~20.0.3",
     "lerna": "^3.22.1",
     "lerna-changelog": "^1.0.1",


### PR DESCRIPTION
`nx generate-api editor/api` is now `nx generate-api`
