### PR TITLE
Break Block reverse improvements & smaller screen design improvements

### DIFF
--- a/libs/article/website/src/lib/__snapshots__/article-container.spec.tsx.snap
+++ b/libs/article/website/src/lib/__snapshots__/article-container.spec.tsx.snap
@@ -745,13 +745,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp elyvxql0"
+      class="css-1hmsqcp eg4920z0"
     >
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       />
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -2584,13 +2584,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp elyvxql0"
+      class="css-1hmsqcp eg4920z0"
     >
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       />
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -4423,13 +4423,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp elyvxql0"
+      class="css-1hmsqcp eg4920z0"
     >
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       />
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -6262,13 +6262,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp elyvxql0"
+      class="css-1hmsqcp eg4920z0"
     >
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       />
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"

--- a/libs/article/website/src/lib/__snapshots__/article-container.spec.tsx.snap
+++ b/libs/article/website/src/lib/__snapshots__/article-container.spec.tsx.snap
@@ -745,16 +745,17 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-2iryc4 e2qlf240"
+      class="css-1hmsqcp e16ofgi50"
     >
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       />
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       >
-        <h4
-          class="MuiTypography-root MuiTypography-h4 css-kogsit-MuiTypography-root-BreakBlock"
+        <div
+          class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
+          role="heading"
         />
         <div
           class="css-0 e1e9qmuq0"
@@ -2583,16 +2584,17 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-2iryc4 e2qlf240"
+      class="css-1hmsqcp e16ofgi50"
     >
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       />
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       >
-        <h4
-          class="MuiTypography-root MuiTypography-h4 css-kogsit-MuiTypography-root-BreakBlock"
+        <div
+          class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
+          role="heading"
         />
         <div
           class="css-0 e1e9qmuq0"
@@ -4421,16 +4423,17 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-2iryc4 e2qlf240"
+      class="css-1hmsqcp e16ofgi50"
     >
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       />
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       >
-        <h4
-          class="MuiTypography-root MuiTypography-h4 css-kogsit-MuiTypography-root-BreakBlock"
+        <div
+          class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
+          role="heading"
         />
         <div
           class="css-0 e1e9qmuq0"
@@ -6259,16 +6262,17 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-2iryc4 e2qlf240"
+      class="css-1hmsqcp e16ofgi50"
     >
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       />
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       >
-        <h4
-          class="MuiTypography-root MuiTypography-h4 css-kogsit-MuiTypography-root-BreakBlock"
+        <div
+          class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
+          role="heading"
         />
         <div
           class="css-0 e1e9qmuq0"

--- a/libs/article/website/src/lib/__snapshots__/article-container.spec.tsx.snap
+++ b/libs/article/website/src/lib/__snapshots__/article-container.spec.tsx.snap
@@ -745,13 +745,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp e16ofgi50"
+      class="css-1hmsqcp elyvxql0"
     >
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       />
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -2584,13 +2584,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp e16ofgi50"
+      class="css-1hmsqcp elyvxql0"
     >
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       />
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -4423,13 +4423,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp e16ofgi50"
+      class="css-1hmsqcp elyvxql0"
     >
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       />
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -6262,13 +6262,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp e16ofgi50"
+      class="css-1hmsqcp elyvxql0"
     >
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       />
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"

--- a/libs/article/website/src/lib/__snapshots__/article.spec.tsx.snap
+++ b/libs/article/website/src/lib/__snapshots__/article.spec.tsx.snap
@@ -745,16 +745,17 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-2iryc4 e2qlf240"
+      class="css-1hmsqcp e16ofgi50"
     >
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       />
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       >
-        <h4
-          class="MuiTypography-root MuiTypography-h4 css-kogsit-MuiTypography-root-BreakBlock"
+        <div
+          class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
+          role="heading"
         />
         <div
           class="css-0 e1e9qmuq0"
@@ -2565,16 +2566,17 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-2iryc4 e2qlf240"
+      class="css-1hmsqcp e16ofgi50"
     >
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       />
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       >
-        <h4
-          class="MuiTypography-root MuiTypography-h4 css-kogsit-MuiTypography-root-BreakBlock"
+        <div
+          class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
+          role="heading"
         />
         <div
           class="css-0 e1e9qmuq0"
@@ -4412,16 +4414,17 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-2iryc4 e2qlf240"
+      class="css-1hmsqcp e16ofgi50"
     >
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       />
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       >
-        <h4
-          class="MuiTypography-root MuiTypography-h4 css-kogsit-MuiTypography-root-BreakBlock"
+        <div
+          class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
+          role="heading"
         />
         <div
           class="css-0 e1e9qmuq0"
@@ -6267,16 +6270,17 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-2iryc4 e2qlf240"
+      class="css-1hmsqcp e16ofgi50"
     >
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       />
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       >
-        <h4
-          class="MuiTypography-root MuiTypography-h4 css-kogsit-MuiTypography-root-BreakBlock"
+        <div
+          class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
+          role="heading"
         />
         <div
           class="css-0 e1e9qmuq0"
