### PR TITLE
bugfix(tsri): Bring back teaser date

### DIFF
--- a/libs/block-content/website/src/lib/teaser/teaser.tsx
+++ b/libs/block-content/website/src/lib/teaser/teaser.tsx
@@ -276,6 +276,8 @@ export const TeaserMetadata = styled('div')`
   grid-area: authors;
 `
 
+export const TeaserDate = styled('time')``
+
 export const TeaserTime = styled('time')`
   font-weight: 400;
 `


### PR DESCRIPTION
@Itrulia Hey, I see your changes removed the `TeaserDate` and also used it in `tsri` website. 
Can you confirm this PR or fix it differently?