### PR TITLE
fix(website): use PNG instead of fake WEBP as it breaks safari

### DIFF
--- a/libs/user/website/src/lib/personal-data-form/__snapshots__/personal-data-form-container.stories.spec.tsx.snap
+++ b/libs/user/website/src/lib/personal-data-form/__snapshots__/personal-data-form-container.stories.spec.tsx.snap
@@ -713,21 +713,21 @@ exports[`Personal Data Form Container should render DeleteImage 1`] = `
 +
 + fragment ImageURLs on Image {
 +   url
-+   bigURL: transformURL(input: {width: 800, output: WEBP, quality: 1})
-+   largeURL: transformURL(input: {width: 500, output: WEBP, quality: 1})
-+   mediumURL: transformURL(input: {width: 300, output: WEBP, quality: 1})
-+   smallURL: transformURL(input: {width: 200, output: WEBP, quality: 1})
++   bigURL: transformURL(input: {width: 800, output: PNG, quality: 1})
++   largeURL: transformURL(input: {width: 500, output: PNG, quality: 1})
++   mediumURL: transformURL(input: {width: 300, output: PNG, quality: 1})
++   smallURL: transformURL(input: {width: 200, output: PNG, quality: 1})
 +   squareBigURL: transformURL(
-+     input: {width: 800, height: 800, output: WEBP, quality: 1}
++     input: {width: 800, height: 800, output: PNG, quality: 1}
 +   )
 +   squareLargeURL: transformURL(
-+     input: {width: 500, height: 500, output: WEBP, quality: 1}
++     input: {width: 500, height: 500, output: PNG, quality: 1}
 +   )
 +   squareMediumURL: transformURL(
-+     input: {width: 300, height: 300, output: WEBP, quality: 1}
++     input: {width: 300, height: 300, output: PNG, quality: 1}
 +   )
 +   squareSmallURL: transformURL(
-+     input: {width: 200, height: 200, output: WEBP, quality: 1}
++     input: {width: 200, height: 200, output: PNG, quality: 1}
 +   )
 +   __typename
 + }

--- a/libs/website/api/src/lib/graphql.ts
+++ b/libs/website/api/src/lib/graphql.ts
@@ -1974,21 +1974,21 @@ export const FullOAuth2AccountFragmentDoc = gql`
 export const ImageUrLsFragmentDoc = gql`
     fragment ImageURLs on Image {
   url
-  bigURL: transformURL(input: {width: 800, output: WEBP, quality: 1})
-  largeURL: transformURL(input: {width: 500, output: WEBP, quality: 1})
-  mediumURL: transformURL(input: {width: 300, output: WEBP, quality: 1})
-  smallURL: transformURL(input: {width: 200, output: WEBP, quality: 1})
+  bigURL: transformURL(input: {width: 800, output: PNG, quality: 1})
+  largeURL: transformURL(input: {width: 500, output: PNG, quality: 1})
+  mediumURL: transformURL(input: {width: 300, output: PNG, quality: 1})
+  smallURL: transformURL(input: {width: 200, output: PNG, quality: 1})
   squareBigURL: transformURL(
-    input: {width: 800, height: 800, output: WEBP, quality: 1}
+    input: {width: 800, height: 800, output: PNG, quality: 1}
   )
   squareLargeURL: transformURL(
-    input: {width: 500, height: 500, output: WEBP, quality: 1}
+    input: {width: 500, height: 500, output: PNG, quality: 1}
   )
   squareMediumURL: transformURL(
-    input: {width: 300, height: 300, output: WEBP, quality: 1}
+    input: {width: 300, height: 300, output: PNG, quality: 1}
   )
   squareSmallURL: transformURL(
-    input: {width: 200, height: 200, output: WEBP, quality: 1}
+    input: {width: 200, height: 200, output: PNG, quality: 1}
   )
 }
     `;