@@ -8029,16 +8033,17 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-2iryc4 e2qlf240"
+      class="css-1hmsqcp e16ofgi50"
     >
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       />
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       >
-        <h4
-          class="MuiTypography-root MuiTypography-h4 css-kogsit-MuiTypography-root-BreakBlock"
+        <div
+          class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
+          role="heading"
         />
         <div
           class="css-0 e1e9qmuq0"
@@ -9872,16 +9877,17 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-2iryc4 e2qlf240"
+      class="css-1hmsqcp e16ofgi50"
     >
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       />
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       >
-        <h4
-          class="MuiTypography-root MuiTypography-h4 css-kogsit-MuiTypography-root-BreakBlock"
+        <div
+          class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
+          role="heading"
         />
         <div
           class="css-0 e1e9qmuq0"
@@ -11719,16 +11725,17 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-2iryc4 e2qlf240"
+      class="css-1hmsqcp e16ofgi50"
     >
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       />
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       >
-        <h4
-          class="MuiTypography-root MuiTypography-h4 css-kogsit-MuiTypography-root-BreakBlock"
+        <div
+          class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
+          role="heading"
         />
         <div
           class="css-0 e1e9qmuq0"

--- a/libs/article/website/src/lib/__snapshots__/article.spec.tsx.snap
+++ b/libs/article/website/src/lib/__snapshots__/article.spec.tsx.snap
@@ -745,13 +745,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp e16ofgi50"
+      class="css-1hmsqcp elyvxql0"
     >
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       />
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -2566,13 +2566,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp e16ofgi50"
+      class="css-1hmsqcp elyvxql0"
     >
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       />
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -4414,13 +4414,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp e16ofgi50"
+      class="css-1hmsqcp elyvxql0"
     >
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       />
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -6270,13 +6270,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp e16ofgi50"
+      class="css-1hmsqcp elyvxql0"
     >
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       />
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -8033,13 +8033,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp e16ofgi50"
+      class="css-1hmsqcp elyvxql0"
     >
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       />
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -9877,13 +9877,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp e16ofgi50"
+      class="css-1hmsqcp elyvxql0"
     >
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       />
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -11725,13 +11725,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp e16ofgi50"
+      class="css-1hmsqcp elyvxql0"
     >
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       />
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"

--- a/libs/article/website/src/lib/__snapshots__/article.spec.tsx.snap
+++ b/libs/article/website/src/lib/__snapshots__/article.spec.tsx.snap
@@ -745,13 +745,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp elyvxql0"
+      class="css-1hmsqcp eg4920z0"
     >
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       />
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -2566,13 +2566,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp elyvxql0"
+      class="css-1hmsqcp eg4920z0"
     >
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       />
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -4414,13 +4414,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp elyvxql0"
+      class="css-1hmsqcp eg4920z0"
     >
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       />
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -6270,13 +6270,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp elyvxql0"
+      class="css-1hmsqcp eg4920z0"
     >
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       />
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -8033,13 +8033,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp elyvxql0"
+      class="css-1hmsqcp eg4920z0"
     >
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       />
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -9877,13 +9877,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp elyvxql0"
+      class="css-1hmsqcp eg4920z0"
     >
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       />
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -11725,13 +11725,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp elyvxql0"
+      class="css-1hmsqcp eg4920z0"
     >
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       />
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"

--- a/libs/block-content/website/src/lib/__snapshots__/blocks.spec.tsx.snap
+++ b/libs/block-content/website/src/lib/__snapshots__/blocks.spec.tsx.snap
@@ -379,10 +379,10 @@ exports[`Blocks should render Default 1`] = `
     </div>
   </div>
   <div
-    class="css-1hmsqcp e16ofgi50"
+    class="css-1hmsqcp elyvxql0"
   >
     <div
-      class="css-rym9rp e16ofgi51"
+      class="css-rym9rp elyvxql1"
     >
       <img
         alt="DSC07717"
@@ -398,7 +398,7 @@ https://unsplash.it/200/100 200w"
       />
     </div>
     <div
-      class="css-rym9rp e16ofgi51"
+      class="css-rym9rp elyvxql1"
     >
       <div
         class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -2148,10 +2148,10 @@ exports[`Blocks should render WithLayout 1`] = `
       </div>
     </div>
     <div
-      class="css-1hmsqcp e16ofgi50"
+      class="css-1hmsqcp elyvxql0"
     >
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       >
         <img
           alt="DSC07717"
@@ -2167,7 +2167,7 @@ https://unsplash.it/200/100 200w"
         />
       </div>
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"

