### PR TITLE
fix(dev): Make sure editor runs in npm run dev, do not run client websites by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test-all": "nx run-many --target=test --parallel=10 --runInBand",
     "test-backend": "nx run-many --target=test --parallel=10 --runInBand --exclude='*website*'",
     "test-website": "nx run-many --target=test --parallel=3 --runInBand --projects=*website*",
-    "watch": "npm run migrate && nx run-many -t serve --output-style stream",
+    "watch": "npm run migrate && nx run-many --target=serve --output-style=stream --projects=api-example,editor,website-example",
     "generate-api": "graphql-codegen -r dotenv/config --config codegen.yml",
     "changelog": "node -r dotenv/config ./node_modules/.bin/lerna-changelog",
     "publish": "lerna publish from-package --ignore-scripts --no-verify-access",


### PR DESCRIPTION
Problem was connected with concurrency/parallel option which limits to 3 by default. Instead of increasing the value, decided to not run all the websites for clients