### PR TITLE
refactor(consent): use @ArgType instead of @InputType

### DIFF
--- a/libs/consent/api/__tests__/prisma/seed.ts
+++ b/libs/consent/api/__tests__/prisma/seed.ts
@@ -1,4 +1,4 @@
-import {PaymentPeriodicity, PrismaClient, SubscriptionEvent} from '@prisma/client'
+import {PrismaClient} from '@prisma/client'
 import {seed as rootSeed} from '../../../../api/prisma/seed'
 import {hashPassword} from '../../../../api/src/lib/db/user'
 
@@ -12,7 +12,7 @@ async function seed() {
     throw new Error('@wepublish/api seeding has not been done')
   }
 
-  const dev = await prisma.user.upsert({
+  await prisma.user.upsert({
     where: {
       email: 'dev@wepublish.ch'
     },
@@ -27,7 +27,7 @@ async function seed() {
     }
   })
 
-  const editor = await prisma.user.upsert({
+  await prisma.user.upsert({
     where: {
       email: 'editor@wepublish.ch'
     },
@@ -41,206 +41,6 @@ async function seed() {
       password: await hashPassword('123')
     }
   })
-
-  const mailTemplates = []
-  for (let i = 0; i < 10; i++) {
-    const template = await prisma.mailTemplate.upsert({
-      where: {
-        externalMailTemplateId: `sample-slug-${i}`
-      },
-      update: {},
-      create: {
-        name: `sample-template-${i}`,
-        description: `sample-template-description-${i}`,
-        externalMailTemplateId: `sample-slug-${i}`,
-        remoteMissing: false
-      }
-    })
-    mailTemplates.push(template)
-  }
-
-  const paymentMethod = await prisma.paymentMethod.upsert({
-    where: {
-      id: '1'
-    },
-    update: {},
-    create: {
-      name: 'Shiny Rocks',
-      slug: 'shiny-rocks',
-      description: 'Payment by transaction of a handful of shiny rocks',
-      paymentProviderID: 'stripe_checkout',
-      active: true
-    }
-  })
-
-  const memberPlan = await prisma.memberPlan.upsert({
-    where: {
-      slug: 'test-plan'
-    },
-    update: {},
-    create: {
-      name: 'Test Plan',
-      slug: 'test-plan',
-      tags: [],
-      description: {},
-      active: true,
-      amountPerMonthMin: 1
-    }
-  })
-
-  await prisma.subscription.upsert({
-    where: {
-      id: '1'
-    },
-    update: {},
-    create: {
-      id: '1',
-      paymentPeriodicity: PaymentPeriodicity.biannual,
-      paymentMethod: {connect: {id: paymentMethod.id}},
-      memberPlan: {connect: {id: memberPlan.id}},
-      monthlyAmount: 3,
-      autoRenew: true,
-      startsAt: new Date().toISOString(),
-      user: {connect: {id: editor.id}}
-    }
-  })
-
-  await prisma.subscription.upsert({
-    where: {
-      id: '2'
-    },
-    update: {},
-    create: {
-      id: '2',
-      paymentPeriodicity: PaymentPeriodicity.biannual,
-      paymentMethod: {connect: {id: paymentMethod.id}},
-      memberPlan: {connect: {id: memberPlan.id}},
-      monthlyAmount: 3,
-      autoRenew: false,
-      startsAt: new Date().toISOString(),
-      user: {connect: {id: dev.id}}
-    }
-  })
-
-  await prisma.availablePaymentMethod.upsert({
-    where: {
-      id: '1'
-    },
-    update: {},
-    create: {
-      paymentMethodIDs: [],
-      paymentPeriodicities: [PaymentPeriodicity.monthly],
-      forceAutoRenewal: false,
-      MemberPlan: {connect: {id: memberPlan.id}}
-    }
-  })
-
-  const flow1 = await prisma.subscriptionFlow.upsert({
-    where: {
-      id: '4a5c51b4-9499-45e4-82ea-b01c990ad87d'
-    },
-    update: {},
-    create: {
-      default: false,
-      memberPlan: {connect: {id: memberPlan.id}},
-      paymentMethods: {connect: [{id: paymentMethod.id}]},
-      periodicities: [PaymentPeriodicity.monthly, PaymentPeriodicity.yearly],
-      autoRenewal: [true]
-    }
-  })
-
-  const flow2 = await prisma.subscriptionFlow.upsert({
-    where: {
-      id: 'a0031cb7-e5e9-4008-9973-3c4d6bf40601'
-    },
-    update: {},
-    create: {
-      default: false,
-      memberPlan: {connect: {id: memberPlan.id}},
-      paymentMethods: {connect: [{id: paymentMethod.id}]},
-      periodicities: [PaymentPeriodicity.monthly, PaymentPeriodicity.yearly],
-      autoRenewal: [false]
-    }
-  })
-
-  const subscriptionFlows = [flow1, flow2]
-
-  const events = [
-    {
-      id: '847448f2-9985-469a-bfc5-7f8b957c67af',
-      event: SubscriptionEvent.DEACTIVATION_UNPAID,
-      daysAwayFromEnding: 10,
-      mailTemplate: {connect: {id: mailTemplates[8].id}},
-      subscriptionFlow: {connect: {id: subscriptionFlows[0].id}}
-    },
-    {
-      id: 'e8ba6158-fbfd-4d36-aa78-fd608f666232',
-      event: SubscriptionEvent.DEACTIVATION_BY_USER,
-      daysAwayFromEnding: null,
-      mailTemplate: {connect: {id: mailTemplates[9].id}},
-      subscriptionFlow: {connect: {id: subscriptionFlows[0].id}}
-    },
-    {
-      id: '96c35c14-9897-48f2-9484-1919b2f8a2a9',
-      event: SubscriptionEvent.CUSTOM,
-      daysAwayFromEnding: -6,
-      mailTemplate: {connect: {id: mailTemplates[1].id}},
-      subscriptionFlow: {connect: {id: subscriptionFlows[0].id}}
-    },
-    {
-      id: 'fbae3149-3018-454c-908d-685c83246540',
-      event: SubscriptionEvent.INVOICE_CREATION,
-      daysAwayFromEnding: -30,
-      mailTemplate: {connect: {id: mailTemplates[2].id}},
-      subscriptionFlow: {connect: {id: subscriptionFlows[0].id}}
-    },
-    {
-      id: 'eee0ff57-4e3c-4d73-b158-de0ae979e9a7',
-      event: SubscriptionEvent.SUBSCRIBE,
-      daysAwayFromEnding: null,
-      mailTemplate: {connect: {id: mailTemplates[3].id}},
-      subscriptionFlow: {connect: {id: subscriptionFlows[1].id}}
-    },
-    {
-      id: '82f8b2a0-38e8-4b9f-9996-9beff5ed195f',
-      event: SubscriptionEvent.RENEWAL_SUCCESS,
-      daysAwayFromEnding: null,
-      mailTemplate: {connect: {id: mailTemplates[4].id}},
-      subscriptionFlow: {connect: {id: subscriptionFlows[1].id}}
-    },
-    {
-      id: '1c1b5f7a-c49d-4734-beef-a38477f38e13',
-      event: SubscriptionEvent.RENEWAL_FAILED,
-      daysAwayFromEnding: null,
-      mailTemplate: {connect: {id: mailTemplates[5].id}},
-      subscriptionFlow: {connect: {id: subscriptionFlows[1].id}}
-    },
-    {
-      id: 'b23386cf-eb10-453d-8bc7-586caad230c7',
-      event: SubscriptionEvent.INVOICE_CREATION,
-      daysAwayFromEnding: -30,
-      mailTemplate: {connect: {id: mailTemplates[6].id}},
-      subscriptionFlow: {connect: {id: subscriptionFlows[1].id}}
-    },
-    {
-      id: 'f2b663e5-ac95-4d89-8b08-ca3fb470362a',
-      event: SubscriptionEvent.DEACTIVATION_UNPAID,
-      daysAwayFromEnding: 10,
-      mailTemplate: {connect: {id: mailTemplates[7].id}},
-      subscriptionFlow: {connect: {id: subscriptionFlows[1].id}}
-    }
-  ]
-
-  for (const event of events) {
-    const {id, ...createObj} = event
-    await prisma.subscriptionInterval.upsert({
-      where: {
-        id: event.id
-      },
-      update: {},
-      create: createObj
-    })
-  }
 
   await prisma.$disconnect()
 }

--- a/libs/consent/api/__tests__/prisma/seed.ts
+++ b/libs/consent/api/__tests__/prisma/seed.ts
@@ -1,0 +1,248 @@
+import {PaymentPeriodicity, PrismaClient, SubscriptionEvent} from '@prisma/client'
+import {seed as rootSeed} from '../../../../api/prisma/seed'
+import {hashPassword} from '../../../../api/src/lib/db/user'
+
+async function seed() {
+  const prisma = new PrismaClient()
+  await prisma.$connect()
+
+  const [adminUserRole, editorUserRole] = await rootSeed(prisma)
+
+  if (!adminUserRole || !editorUserRole) {
+    throw new Error('@wepublish/api seeding has not been done')
+  }
+
+  const dev = await prisma.user.upsert({
+    where: {
+      email: 'dev@wepublish.ch'
+    },
+    update: {},
+    create: {
+      email: 'dev@wepublish.ch',
+      emailVerifiedAt: new Date(),
+      name: 'Dev User',
+      active: true,
+      roleIDs: [adminUserRole.id],
+      password: await hashPassword('123')
+    }
+  })
+
+  const editor = await prisma.user.upsert({
+    where: {
+      email: 'editor@wepublish.ch'
+    },
+    update: {},
+    create: {
+      email: 'editor@wepublish.ch',
+      emailVerifiedAt: new Date(),
+      name: 'Editor User',
+      active: true,
+      roleIDs: [editorUserRole.id],
+      password: await hashPassword('123')
+    }
+  })
+
+  const mailTemplates = []
+  for (let i = 0; i < 10; i++) {
+    const template = await prisma.mailTemplate.upsert({
+      where: {
+        externalMailTemplateId: `sample-slug-${i}`
+      },
+      update: {},
+      create: {
+        name: `sample-template-${i}`,
+        description: `sample-template-description-${i}`,
+        externalMailTemplateId: `sample-slug-${i}`,
+        remoteMissing: false
+      }
+    })
+    mailTemplates.push(template)
+  }
+
+  const paymentMethod = await prisma.paymentMethod.upsert({
+    where: {
+      id: '1'
+    },
+    update: {},
+    create: {
+      name: 'Shiny Rocks',
+      slug: 'shiny-rocks',
+      description: 'Payment by transaction of a handful of shiny rocks',
+      paymentProviderID: 'stripe_checkout',
+      active: true
+    }
+  })
+
+  const memberPlan = await prisma.memberPlan.upsert({
+    where: {
+      slug: 'test-plan'
+    },
+    update: {},
+    create: {
+      name: 'Test Plan',
+      slug: 'test-plan',
+      tags: [],
+      description: {},
+      active: true,
+      amountPerMonthMin: 1
+    }
+  })
+
+  await prisma.subscription.upsert({
+    where: {
+      id: '1'
+    },
+    update: {},
+    create: {
+      id: '1',
+      paymentPeriodicity: PaymentPeriodicity.biannual,
+      paymentMethod: {connect: {id: paymentMethod.id}},
+      memberPlan: {connect: {id: memberPlan.id}},
+      monthlyAmount: 3,
+      autoRenew: true,
+      startsAt: new Date().toISOString(),
+      user: {connect: {id: editor.id}}
+    }
+  })
+
+  await prisma.subscription.upsert({
+    where: {
+      id: '2'
+    },
+    update: {},
+    create: {
+      id: '2',
+      paymentPeriodicity: PaymentPeriodicity.biannual,
+      paymentMethod: {connect: {id: paymentMethod.id}},
+      memberPlan: {connect: {id: memberPlan.id}},
+      monthlyAmount: 3,
+      autoRenew: false,
+      startsAt: new Date().toISOString(),
+      user: {connect: {id: dev.id}}
+    }
+  })
+
+  await prisma.availablePaymentMethod.upsert({
+    where: {
+      id: '1'
+    },
+    update: {},
+    create: {
+      paymentMethodIDs: [],
+      paymentPeriodicities: [PaymentPeriodicity.monthly],
+      forceAutoRenewal: false,
+      MemberPlan: {connect: {id: memberPlan.id}}
+    }
+  })
+
+  const flow1 = await prisma.subscriptionFlow.upsert({
+    where: {
+      id: '4a5c51b4-9499-45e4-82ea-b01c990ad87d'
+    },
+    update: {},
+    create: {
+      default: false,
+      memberPlan: {connect: {id: memberPlan.id}},
+      paymentMethods: {connect: [{id: paymentMethod.id}]},
+      periodicities: [PaymentPeriodicity.monthly, PaymentPeriodicity.yearly],
+      autoRenewal: [true]
+    }
+  })
+
+  const flow2 = await prisma.subscriptionFlow.upsert({
+    where: {
+      id: 'a0031cb7-e5e9-4008-9973-3c4d6bf40601'
+    },
+    update: {},
+    create: {
+      default: false,
+      memberPlan: {connect: {id: memberPlan.id}},
+      paymentMethods: {connect: [{id: paymentMethod.id}]},
+      periodicities: [PaymentPeriodicity.monthly, PaymentPeriodicity.yearly],
+      autoRenewal: [false]
+    }
+  })
+
+  const subscriptionFlows = [flow1, flow2]
+
+  const events = [
+    {
+      id: '847448f2-9985-469a-bfc5-7f8b957c67af',
+      event: SubscriptionEvent.DEACTIVATION_UNPAID,
+      daysAwayFromEnding: 10,
+      mailTemplate: {connect: {id: mailTemplates[8].id}},
+      subscriptionFlow: {connect: {id: subscriptionFlows[0].id}}
+    },
+    {
+      id: 'e8ba6158-fbfd-4d36-aa78-fd608f666232',
+      event: SubscriptionEvent.DEACTIVATION_BY_USER,
+      daysAwayFromEnding: null,
+      mailTemplate: {connect: {id: mailTemplates[9].id}},
+      subscriptionFlow: {connect: {id: subscriptionFlows[0].id}}
+    },
+    {
+      id: '96c35c14-9897-48f2-9484-1919b2f8a2a9',
+      event: SubscriptionEvent.CUSTOM,
+      daysAwayFromEnding: -6,
+      mailTemplate: {connect: {id: mailTemplates[1].id}},
+      subscriptionFlow: {connect: {id: subscriptionFlows[0].id}}
+    },
+    {
+      id: 'fbae3149-3018-454c-908d-685c83246540',
+      event: SubscriptionEvent.INVOICE_CREATION,
+      daysAwayFromEnding: -30,
+      mailTemplate: {connect: {id: mailTemplates[2].id}},
+      subscriptionFlow: {connect: {id: subscriptionFlows[0].id}}
+    },
+    {
+      id: 'eee0ff57-4e3c-4d73-b158-de0ae979e9a7',
+      event: SubscriptionEvent.SUBSCRIBE,
+      daysAwayFromEnding: null,
+      mailTemplate: {connect: {id: mailTemplates[3].id}},
+      subscriptionFlow: {connect: {id: subscriptionFlows[1].id}}
+    },
+    {
+      id: '82f8b2a0-38e8-4b9f-9996-9beff5ed195f',
+      event: SubscriptionEvent.RENEWAL_SUCCESS,
+      daysAwayFromEnding: null,
+      mailTemplate: {connect: {id: mailTemplates[4].id}},
+      subscriptionFlow: {connect: {id: subscriptionFlows[1].id}}
+    },
+    {
+      id: '1c1b5f7a-c49d-4734-beef-a38477f38e13',
+      event: SubscriptionEvent.RENEWAL_FAILED,
+      daysAwayFromEnding: null,
+      mailTemplate: {connect: {id: mailTemplates[5].id}},
+      subscriptionFlow: {connect: {id: subscriptionFlows[1].id}}
+    },
+    {
+      id: 'b23386cf-eb10-453d-8bc7-586caad230c7',
+      event: SubscriptionEvent.INVOICE_CREATION,
+      daysAwayFromEnding: -30,
+      mailTemplate: {connect: {id: mailTemplates[6].id}},
+      subscriptionFlow: {connect: {id: subscriptionFlows[1].id}}
+    },
+    {
+      id: 'f2b663e5-ac95-4d89-8b08-ca3fb470362a',
+      event: SubscriptionEvent.DEACTIVATION_UNPAID,
+      daysAwayFromEnding: 10,
+      mailTemplate: {connect: {id: mailTemplates[7].id}},
+      subscriptionFlow: {connect: {id: subscriptionFlows[1].id}}
+    }
+  ]
+
+  for (const event of events) {
+    const {id, ...createObj} = event
+    await prisma.subscriptionInterval.upsert({
+      where: {
+        id: event.id
+      },
+      update: {},
+      create: createObj
+    })
+  }
+
+  await prisma.$disconnect()
+}
+
+seed()

--- a/libs/consent/api/package.json
+++ b/libs/consent/api/package.json
@@ -1,3 +1,6 @@
 {
-  "name": "@wepublish/consent/api"
+  "prisma": {
+    "schema": "../../api/prisma/schema.prisma",
+    "seed": "npx tsx __tests__/prisma/seed.ts"
+  }
 }

--- a/libs/consent/api/setup-database.js
+++ b/libs/consent/api/setup-database.js
@@ -6,5 +6,7 @@ export default async () => {
   process.env.DATABASE_URL = databaseUrl
   process.env.TZ = 'UTC'
 
-  await execa(`npx`, ['prisma', 'migrate', 'deploy'])
+  await execa(`npx`, ['prisma', 'migrate', 'deploy'], {
+    cwd: __dirname
+  })
 }

--- a/libs/consent/api/setup-database.js
+++ b/libs/consent/api/setup-database.js
@@ -1,8 +1,8 @@
 import execa from 'execa'
-import {displayName} from './jest.config'
+import config from './jest.config'
 
 export default async () => {
-  const databaseUrl = `postgresql://postgres@localhost:5432/${displayName}?schema=public`
+  const databaseUrl = `postgresql://postgres@localhost:5432/${config.displayName}?schema=public`
   process.env.DATABASE_URL = databaseUrl
   process.env.TZ = 'UTC'
 

--- a/libs/consent/api/src/lib/consent/consent.model.ts
+++ b/libs/consent/api/src/lib/consent/consent.model.ts
@@ -1,4 +1,4 @@
-import {Field, ObjectType, InputType} from '@nestjs/graphql'
+import {Field, ObjectType, InputType, ArgsType, PartialType} from '@nestjs/graphql'
 
 @ObjectType()
 export class Consent {
@@ -21,8 +21,8 @@ export class Consent {
   defaultValue!: boolean
 }
 
-@InputType()
-export class ConsentInput {
+@ArgsType()
+export class CreateConsentInput {
   @Field()
   name!: string
 
@@ -31,6 +31,12 @@ export class ConsentInput {
 
   @Field()
   defaultValue!: boolean
+}
+
+@ArgsType()
+export class UpdateConsentInput extends PartialType(CreateConsentInput, ArgsType) {
+  @Field()
+  id!: string
 }
 
 @InputType()

--- a/libs/consent/api/src/lib/consent/consent.resolver.spec.ts
+++ b/libs/consent/api/src/lib/consent/consent.resolver.spec.ts
@@ -39,8 +39,8 @@ const consentQuery = `
 `
 
 const createConsentMutation = `
-  mutation createConsent($consent: ConsentInput!) {
-    createConsent(consent: $consent) {
+  mutation createConsent($name: String!, $slug: String!, $defaultValue: Boolean!) {
+    createConsent(name: $name, slug: $slug, defaultValue: $defaultValue) {
       id
       createdAt
       modifiedAt
@@ -52,8 +52,8 @@ const createConsentMutation = `
 `
 
 const updateConsentMutation = `
-  mutation updateConsent($id: String!, $consent: ConsentInput!) {
-    updateConsent(id: $id, consent: $consent) {
+  mutation updateConsent($id: String!, $name: String, $slug: String, $defaultValue: Boolean) {
+    updateConsent(id: $id, name: $name, slug: $slug, defaultValue: $defaultValue) {
       id
       createdAt
       modifiedAt
@@ -134,9 +134,7 @@ describe('ConsentResolver', () => {
       .post('/')
       .send({
         query: createConsentMutation,
-        variables: {
-          consent: toCreate
-        }
+        variables: toCreate
       })
       .set('Accept', 'application/json')
       .expect(200)
@@ -165,7 +163,7 @@ describe('ConsentResolver', () => {
         query: updateConsentMutation,
         variables: {
           id: idToUpdate,
-          consent: toUpdate
+          ...toUpdate
         }
       })
       .set('Accept', 'application/json')

--- a/libs/consent/api/src/lib/consent/consent.resolver.ts
+++ b/libs/consent/api/src/lib/consent/consent.resolver.ts
@@ -1,20 +1,17 @@
 import {Args, Mutation, Query, Resolver} from '@nestjs/graphql'
 import {
   CanCreateConsent,
-  CanUpdateConsent,
   CanDeleteConsent,
+  CanUpdateConsent,
   Permissions
 } from '@wepublish/permissions/api'
-import {Consent, ConsentInput, ConsentFilter} from './consent.model'
+import {Consent, ConsentFilter, CreateConsentInput, UpdateConsentInput} from './consent.model'
 import {ConsentService} from './consent.service'
 
 @Resolver()
 export class ConsentResolver {
   constructor(private consents: ConsentService) {}
 
-  /*
-  Queries
- */
   @Query(returns => [Consent], {
     name: 'consents',
     description: `
@@ -35,9 +32,6 @@ export class ConsentResolver {
     return this.consents.consent(id)
   }
 
-  /*
-  Mutations
- */
   @Mutation(returns => Consent, {
     name: 'createConsent',
     description: `
@@ -45,7 +39,7 @@ export class ConsentResolver {
     `
   })
   @Permissions(CanCreateConsent)
-  createConsent(@Args('consent') consent: ConsentInput) {
+  createConsent(@Args() consent: CreateConsentInput) {
     return this.consents.createConsent(consent)
   }
 
@@ -56,8 +50,8 @@ export class ConsentResolver {
     `
   })
   @Permissions(CanUpdateConsent)
-  updateConsent(@Args('id') id: string, @Args('consent') consent: ConsentInput) {
-    return this.consents.updateConsent({id, consent})
+  updateConsent(@Args() consent: UpdateConsentInput) {
+    return this.consents.updateConsent(consent)
   }
 
   @Mutation(returns => Consent, {

--- a/libs/consent/api/src/lib/consent/consent.service.spec.ts
+++ b/libs/consent/api/src/lib/consent/consent.service.spec.ts
@@ -109,7 +109,7 @@ describe('ConsentService', () => {
       defaultValue: false
     }
 
-    const result = await service.updateConsent({id: idToUpdate, consent})
+    const result = await service.updateConsent({id: idToUpdate, ...consent})
     expect(result).toMatchObject([
       {
         id: idToUpdate,

--- a/libs/consent/api/src/lib/consent/consent.service.ts
+++ b/libs/consent/api/src/lib/consent/consent.service.ts
@@ -1,14 +1,11 @@
-import {Injectable} from '@nestjs/common'
+import {Injectable, NotFoundException} from '@nestjs/common'
 import {PrismaClient} from '@prisma/client'
-import {Consent, ConsentInput, ConsentFilter} from './consent.model'
+import {Consent, ConsentFilter, CreateConsentInput, UpdateConsentInput} from './consent.model'
 
 @Injectable()
 export class ConsentService {
   constructor(private prisma: PrismaClient) {}
 
-  /*
-  Queries
- */
   async consentList(filter?: ConsentFilter): Promise<Consent[]> {
     const data = await this.prisma.consent.findMany({
       where: {
@@ -18,6 +15,7 @@ export class ConsentService {
         createdAt: 'desc'
       }
     })
+
     return data
   }
 
@@ -29,27 +27,24 @@ export class ConsentService {
     })
 
     if (!data) {
-      throw Error(`Consent with id ${id} not found`)
+      throw new NotFoundException(`Consent with id ${id} not found`)
     }
 
     return data
   }
 
-  /*
-  Mutations
- */
-  async createConsent(consent: ConsentInput): Promise<Consent> {
-    const created = await this.prisma.consent.create({data: consent})
-    return created
+  async createConsent(consent: CreateConsentInput): Promise<Consent> {
+    return await this.prisma.consent.create({data: consent})
   }
 
-  async updateConsent({id, consent}: {id: string; consent: ConsentInput}): Promise<Consent> {
+  async updateConsent({id, ...consent}: UpdateConsentInput): Promise<Consent> {
     const updated = await this.prisma.consent.update({
       where: {id},
       data: {
         ...consent
       }
     })
+
     return updated
   }
 

--- a/libs/consent/api/src/lib/user-consent/user-consent.model.ts
+++ b/libs/consent/api/src/lib/user-consent/user-consent.model.ts
@@ -1,7 +1,7 @@
-import {Field, ObjectType, InputType} from '@nestjs/graphql'
-import {Consent} from '../consent/consent.model'
-import {User} from '@wepublish/user/api'
+import {ArgsType, Field, ObjectType} from '@nestjs/graphql'
 import {User as UserType} from '@prisma/client'
+import {User} from '@wepublish/user/api'
+import {Consent} from '../consent/consent.model'
 
 @ObjectType()
 export class UserConsent {
@@ -24,7 +24,7 @@ export class UserConsent {
   value!: boolean
 }
 
-@InputType()
+@ArgsType()
 export class UserConsentInput {
   @Field()
   consentId!: string
@@ -36,13 +36,7 @@ export class UserConsentInput {
   value!: boolean
 }
 
-@InputType()
-export class UpdateUserConsentInput {
-  @Field()
-  value!: boolean
-}
-
-@InputType()
+@ArgsType()
 export class UserConsentFilter {
   @Field({nullable: true})
   name?: string

--- a/libs/consent/api/src/lib/user-consent/user-consent.resolver.spec.ts
+++ b/libs/consent/api/src/lib/user-consent/user-consent.resolver.spec.ts
@@ -1,14 +1,14 @@
-import {Test, TestingModule} from '@nestjs/testing'
+import {ApolloDriver, ApolloDriverConfig} from '@nestjs/apollo'
 import {INestApplication, Module} from '@nestjs/common'
-import request from 'supertest'
 import {GraphQLModule} from '@nestjs/graphql'
-import {ApolloDriverConfig, ApolloDriver} from '@nestjs/apollo'
-import {PrismaClient, Prisma, UserConsent} from '@prisma/client'
+import {Test, TestingModule} from '@nestjs/testing'
+import {Prisma, PrismaClient, UserConsent} from '@prisma/client'
+import {AuthenticationGuard, AuthenticationModule} from '@wepublish/authentication/api'
 import {PrismaModule} from '@wepublish/nest-modules'
+import request from 'supertest'
+import {generateRandomString} from '../consent/consent.resolver.spec'
 import {UserConsentResolver} from './user-consent.resolver'
 import {UserConsentService} from './user-consent.service'
-import {AuthenticationModule, AuthenticationGuard} from '@wepublish/authentication/api'
-import {generateRandomString} from '../consent/consent.resolver.spec'
 
 @Module({
   imports: [
@@ -48,8 +48,8 @@ const userConsentQuery = `
 `
 
 const createUserConsentMutation = `
-  mutation createUserConsent($userConsent: UserConsentInput!) {
-    createUserConsent(userConsent: $userConsent) {
+  mutation createUserConsent($consentId: String!, $userId: String!, $value: Boolean!) {
+    createUserConsent(consentId: $consentId, userId: $userId, value: $value) {
       id
       value
     }
@@ -57,8 +57,8 @@ const createUserConsentMutation = `
 `
 
 const updateUserConsentMutation = `
-  mutation updateUserConsent($id: String!, $userConsent: UpdateUserConsentInput!) {
-    updateUserConsent(id: $id, userConsent: $userConsent) {
+  mutation updateUserConsent($id: String!, $value: Boolean!) {
+    updateUserConsent(id: $id, value: $value) {
       id
       value
       createdAt
@@ -203,11 +203,9 @@ describe('UserConsentResolver', () => {
       .send({
         query: createUserConsentMutation,
         variables: {
-          userConsent: {
-            consentId: createdConsent.id,
-            userId: createdUser.id,
-            value: true
-          }
+          consentId: createdConsent.id,
+          userId: createdUser.id,
+          value: true
         }
       })
       .expect(200)
@@ -229,9 +227,7 @@ describe('UserConsentResolver', () => {
         query: updateUserConsentMutation,
         variables: {
           id: idToUpdate,
-          userConsent: {
-            value: false
-          }
+          value: false
         }
       })
       .expect(200)
@@ -271,9 +267,7 @@ describe('UserConsentResolver', () => {
         query: updateUserConsentMutation,
         variables: {
           id: idToUpdate,
-          userConsent: {
-            value: false
-          }
+          value: false
         }
       })
       .expect(200)

--- a/libs/consent/api/src/lib/user-consent/user-consent.service.spec.ts
+++ b/libs/consent/api/src/lib/user-consent/user-consent.service.spec.ts
@@ -168,9 +168,7 @@ describe('UserConsentService', () => {
       value: true
     }
 
-    const user = {user: {roleIDs: ['admin']}} as UserSession
-
-    const result = await service.createUserConsent(userConsent, user)
+    const result = await service.createUserConsent(userConsent)
     expect(result).toMatchSnapshot()
     expect(mockFunction.mock.calls[0][0]).toMatchSnapshot()
   })
@@ -192,14 +190,11 @@ describe('UserConsentService', () => {
     ])
 
     const mockFunction = jest.spyOn(prisma.userConsent, 'update').mockReturnValue(mockValue as any)
-
-    const userConsent = {
-      value: false
-    }
+    const userConsent = false
 
     const user = {user: {roleIDs: ['admin']}} as UserSession
 
-    const result = await service.updateUserConsent({id: idToUpdate, userConsent, user})
+    const result = await service.updateUserConsent(idToUpdate, userConsent, user)
     expect(result).toMatchObject([
       {
         id: idToUpdate,

--- a/libs/consent/editor/src/lib/consent-create-view.tsx
+++ b/libs/consent/editor/src/lib/consent-create-view.tsx
@@ -5,9 +5,9 @@ import {useTranslation} from 'react-i18next'
 import {useNavigate} from 'react-router-dom'
 import {Form, Message, Schema, toaster} from 'rsuite'
 
-import {ModelTitle} from '@wepublish/ui/editor'
 import {ConsentForm} from './consent-form'
 import {getApiClientV2} from '../apiClientv2'
+import {SingleViewTitle} from '@wepublish/ui/editor'
 
 const onErrorToast = (error: ApolloError, slug?: string) => {
   if (error.message.includes('Unique constraint')) {
@@ -35,7 +35,7 @@ export const ConsentCreateView = () => {
     name: '',
     slug: '',
     defaultValue: true
-  } as MutationCreateConsentArgs['consent'])
+  } as MutationCreateConsentArgs)
 
   const [shouldClose, setShouldClose] = useState(false)
 
@@ -58,9 +58,7 @@ export const ConsentCreateView = () => {
 
   const onSubmit = () => {
     createConsent({
-      variables: {
-        consent
-      }
+      variables: consent
     })
   }
 
@@ -78,7 +76,7 @@ export const ConsentCreateView = () => {
       model={validationModel}
       disabled={loading}
       onSubmit={validationPassed => validationPassed && onSubmit()}>
-      <ModelTitle
+      <SingleViewTitle
         loading={loading}
         title={t('consents.titleCreate')}
         loadingTitle={t('consents.titleCreate')}

--- a/libs/consent/editor/src/lib/consent-edit-view.tsx
+++ b/libs/consent/editor/src/lib/consent-edit-view.tsx
@@ -1,6 +1,8 @@
 import {ApolloError} from '@apollo/client'
 import {stripTypename} from '@wepublish/editor/api'
 import {
+  FullConsentFragment,
+  MutationCreateConsentArgs,
   MutationUpdateConsentArgs,
   useConsentQuery,
   useUpdateConsentMutation
@@ -10,11 +12,11 @@ import {useTranslation} from 'react-i18next'
 import {useNavigate, useParams} from 'react-router-dom'
 import {Form, Message, Schema, toaster} from 'rsuite'
 
-import {ModelTitle} from '@wepublish/ui/editor'
 import {ConsentForm} from './consent-form'
 import {getApiClientV2} from '../apiClientv2'
+import {SingleViewTitle} from '@wepublish/ui/editor'
 
-const mapApiDataToInput = (consent: any): MutationUpdateConsentArgs['consent'] => ({
+const mapApiDataToInput = (consent: FullConsentFragment): MutationUpdateConsentArgs => ({
   ...stripTypename(consent),
   name: consent.name,
   slug: consent.slug,
@@ -46,7 +48,7 @@ export const ConsentEditView = () => {
   }
 
   const closePath = '/consents'
-  const [consent, setConsent] = useState({
+  const [consent, setConsent] = useState<MutationCreateConsentArgs | MutationUpdateConsentArgs>({
     defaultValue: true,
     name: '',
     slug: ''
@@ -69,14 +71,16 @@ export const ConsentEditView = () => {
 
   const [updateConsent, {loading: updateLoading}] = useUpdateConsentMutation({
     client,
-    onError: error => onErrorToast(error, consent.slug),
+    onError: error => onErrorToast(error, consent.slug ?? ''),
     onCompleted: data => {
       if (shouldClose) {
         navigate(closePath)
       }
+
       if (data.updateConsent) {
         setConsent(mapApiDataToInput(data.updateConsent))
       }
+
       toaster.push(
         <Message type="success" showIcon closable duration={3000}>
           {t('toast.updatedSuccess')}
@@ -89,11 +93,9 @@ export const ConsentEditView = () => {
     updateConsent({
       variables: {
         id: consentId,
-        consent: {
-          name: consent.name,
-          slug: consent.slug,
-          defaultValue: consent.defaultValue
-        }
+        name: consent.name,
+        slug: consent.slug,
+        defaultValue: consent.defaultValue
       }
     })
   }
@@ -114,7 +116,7 @@ export const ConsentEditView = () => {
       model={validationModel}
       disabled={loading}
       onSubmit={validationPassed => validationPassed && onSubmit()}>
-      <ModelTitle
+      <SingleViewTitle
         loading={loading}
         title={t('consents.titleEdit')}
         loadingTitle={t('consents.titleEdit')}

--- a/libs/consent/editor/src/lib/consent-form.tsx
+++ b/libs/consent/editor/src/lib/consent-form.tsx
@@ -13,7 +13,7 @@ const consentValues = [
   }
 ]
 
-type ConsentFormData = MutationCreateConsentArgs['consent'] | MutationUpdateConsentArgs['consent']
+type ConsentFormData = MutationCreateConsentArgs | MutationUpdateConsentArgs
 
 type ConsentFormProps = {
   create?: boolean
@@ -48,7 +48,7 @@ export const ConsentForm = ({consent, onChange, create}: ConsentFormProps) => {
         <Form.Group controlId="defaultValue">
           <Form.ControlLabel>{t('consents.defaultValueTitle')}</Form.ControlLabel>
           <Checkbox
-            checked={consent.defaultValue}
+            checked={!!consent.defaultValue}
             onChange={(_, checked) => {
               onChange({defaultValue: checked})
             }}>

--- a/libs/consent/editor/src/lib/user-consent-create-view.tsx
+++ b/libs/consent/editor/src/lib/user-consent-create-view.tsx
@@ -5,9 +5,9 @@ import {useTranslation} from 'react-i18next'
 import {useNavigate} from 'react-router-dom'
 import {Form, Message, Schema, toaster} from 'rsuite'
 
-import {ModelTitle} from '@wepublish/ui/editor'
 import {UserConsentForm} from './user-consent-form'
 import {getApiClientV2} from '../apiClientv2'
+import {SingleViewTitle} from '@wepublish/ui/editor'
 
 const onErrorToast = (error: ApolloError, slug?: string) => {
   if (error.message.includes('Unique constraint')) {
@@ -35,7 +35,7 @@ export const UserConsentCreateView = () => {
     consentId: '',
     userId: '',
     value: true
-  } as MutationCreateUserConsentArgs['userConsent'])
+  } as MutationCreateUserConsentArgs)
 
   const [shouldClose, setShouldClose] = useState(false)
 
@@ -58,9 +58,7 @@ export const UserConsentCreateView = () => {
 
   const onSubmit = () => {
     createUserConsent({
-      variables: {
-        userConsent
-      }
+      variables: userConsent
     })
   }
 
@@ -78,7 +76,7 @@ export const UserConsentCreateView = () => {
       model={validationModel}
       disabled={loading}
       onSubmit={validationPassed => validationPassed && onSubmit()}>
-      <ModelTitle
+      <SingleViewTitle
         loading={loading}
         title={t('userConsents.titleCreate')}
         loadingTitle={t('userConsents.titleCreate')}

--- a/libs/consent/editor/src/lib/user-consent-edit-view.tsx
+++ b/libs/consent/editor/src/lib/user-consent-edit-view.tsx
@@ -1,6 +1,7 @@
 import {ApolloError} from '@apollo/client'
 import {stripTypename} from '@wepublish/editor/api'
 import {
+  FullUserConsentFragment,
   MutationUpdateUserConsentArgs,
   useUpdateUserConsentMutation,
   useUserConsentQuery
@@ -10,11 +11,13 @@ import {useTranslation} from 'react-i18next'
 import {useNavigate, useParams} from 'react-router-dom'
 import {Form, Message, Schema, toaster} from 'rsuite'
 
-import {ModelTitle} from '@wepublish/ui/editor'
-import {UserConsentForm} from './user-consent-form'
+import {SingleViewTitle} from '@wepublish/ui/editor'
 import {getApiClientV2} from '../apiClientv2'
+import {UserConsentForm} from './user-consent-form'
 
-const mapApiDataToInput = (userConsent: any): MutationUpdateUserConsentArgs['userConsent'] => ({
+const mapApiDataToInput = (
+  userConsent: FullUserConsentFragment
+): MutationUpdateUserConsentArgs => ({
   ...stripTypename(userConsent),
   value: userConsent.value
 })
@@ -46,7 +49,7 @@ export const UserConsentEditView = () => {
   const closePath = '/userConsents'
   const [userConsent, setUserConsent] = useState({
     value: false
-  } as MutationUpdateUserConsentArgs['userConsent'])
+  } as MutationUpdateUserConsentArgs)
 
   const [shouldClose, setShouldClose] = useState<boolean>(false)
 
@@ -85,9 +88,7 @@ export const UserConsentEditView = () => {
     updateUserConsent({
       variables: {
         id: userConsentId,
-        userConsent: {
-          value: userConsent.value
-        }
+        value: userConsent.value
       }
     })
   }
@@ -106,7 +107,7 @@ export const UserConsentEditView = () => {
       model={validationModel}
       disabled={loading}
       onSubmit={validationPassed => validationPassed && onSubmit()}>
-      <ModelTitle
+      <SingleViewTitle
         loading={loading}
         title={t('userConsents.titleEdit')}
         loadingTitle={t('userConsents.titleEdit')}

--- a/libs/consent/editor/src/lib/user-consent-form.tsx
+++ b/libs/consent/editor/src/lib/user-consent-form.tsx
@@ -10,9 +10,7 @@ import {useTranslation} from 'react-i18next'
 import {Checkbox, Form, Loader, Message, Panel, SelectPicker, toaster} from 'rsuite'
 import {getApiClientV2} from '../apiClientv2'
 
-type UserConsentFormData = Partial<
-  MutationCreateUserConsentArgs['userConsent'] & MutationUpdateUserConsentArgs['userConsent']
->
+type UserConsentFormData = Partial<MutationCreateUserConsentArgs & MutationUpdateUserConsentArgs>
 
 type UserConsentFormProps = {
   isEdit?: boolean


### PR DESCRIPTION
Keeps the API cleaner & more generalized

Also added seeding to not utilize api-example seeding