--- a/libs/block-content/website/src/lib/__snapshots__/blocks.spec.tsx.snap
+++ b/libs/block-content/website/src/lib/__snapshots__/blocks.spec.tsx.snap
@@ -379,10 +379,10 @@ exports[`Blocks should render Default 1`] = `
     </div>
   </div>
   <div
-    class="css-1hmsqcp elyvxql0"
+    class="css-1hmsqcp eg4920z0"
   >
     <div
-      class="css-rym9rp elyvxql1"
+      class="css-rym9rp eg4920z1"
     >
       <img
         alt="DSC07717"
@@ -398,7 +398,7 @@ https://unsplash.it/200/100 200w"
       />
     </div>
     <div
-      class="css-rym9rp elyvxql1"
+      class="css-rym9rp eg4920z1"
     >
       <div
         class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -2148,10 +2148,10 @@ exports[`Blocks should render WithLayout 1`] = `
       </div>
     </div>
     <div
-      class="css-1hmsqcp elyvxql0"
+      class="css-1hmsqcp eg4920z0"
     >
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       >
         <img
           alt="DSC07717"
@@ -2167,7 +2167,7 @@ https://unsplash.it/200/100 200w"
         />
       </div>
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"

--- a/libs/block-content/website/src/lib/__snapshots__/blocks.spec.tsx.snap
+++ b/libs/block-content/website/src/lib/__snapshots__/blocks.spec.tsx.snap
@@ -379,32 +379,33 @@ exports[`Blocks should render Default 1`] = `
     </div>
   </div>
   <div
-    class="css-2iryc4 e2qlf240"
+    class="css-1hmsqcp e16ofgi50"
   >
     <div
-      class="css-1nww0tx e2qlf241"
+      class="css-rym9rp e16ofgi51"
     >
       <img
         alt="DSC07717"
         class="css-1a2v9hb e1nfkf2e0"
         height="6000"
         loading="lazy"
-        srcset="https://unsplash.it/800/800 800w,
-https://unsplash.it/500/500 500w,
-https://unsplash.it/300/300 300w,
-https://unsplash.it/200/200 200w"
+        srcset="https://unsplash.it/800/400 800w,
+https://unsplash.it/500/300 500w,
+https://unsplash.it/300/200 300w,
+https://unsplash.it/200/100 200w"
         title=""
         width="4000"
       />
     </div>
     <div
-      class="css-1nww0tx e2qlf241"
+      class="css-rym9rp e16ofgi51"
     >
-      <h4
-        class="MuiTypography-root MuiTypography-h4 css-kogsit-MuiTypography-root-BreakBlock"
+      <div
+        class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
+        role="heading"
       >
         Break block test
-      </h4>
+      </div>
       <div
         class="css-0 e1e9qmuq0"
       >
@@ -2147,32 +2148,33 @@ exports[`Blocks should render WithLayout 1`] = `
       </div>
     </div>
     <div
-      class="css-2iryc4 e2qlf240"
+      class="css-1hmsqcp e16ofgi50"
     >
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       >
         <img
           alt="DSC07717"
           class="css-1a2v9hb e1nfkf2e0"
           height="6000"
           loading="lazy"
-          srcset="https://unsplash.it/800/800 800w,
-https://unsplash.it/500/500 500w,
-https://unsplash.it/300/300 300w,
-https://unsplash.it/200/200 200w"
+          srcset="https://unsplash.it/800/400 800w,
+https://unsplash.it/500/300 500w,
+https://unsplash.it/300/200 300w,
+https://unsplash.it/200/100 200w"
           title=""
           width="4000"
         />
       </div>
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       >
-        <h4
-          class="MuiTypography-root MuiTypography-h4 css-kogsit-MuiTypography-root-BreakBlock"
+        <div
+          class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
+          role="heading"
         >
           Break block test
-        </h4>
+        </div>
         <div
           class="css-0 e1e9qmuq0"
         >

--- a/libs/block-content/website/src/lib/break/__snapshots__/break-block.spec.tsx.snap
+++ b/libs/block-content/website/src/lib/break/__snapshots__/break-block.spec.tsx.snap
@@ -3,10 +3,10 @@
 exports[`Break Block should render Default 1`] = `
 <DocumentFragment>
   <div
-    class="css-1hmsqcp e16ofgi50"
+    class="css-1hmsqcp elyvxql0"
   >
     <div
-      class="css-rym9rp e16ofgi51"
+      class="css-rym9rp elyvxql1"
     >
       <img
         alt="DSC07717"
@@ -22,7 +22,7 @@ https://unsplash.it/200/100 200w"
       />
     </div>
     <div
-      class="css-rym9rp e16ofgi51"
+      class="css-rym9rp elyvxql1"
     >
       <div
         class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -161,10 +161,10 @@ https://unsplash.it/200/100 200w"
 exports[`Break Block should render ImageRight 1`] = `
 <DocumentFragment>
   <div
-    class="css-1hmsqcp e16ofgi50"
+    class="css-1hmsqcp elyvxql0"
   >
     <div
-      class="css-16scpt9 e16ofgi51"
+      class="css-16scpt9 elyvxql1"
     >
       <img
         alt="DSC07717"