--- a/libs/website/api/src/lib/schemas/image.graphql
+++ b/libs/website/api/src/lib/schemas/image.graphql
@@ -1,15 +1,15 @@
 fragment ImageURLs on Image {
   url
 
-  bigURL: transformURL(input: {width: 800, output: WEBP, quality: 1})
-  largeURL: transformURL(input: {width: 500, output: WEBP, quality: 1})
-  mediumURL: transformURL(input: {width: 300, output: WEBP, quality: 1})
-  smallURL: transformURL(input: {width: 200, output: WEBP, quality: 1})
+  bigURL: transformURL(input: {width: 800, output: PNG, quality: 1})
+  largeURL: transformURL(input: {width: 500, output: PNG, quality: 1})
+  mediumURL: transformURL(input: {width: 300, output: PNG, quality: 1})
+  smallURL: transformURL(input: {width: 200, output: PNG, quality: 1})
 
-  squareBigURL: transformURL(input: {width: 800, height: 800, output: WEBP, quality: 1})
-  squareLargeURL: transformURL(input: {width: 500, height: 500, output: WEBP, quality: 1})
-  squareMediumURL: transformURL(input: {width: 300, height: 300, output: WEBP, quality: 1})
-  squareSmallURL: transformURL(input: {width: 200, height: 200, output: WEBP, quality: 1})
+  squareBigURL: transformURL(input: {width: 800, height: 800, output: PNG, quality: 1})
+  squareLargeURL: transformURL(input: {width: 500, height: 500, output: PNG, quality: 1})
+  squareMediumURL: transformURL(input: {width: 300, height: 300, output: PNG, quality: 1})
+  squareSmallURL: transformURL(input: {width: 200, height: 200, output: PNG, quality: 1})
 }
 
 fragment FullImage on Image {

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "mapped-replacer": "^1.2.1",
         "matomo-tracker": "^3.0.0-beta.0",
         "nanoid": "^2.1.7",
-        "next": "~13.5.4",
+        "next": "~13.4.12",
         "node-cache": "^5.1.2",
         "node-fetch": "2.6.7",
         "openid-client": "^3.14.0",
@@ -16387,9 +16387,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "13.5.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.4.tgz",
-      "integrity": "sha512-LGegJkMvRNw90WWphGJ3RMHMVplYcOfRWf2Be3td3sUa+1AaxmsYyANsA+znrGCBjXJNi4XAQlSoEfUxs/4kIQ=="
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.19.tgz",
+      "integrity": "sha512-FsAT5x0jF2kkhNkKkukhsyYOrRqtSxrEhfliniIq0bwWbuXLgyt3Gv0Ml+b91XwjwArmuP7NxCiGd++GGKdNMQ=="
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "13.3.0",
@@ -16421,9 +16421,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "13.5.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.5.4.tgz",
-      "integrity": "sha512-Df8SHuXgF1p+aonBMcDPEsaahNo2TCwuie7VXED4FVyECvdXfRT9unapm54NssV9tF3OQFKBFOdlje4T43VO0w==",
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.19.tgz",
+      "integrity": "sha512-vv1qrjXeGbuF2mOkhkdxMDtv9np7W4mcBtaDnHU+yJG+bBwa6rYsYSCI/9Xm5+TuF5SbZbrWO6G1NfTh1TMjvQ==",
       "cpu": [
         "arm64"
       ],
@@ -16436,9 +16436,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "13.5.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.5.4.tgz",
-      "integrity": "sha512-siPuUwO45PnNRMeZnSa8n/Lye5ZX93IJom9wQRB5DEOdFrw0JjOMu1GINB8jAEdwa7Vdyn1oJ2xGNaQpdQQ9Pw==",
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.19.tgz",
+      "integrity": "sha512-jyzO6wwYhx6F+7gD8ddZfuqO4TtpJdw3wyOduR4fxTUCm3aLw7YmHGYNjS0xRSYGAkLpBkH1E0RcelyId6lNsw==",
       "cpu": [
         "x64"
       ],
@@ -16451,9 +16451,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "13.5.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.5.4.tgz",
-      "integrity": "sha512-l/k/fvRP/zmB2jkFMfefmFkyZbDkYW0mRM/LB+tH5u9pB98WsHXC0WvDHlGCYp3CH/jlkJPL7gN8nkTQVrQ/2w==",
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.19.tgz",
+      "integrity": "sha512-vdlnIlaAEh6H+G6HrKZB9c2zJKnpPVKnA6LBwjwT2BTjxI7e0Hx30+FoWCgi50e+YO49p6oPOtesP9mXDRiiUg==",
       "cpu": [
         "arm64"
       ],
@@ -16466,9 +16466,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "13.5.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.5.4.tgz",
-      "integrity": "sha512-YYGb7SlLkI+XqfQa8VPErljb7k9nUnhhRrVaOdfJNCaQnHBcvbT7cx/UjDQLdleJcfyg1Hkn5YSSIeVfjgmkTg==",
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.19.tgz",
+      "integrity": "sha512-aU0HkH2XPgxqrbNRBFb3si9Ahu/CpaR5RPmN2s9GiM9qJCiBBlZtRTiEca+DC+xRPyCThTtWYgxjWHgU7ZkyvA==",
       "cpu": [
         "arm64"
       ],
@@ -16481,9 +16481,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "13.5.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.5.4.tgz",
-      "integrity": "sha512-uE61vyUSClnCH18YHjA8tE1prr/PBFlBFhxBZis4XBRJoR+txAky5d7gGNUIbQ8sZZ7LVkSVgm/5Fc7mwXmRAg==",
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.19.tgz",
+      "integrity": "sha512-htwOEagMa/CXNykFFeAHHvMJeqZfNQEoQvHfsA4wgg5QqGNqD5soeCer4oGlCol6NGUxknrQO6VEustcv+Md+g==",
       "cpu": [
         "x64"
       ],
@@ -16496,9 +16496,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "13.5.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.5.4.tgz",
-      "integrity": "sha512-qVEKFYML/GvJSy9CfYqAdUexA6M5AklYcQCW+8JECmkQHGoPxCf04iMh7CPR7wkHyWWK+XLt4Ja7hhsPJtSnhg==",
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.19.tgz",
+      "integrity": "sha512-4Gj4vvtbK1JH8ApWTT214b3GwUh9EKKQjY41hH/t+u55Knxi/0wesMzwQRhppK6Ddalhu0TEttbiJ+wRcoEj5Q==",
       "cpu": [
         "x64"
       ],
@@ -16511,9 +16511,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "13.5.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.5.4.tgz",
-      "integrity": "sha512-mDSQfqxAlfpeZOLPxLymZkX0hYF3juN57W6vFHTvwKlnHfmh12Pt7hPIRLYIShk8uYRsKPtMTth/EzpwRI+u8w==",
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.19.tgz",
+      "integrity": "sha512-bUfDevQK4NsIAHXs3/JNgnvEY+LRyneDN788W2NYiRIIzmILjba7LaQTfihuFawZDhRtkYCv3JDC3B4TwnmRJw==",
       "cpu": [
         "arm64"
       ],
@@ -16526,9 +16526,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "13.5.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.5.4.tgz",
-      "integrity": "sha512-aoqAT2XIekIWoriwzOmGFAvTtVY5O7JjV21giozBTP5c6uZhpvTWRbmHXbmsjZqY4HnEZQRXWkSAppsIBweKqw==",
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.19.tgz",
+      "integrity": "sha512-Y5kikILFAr81LYIFaw6j/NrOtmiM4Sf3GtOc0pn50ez2GCkr+oejYuKGcwAwq3jiTKuzF6OF4iT2INPoxRycEA==",
       "cpu": [
         "ia32"
       ],
@@ -16541,9 +16541,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "13.5.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.5.4.tgz",
-      "integrity": "sha512-cyRvlAxwlddlqeB9xtPSfNSCRy8BOa4wtMo0IuI9P7Y0XT2qpDrpFKRyZ7kUngZis59mPVla5k8X1oOJ8RxDYg==",
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.19.tgz",
+      "integrity": "sha512-YzA78jBDXMYiINdPdJJwGgPNT3YqBNNGhsthsDoWHL9p24tEJn9ViQf/ZqTbwSpX/RrkPupLfuuTH2sf73JBAw==",
       "cpu": [
         "x64"
       ],
@@ -50779,34 +50779,35 @@
       "dev": true
     },
     "node_modules/next": {
-      "version": "13.5.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-13.5.4.tgz",
-      "integrity": "sha512-+93un5S779gho8y9ASQhb/bTkQF17FNQOtXLKAj3lsNgltEcF0C5PMLLncDmH+8X1EnJH1kbqAERa29nRXqhjA==",
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.4.19.tgz",
+      "integrity": "sha512-HuPSzzAbJ1T4BD8e0bs6B9C1kWQ6gv8ykZoRWs5AQoiIuqbGHHdQO7Ljuvg05Q0Z24E2ABozHe6FxDvI6HfyAw==",
       "dependencies": {
-        "@next/env": "13.5.4",
-        "@swc/helpers": "0.5.2",
+        "@next/env": "13.4.19",
+        "@swc/helpers": "0.5.1",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001406",
-        "postcss": "8.4.31",
+        "postcss": "8.4.14",
         "styled-jsx": "5.1.1",
-        "watchpack": "2.4.0"
+        "watchpack": "2.4.0",
+        "zod": "3.21.4"
       },
       "bin": {
         "next": "dist/bin/next"
       },
       "engines": {
-        "node": ">=16.14.0"
+        "node": ">=16.8.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "13.5.4",
-        "@next/swc-darwin-x64": "13.5.4",
-        "@next/swc-linux-arm64-gnu": "13.5.4",
-        "@next/swc-linux-arm64-musl": "13.5.4",
-        "@next/swc-linux-x64-gnu": "13.5.4",
-        "@next/swc-linux-x64-musl": "13.5.4",
-        "@next/swc-win32-arm64-msvc": "13.5.4",
-        "@next/swc-win32-ia32-msvc": "13.5.4",
-        "@next/swc-win32-x64-msvc": "13.5.4"
+        "@next/swc-darwin-arm64": "13.4.19",
+        "@next/swc-darwin-x64": "13.4.19",
+        "@next/swc-linux-arm64-gnu": "13.4.19",
+        "@next/swc-linux-arm64-musl": "13.4.19",
+        "@next/swc-linux-x64-gnu": "13.4.19",
+        "@next/swc-linux-x64-musl": "13.4.19",
+        "@next/swc-win32-arm64-msvc": "13.4.19",
+        "@next/swc-win32-ia32-msvc": "13.4.19",
+        "@next/swc-win32-x64-msvc": "13.4.19"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -50821,6 +50822,54 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next/node_modules/@swc/helpers": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.1.tgz",
+      "integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/next/node_modules/nanoid": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next/node_modules/postcss": {
+      "version": "8.4.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
+      "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.4",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/nice-try": {
@@ -54112,6 +54161,7 @@
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
       "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -54696,6 +54746,7 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
       "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -256,7 +256,7 @@
     "mapped-replacer": "^1.2.1",
     "matomo-tracker": "^3.0.0-beta.0",
     "nanoid": "^2.1.7",
-    "next": "~13.5.4",
+    "next": "~13.4.12",
     "node-cache": "^5.1.2",
     "node-fetch": "2.6.7",
     "openid-client": "^3.14.0",


### PR DESCRIPTION
The media server returns a PNG with a WEBP ending and not actually returning a PNG.
Unlike the other browsers, this breaks Safari in weird ways:

1. It gets insanely slow
2. It breaks the layout
