### PR TITLE
feat(seeding): Ensure admin user while seeding

### DIFF
--- a/libs/api/prisma/run-seed.ts
+++ b/libs/api/prisma/run-seed.ts
@@ -2,6 +2,7 @@ import {PrismaClient} from '@prisma/client'
 import {seed as rootSeed} from './seed'
 import bcrypt from 'bcrypt'
 import {randomBytes} from 'crypto'
+import {DefaultBcryptHashCostFactor} from '../src/lib/db/common'
 
 const generateSecureRandomPassword = (length: number) => {
   const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._-'
@@ -18,6 +19,7 @@ const generateSecureRandomPassword = (length: number) => {
   }
   return password
 }
+
 export async function runSeed() {
   const prisma = new PrismaClient()
   await prisma.$connect()
@@ -27,47 +29,51 @@ export async function runSeed() {
     throw new Error('@wepublish/api seeding has not been done')
   }
 
-  const admin = await prisma.user.findUnique({
-    where: {
-      id: 'admin'
+  const ensureAdminUserWithSetPassword = async (password: string) => {
+    const id = 'admin'
+    const data = {
+      email: 'admin@wepublish.ch',
+      name: 'WePublish Admin',
+      active: true,
+      password: await bcrypt.hash(password, DefaultBcryptHashCostFactor),
+      roleIDs: [adminUserRole.id]
     }
-  })
-  if (!admin) {
-    const email = 'admin@wepublish.ch'
-    const overriddenPw = process.env.OVERRIDE_ADMIN_PW
-    let password = generateSecureRandomPassword(20)
-    if (overriddenPw) {
-      console.log(
-        '\x1b[31m\x1b[1m%s\x1b[0m',
-        `!!!!!!!!!!!!!!!!!! WARNING: UNSECURE PASSWORD IS OVERRIDDEN WITH ENV VARIABLE !!!!!!!!!!!!!!!!!! `
-      )
-      password = overriddenPw
-    }
-
-    console.log(
-      '\x1b[31m\x1b[1m%s\x1b[0m',
-      `Bootstrapping initial admin user ${email} with password: ${password}`
-    )
+    console.log('\x1b[31m\x1b[1m%s\x1b[0m', `Ensuring admin user`)
     await prisma.user.upsert({
-      where: {
-        id: 'admin'
+      where: {id},
+      update: {
+        ...data
       },
-      update: {},
       create: {
-        id: 'admin',
-        email,
+        id,
         emailVerifiedAt: new Date(),
-        name: 'Admin',
-        active: true,
-        roleIDs: [adminUserRole.id],
-        password: await bcrypt.hash(password, 11)
+        ...data
       }
     })
+  }
+
+  const ensureAdminUserWithGeneratedPassword = async () => {
+    const admin = await prisma.user.findUnique({where: {id: 'admin'}})
+    if (!admin) {
+      const password = generateSecureRandomPassword(20)
+      await ensureAdminUserWithSetPassword(password)
+      console.log(
+        '\x1b[31m\x1b[1m%s\x1b[0m',
+        `Bootstrapped initial admin user with password: ${password}`
+      )
+    } else {
+      console.log(
+        '\x1b[32m\x1b[1m%s\x1b[0m',
+        'Skipping bootstrapping of initial admin user because the user already exist...'
+      )
+    }
+  }
+
+  const setAdminPassword = process.env.OVERRIDE_ADMIN_PW
+  if (setAdminPassword) {
+    await ensureAdminUserWithSetPassword(setAdminPassword)
   } else {
-    console.log(
-      '\x1b[32m\x1b[1m%s\x1b[0m',
-      'Skipping bootstrapping of initial admin user because the user already exist...'
-    )
+    await ensureAdminUserWithGeneratedPassword()
   }
 
   await prisma.$disconnect()


### PR DESCRIPTION
Create admin user with generated password if not exists
Alternatively if OVERRIDE_ADMIN_PW passed set the password to the value