@@ -180,7 +180,7 @@ https://unsplash.it/200/100 200w"
       />
     </div>
     <div
-      class="css-rym9rp e16ofgi51"
+      class="css-rym9rp elyvxql1"
     >
       <div
         class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -319,10 +319,10 @@ https://unsplash.it/200/100 200w"
 exports[`Break Block should render WithClassName 1`] = `
 <DocumentFragment>
   <div
-    class="extra-classname css-1hmsqcp e16ofgi50"
+    class="extra-classname css-1hmsqcp elyvxql0"
   >
     <div
-      class="css-rym9rp e16ofgi51"
+      class="css-rym9rp elyvxql1"
     >
       <img
         alt="DSC07717"
@@ -338,7 +338,7 @@ https://unsplash.it/200/100 200w"
       />
     </div>
     <div
-      class="css-rym9rp e16ofgi51"
+      class="css-rym9rp elyvxql1"
     >
       <div
         class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -477,10 +477,10 @@ https://unsplash.it/200/100 200w"
 exports[`Break Block should render WithEmotion 1`] = `
 <DocumentFragment>
   <div
-    class="css-1hmsqcp e16ofgi50"
+    class="css-1hmsqcp elyvxql0"
   >
     <div
-      class="css-rym9rp e16ofgi51"
+      class="css-rym9rp elyvxql1"
     >
       <img
         alt="DSC07717"
@@ -496,7 +496,7 @@ https://unsplash.it/200/100 200w"
       />
     </div>
     <div
-      class="css-rym9rp e16ofgi51"
+      class="css-rym9rp elyvxql1"
     >
       <div
         class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -635,13 +635,13 @@ https://unsplash.it/200/100 200w"
 exports[`Break Block should render WithoutImage 1`] = `
 <DocumentFragment>
   <div
-    class="css-1hmsqcp e16ofgi50"
+    class="css-1hmsqcp elyvxql0"
   >
     <div
-      class="css-rym9rp e16ofgi51"
+      class="css-rym9rp elyvxql1"
     />
     <div
-      class="css-rym9rp e16ofgi51"
+      class="css-rym9rp elyvxql1"
     >
       <div
         class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"

--- a/libs/block-content/website/src/lib/break/__snapshots__/break-block.spec.tsx.snap
+++ b/libs/block-content/website/src/lib/break/__snapshots__/break-block.spec.tsx.snap
@@ -3,10 +3,10 @@
 exports[`Break Block should render Default 1`] = `
 <DocumentFragment>
   <div
-    class="css-1hmsqcp elyvxql0"
+    class="css-1hmsqcp eg4920z0"
   >
     <div
-      class="css-rym9rp elyvxql1"
+      class="css-rym9rp eg4920z1"
     >
       <img
         alt="DSC07717"
@@ -22,7 +22,7 @@ https://unsplash.it/200/100 200w"
       />
     </div>
     <div
-      class="css-rym9rp elyvxql1"
+      class="css-rym9rp eg4920z1"
     >
       <div
         class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -161,10 +161,10 @@ https://unsplash.it/200/100 200w"
 exports[`Break Block should render ImageRight 1`] = `
 <DocumentFragment>
   <div
-    class="css-1hmsqcp elyvxql0"
+    class="css-dt2k4c eg4920z0"
   >
     <div
-      class="css-16scpt9 elyvxql1"
+      class="css-16scpt9 eg4920z1"
     >
       <img
         alt="DSC07717"
@@ -180,7 +180,7 @@ https://unsplash.it/200/100 200w"
       />
     </div>
     <div
-      class="css-rym9rp elyvxql1"
+      class="css-rym9rp eg4920z1"
     >
       <div
         class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -319,10 +319,10 @@ https://unsplash.it/200/100 200w"
 exports[`Break Block should render WithClassName 1`] = `
 <DocumentFragment>
   <div
-    class="extra-classname css-1hmsqcp elyvxql0"
+    class="extra-classname css-1hmsqcp eg4920z0"
   >
     <div
-      class="css-rym9rp elyvxql1"
+      class="css-rym9rp eg4920z1"
     >
       <img
         alt="DSC07717"
@@ -338,7 +338,7 @@ https://unsplash.it/200/100 200w"
       />
     </div>
     <div
-      class="css-rym9rp elyvxql1"
+      class="css-rym9rp eg4920z1"
     >
       <div
         class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -477,10 +477,10 @@ https://unsplash.it/200/100 200w"
 exports[`Break Block should render WithEmotion 1`] = `
 <DocumentFragment>
   <div
-    class="css-1hmsqcp elyvxql0"
+    class="css-1hmsqcp eg4920z0"
   >
     <div
-      class="css-rym9rp elyvxql1"
+      class="css-rym9rp eg4920z1"
     >
       <img
         alt="DSC07717"
@@ -496,7 +496,7 @@ https://unsplash.it/200/100 200w"
       />
     </div>
     <div
-      class="css-rym9rp elyvxql1"
+      class="css-rym9rp eg4920z1"
     >
       <div
         class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -635,13 +635,13 @@ https://unsplash.it/200/100 200w"
 exports[`Break Block should render WithoutImage 1`] = `
 <DocumentFragment>
   <div
-    class="css-1hmsqcp elyvxql0"
+    class="css-1hmsqcp eg4920z0"
   >
     <div
-      class="css-rym9rp elyvxql1"
+      class="css-rym9rp eg4920z1"
     />
     <div
-      class="css-rym9rp elyvxql1"
+      class="css-rym9rp eg4920z1"
     >
       <div
         class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"

--- a/libs/block-content/website/src/lib/break/__snapshots__/break-block.spec.tsx.snap
+++ b/libs/block-content/website/src/lib/break/__snapshots__/break-block.spec.tsx.snap
@@ -3,32 +3,33 @@
 exports[`Break Block should render Default 1`] = `
 <DocumentFragment>
   <div
-    class="css-2iryc4 e2qlf240"
+    class="css-1hmsqcp e16ofgi50"
   >
     <div
-      class="css-1nww0tx e2qlf241"
+      class="css-rym9rp e16ofgi51"
     >
       <img
         alt="DSC07717"
         class="css-1a2v9hb e1nfkf2e0"
         height="6000"
         loading="lazy"
-        srcset="https://unsplash.it/800/800 800w,
-https://unsplash.it/500/500 500w,
-https://unsplash.it/300/300 300w,
-https://unsplash.it/200/200 200w"
+        srcset="https://unsplash.it/800/400 800w,
+https://unsplash.it/500/300 500w,
+https://unsplash.it/300/200 300w,
+https://unsplash.it/200/100 200w"
         title=""
         width="4000"
       />
     </div>
     <div
-      class="css-1nww0tx e2qlf241"
+      class="css-rym9rp e16ofgi51"
     >
-      <h4
-        class="MuiTypography-root MuiTypography-h4 css-kogsit-MuiTypography-root-BreakBlock"
+      <div
+        class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
+        role="heading"
       >
         Break block test
-      </h4>
+      </div>
       <div
         class="css-0 e1e9qmuq0"
       >
@@ -160,32 +161,33 @@ https://unsplash.it/200/200 200w"
 exports[`Break Block should render ImageRight 1`] = `
 <DocumentFragment>
   <div
-    class="css-1hvish2 e2qlf240"
+    class="css-1hmsqcp e16ofgi50"
   >
     <div
-      class="css-1dltqk9 e2qlf241"
+      class="css-16scpt9 e16ofgi51"
     >
       <img
         alt="DSC07717"
         class="css-1a2v9hb e1nfkf2e0"
         height="6000"
         loading="lazy"
-        srcset="https://unsplash.it/800/800 800w,
-https://unsplash.it/500/500 500w,
-https://unsplash.it/300/300 300w,
-https://unsplash.it/200/200 200w"
+        srcset="https://unsplash.it/800/400 800w,
+https://unsplash.it/500/300 500w,
+https://unsplash.it/300/200 300w,
+https://unsplash.it/200/100 200w"
         title=""
         width="4000"
       />
     </div>
     <div
-      class="css-1nww0tx e2qlf241"
+      class="css-rym9rp e16ofgi51"
     >
-      <h4
-        class="MuiTypography-root MuiTypography-h4 css-kogsit-MuiTypography-root-BreakBlock"
+      <div
+        class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
+        role="heading"
       >
         Break block test
-      </h4>
+      </div>
       <div
         class="css-0 e1e9qmuq0"
       >
@@ -317,32 +319,33 @@ https://unsplash.it/200/200 200w"
 exports[`Break Block should render WithClassName 1`] = `
 <DocumentFragment>
   <div
-    class="extra-classname css-2iryc4 e2qlf240"
+    class="extra-classname css-1hmsqcp e16ofgi50"
   >
     <div
-      class="css-1nww0tx e2qlf241"
+      class="css-rym9rp e16ofgi51"
     >
       <img
         alt="DSC07717"
         class="css-1a2v9hb e1nfkf2e0"
         height="6000"
         loading="lazy"
-        srcset="https://unsplash.it/800/800 800w,
-https://unsplash.it/500/500 500w,
-https://unsplash.it/300/300 300w,
-https://unsplash.it/200/200 200w"
+        srcset="https://unsplash.it/800/400 800w,
+https://unsplash.it/500/300 500w,
+https://unsplash.it/300/200 300w,
+https://unsplash.it/200/100 200w"
         title=""
         width="4000"
       />
     </div>
     <div
-      class="css-1nww0tx e2qlf241"
+      class="css-rym9rp e16ofgi51"
     >
-      <h4
-        class="MuiTypography-root MuiTypography-h4 css-kogsit-MuiTypography-root-BreakBlock"
+      <div
+        class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
+        role="heading"
       >
         Break block test
-      </h4>
+      </div>
       <div
         class="css-0 e1e9qmuq0"
       >
@@ -474,32 +477,33 @@ https://unsplash.it/200/200 200w"
 exports[`Break Block should render WithEmotion 1`] = `
 <DocumentFragment>
   <div
-    class="css-2iryc4 e2qlf240"
+    class="css-1hmsqcp e16ofgi50"
   >
     <div
-      class="css-1nww0tx e2qlf241"
+      class="css-rym9rp e16ofgi51"
     >
       <img
         alt="DSC07717"
         class="css-1a2v9hb e1nfkf2e0"
         height="6000"
         loading="lazy"
-        srcset="https://unsplash.it/800/800 800w,
-https://unsplash.it/500/500 500w,
-https://unsplash.it/300/300 300w,
-https://unsplash.it/200/200 200w"
+        srcset="https://unsplash.it/800/400 800w,
+https://unsplash.it/500/300 500w,
+https://unsplash.it/300/200 300w,
+https://unsplash.it/200/100 200w"
         title=""
         width="4000"
       />
     </div>
     <div
-      class="css-1nww0tx e2qlf241"
+      class="css-rym9rp e16ofgi51"
     >
-      <h4
-        class="MuiTypography-root MuiTypography-h4 css-kogsit-MuiTypography-root-BreakBlock"
+      <div
+        class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
+        role="heading"
       >
         Break block test
-      </h4>
+      </div>
       <div
         class="css-0 e1e9qmuq0"
       >
@@ -631,19 +635,20 @@ https://unsplash.it/200/200 200w"
 exports[`Break Block should render WithoutImage 1`] = `
 <DocumentFragment>
   <div
-    class="css-2iryc4 e2qlf240"
+    class="css-1hmsqcp e16ofgi50"
   >
     <div
-      class="css-1nww0tx e2qlf241"
+      class="css-rym9rp e16ofgi51"
     />
     <div
-      class="css-1nww0tx e2qlf241"
+      class="css-rym9rp e16ofgi51"
     >
-      <h4
-        class="MuiTypography-root MuiTypography-h4 css-kogsit-MuiTypography-root-BreakBlock"
+      <div
+        class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
+        role="heading"
       >
         Break block test
-      </h4>
+      </div>
       <div
         class="css-0 e1e9qmuq0"
       >

--- a/libs/block-content/website/src/lib/break/break-block.tsx
+++ b/libs/block-content/website/src/lib/break/break-block.tsx
@@ -5,7 +5,7 @@ import {Block, LinkPageBreakBlock as LinkPageBreakBlockType} from '@wepublish/we
 export const isBreakBlock = (block: Block): block is LinkPageBreakBlockType =>
   block.__typename === 'LinkPageBreakBlock'
 
-export const BreakBlockWrapper = styled('div')`
+export const BreakBlockWrapper = styled('div')<{reverse?: boolean}>`
   display: grid;
   gap: ${({theme}) => theme.spacing(2)};
   justify-content: center;
@@ -13,6 +13,14 @@ export const BreakBlockWrapper = styled('div')`
   ${({theme}) => theme.breakpoints.up('md')} {
     grid-template-columns: 1fr 2fr;
   }
+
+  ${({theme, reverse}) =>
+    reverse &&
+    css`
+      ${theme.breakpoints.up('md')} {
+        grid-template-columns: 2fr 1fr;
+      }
+    `}
 `
 
 export const BreakBlockSegment = styled('div')<{reverse?: boolean}>`
@@ -46,7 +54,7 @@ export const BreakBlock = ({
   const reverse = layoutOption === 'image-right'
 
   return (
-    <BreakBlockWrapper className={className}>
+    <BreakBlockWrapper className={className} reverse={reverse}>
       <BreakBlockSegment reverse={reverse}>
         {image && <Image image={image} square={squareImage} />}
       </BreakBlockSegment>

--- a/libs/block-content/website/src/lib/break/break-block.tsx
+++ b/libs/block-content/website/src/lib/break/break-block.tsx
@@ -5,42 +5,36 @@ import {Block, LinkPageBreakBlock as LinkPageBreakBlockType} from '@wepublish/we
 export const isBreakBlock = (block: Block): block is LinkPageBreakBlockType =>
   block.__typename === 'LinkPageBreakBlock'
 
-export const BreakBlockWrapper = styled('div')<{reverse?: boolean}>`
+export const BreakBlockWrapper = styled('div')`
   display: grid;
   gap: ${({theme}) => theme.spacing(2)};
-  grid-template-columns: 100%;
   justify-content: center;
 
   ${({theme}) => theme.breakpoints.up('md')} {
-    grid-auto-flow: ${props => props.reverse && 'column'};
-    gap: ${({theme}) => theme.spacing(20)};
-    grid-template-columns: repeat(2, 1fr);
-  }
-
-  ${({theme}) => theme.breakpoints.up('lg')} {
-    gap: ${({theme}) => theme.spacing(30)};
+    grid-template-columns: 1fr 2fr;
   }
 `
 
 export const BreakBlockSegment = styled('div')<{reverse?: boolean}>`
   display: grid;
-  width: 100%;
   align-items: center;
-  ${({theme}) => theme.breakpoints.up('md')} {
-    grid-column-end: ${props => props.reverse && '-1'};
-  }
-`
+  gap: ${({theme}) => theme.spacing(2)};
 
-const headingStyles = css`
-  margin-bottom: 24px;
+  ${({theme, reverse}) =>
+    reverse &&
+    css`
+      ${theme.breakpoints.up('md')} {
+        order: 1;
+      }
+    `}
 `
 
 export const BreakBlock = ({
   className,
-  layoutOption,
   text,
   image,
-  richText
+  richText,
+  layoutOption
 }: BuilderBreakBlockProps) => {
   const {
     elements: {H4, Image},
@@ -50,12 +44,14 @@ export const BreakBlock = ({
   const reverse = layoutOption === 'image-right'
 
   return (
-    <BreakBlockWrapper className={className} reverse={reverse}>
-      <BreakBlockSegment reverse={reverse}>
-        {image && <Image image={image} square />}
-      </BreakBlockSegment>
+    <BreakBlockWrapper className={className}>
+      <BreakBlockSegment reverse={reverse}>{image && <Image image={image} />}</BreakBlockSegment>
+
       <BreakBlockSegment>
-        <H4 css={headingStyles}>{text}</H4>
+        <H4 component="div" role="heading">
+          {text}
+        </H4>
+
         <RichText richText={richText} />
       </BreakBlockSegment>
     </BreakBlockWrapper>

--- a/libs/block-content/website/src/lib/break/break-block.tsx
+++ b/libs/block-content/website/src/lib/break/break-block.tsx
@@ -1,4 +1,4 @@
-import {css, styled} from '@mui/material'
+import {css, styled, useMediaQuery, useTheme} from '@mui/material'
 import {BuilderBreakBlockProps, useWebsiteBuilder} from '@wepublish/website/builder'
 import {Block, LinkPageBreakBlock as LinkPageBreakBlockType} from '@wepublish/website/api'
 
@@ -41,11 +41,15 @@ export const BreakBlock = ({
     blocks: {RichText}
   } = useWebsiteBuilder()
 
+  const theme = useTheme()
+  const squareImage = useMediaQuery(theme.breakpoints.up('md'))
   const reverse = layoutOption === 'image-right'
 
   return (
     <BreakBlockWrapper className={className}>
-      <BreakBlockSegment reverse={reverse}>{image && <Image image={image} />}</BreakBlockSegment>
+      <BreakBlockSegment reverse={reverse}>
+        {image && <Image image={image} square={squareImage} />}
+      </BreakBlockSegment>
 
       <BreakBlockSegment>
         <H4 component="div" role="heading">

--- a/libs/page/website/src/lib/__snapshots__/page-container.spec.tsx.snap
+++ b/libs/page/website/src/lib/__snapshots__/page-container.spec.tsx.snap
@@ -713,13 +713,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp elyvxql0"
+      class="css-1hmsqcp eg4920z0"
     >
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       />
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -2329,13 +2329,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp elyvxql0"
+      class="css-1hmsqcp eg4920z0"
     >
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       />
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -3945,13 +3945,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp elyvxql0"
+      class="css-1hmsqcp eg4920z0"
     >
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       />
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -5561,13 +5561,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp elyvxql0"
+      class="css-1hmsqcp eg4920z0"
     >
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       />
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"

--- a/libs/page/website/src/lib/__snapshots__/page-container.spec.tsx.snap
+++ b/libs/page/website/src/lib/__snapshots__/page-container.spec.tsx.snap
@@ -713,13 +713,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp e16ofgi50"
+      class="css-1hmsqcp elyvxql0"
     >
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       />
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -2329,13 +2329,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp e16ofgi50"
+      class="css-1hmsqcp elyvxql0"
     >
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       />
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -3945,13 +3945,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp e16ofgi50"
+      class="css-1hmsqcp elyvxql0"
     >
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       />
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -5561,13 +5561,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp e16ofgi50"
+      class="css-1hmsqcp elyvxql0"
     >
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       />
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"

--- a/libs/page/website/src/lib/__snapshots__/page-container.spec.tsx.snap
+++ b/libs/page/website/src/lib/__snapshots__/page-container.spec.tsx.snap
@@ -713,16 +713,17 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-2iryc4 e2qlf240"
+      class="css-1hmsqcp e16ofgi50"
     >
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       />
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       >
-        <h4
-          class="MuiTypography-root MuiTypography-h4 css-kogsit-MuiTypography-root-BreakBlock"
+        <div
+          class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
+          role="heading"
         />
         <div
           class="css-0 e1e9qmuq0"
@@ -2328,16 +2329,17 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-2iryc4 e2qlf240"
+      class="css-1hmsqcp e16ofgi50"
     >
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       />
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       >
-        <h4
-          class="MuiTypography-root MuiTypography-h4 css-kogsit-MuiTypography-root-BreakBlock"
+        <div
+          class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
+          role="heading"
         />
         <div
           class="css-0 e1e9qmuq0"
@@ -3943,16 +3945,17 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-2iryc4 e2qlf240"
+      class="css-1hmsqcp e16ofgi50"
     >
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       />
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       >
-        <h4
-          class="MuiTypography-root MuiTypography-h4 css-kogsit-MuiTypography-root-BreakBlock"
+        <div
+          class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
+          role="heading"
         />
         <div
           class="css-0 e1e9qmuq0"
@@ -5558,16 +5561,17 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-2iryc4 e2qlf240"
+      class="css-1hmsqcp e16ofgi50"
     >
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       />
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       >
-        <h4
-          class="MuiTypography-root MuiTypography-h4 css-kogsit-MuiTypography-root-BreakBlock"
+        <div
+          class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
+          role="heading"
         />
         <div
           class="css-0 e1e9qmuq0"

--- a/libs/page/website/src/lib/__snapshots__/page.spec.tsx.snap
+++ b/libs/page/website/src/lib/__snapshots__/page.spec.tsx.snap
@@ -713,16 +713,17 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-2iryc4 e2qlf240"
+      class="css-1hmsqcp e16ofgi50"
     >
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       />
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       >
-        <h4
-          class="MuiTypography-root MuiTypography-h4 css-kogsit-MuiTypography-root-BreakBlock"
+        <div
+          class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
+          role="heading"
         />
         <div
           class="css-0 e1e9qmuq0"
@@ -2429,16 +2430,17 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-2iryc4 e2qlf240"
+      class="css-1hmsqcp e16ofgi50"
     >
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       />
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       >
-        <h4
-          class="MuiTypography-root MuiTypography-h4 css-kogsit-MuiTypography-root-BreakBlock"
+        <div
+          class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
+          role="heading"
         />
         <div
           class="css-0 e1e9qmuq0"
@@ -4156,16 +4158,17 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-2iryc4 e2qlf240"
+      class="css-1hmsqcp e16ofgi50"
     >
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       />
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       >
-        <h4
-          class="MuiTypography-root MuiTypography-h4 css-kogsit-MuiTypography-root-BreakBlock"
+        <div
+          class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
+          role="heading"
         />
         <div
           class="css-0 e1e9qmuq0"
@@ -5875,16 +5878,17 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-2iryc4 e2qlf240"
+      class="css-1hmsqcp e16ofgi50"
     >
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       />
       <div
-        class="css-1nww0tx e2qlf241"
+        class="css-rym9rp e16ofgi51"
       >
-        <h4
-          class="MuiTypography-root MuiTypography-h4 css-kogsit-MuiTypography-root-BreakBlock"
+        <div
+          class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
+          role="heading"
         />
         <div
           class="css-0 e1e9qmuq0"

--- a/libs/page/website/src/lib/__snapshots__/page.spec.tsx.snap
+++ b/libs/page/website/src/lib/__snapshots__/page.spec.tsx.snap
@@ -713,13 +713,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp elyvxql0"
+      class="css-1hmsqcp eg4920z0"
     >
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       />
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -2430,13 +2430,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp elyvxql0"
+      class="css-1hmsqcp eg4920z0"
     >
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       />
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -4158,13 +4158,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp elyvxql0"
+      class="css-1hmsqcp eg4920z0"
     >
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       />
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -5878,13 +5878,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp elyvxql0"
+      class="css-1hmsqcp eg4920z0"
     >
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       />
       <div
-        class="css-rym9rp elyvxql1"
+        class="css-rym9rp eg4920z1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"

--- a/libs/page/website/src/lib/__snapshots__/page.spec.tsx.snap
+++ b/libs/page/website/src/lib/__snapshots__/page.spec.tsx.snap
@@ -713,13 +713,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp e16ofgi50"
+      class="css-1hmsqcp elyvxql0"
     >
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       />
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -2430,13 +2430,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp e16ofgi50"
+      class="css-1hmsqcp elyvxql0"
     >
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       />
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -4158,13 +4158,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp e16ofgi50"
+      class="css-1hmsqcp elyvxql0"
     >
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       />
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
@@ -5878,13 +5878,13 @@ https://unsplash.it/200/100 200w"
       </cite>
     </blockquote>
     <div
-      class="css-1hmsqcp e16ofgi50"
+      class="css-1hmsqcp elyvxql0"
     >
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       />
       <div
-        class="css-rym9rp e16ofgi51"
+        class="css-rym9rp elyvxql1"
       >
         <div
           class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"


### PR DESCRIPTION
Made some small improvements to the break block, as the square image was huge on mobile/tablet, spacing was too big on smaller screens etc.

Also changed the reverse to use `order` instead of multiple properties at once