### PR TITLE
fix(website): firefox image block issues & fallback to blocking

### DIFF
--- a/apps/babanews/pages/[slug].tsx
+++ b/apps/babanews/pages/[slug].tsx
@@ -37,7 +37,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
         slug
       }
     })),
-    fallback: true
+    fallback: 'blocking'
   }
 }
 

--- a/apps/babanews/pages/a/[slug].tsx
+++ b/apps/babanews/pages/a/[slug].tsx
@@ -94,7 +94,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
         slug
       }
     })),
-    fallback: true
+    fallback: 'blocking'
   }
 }
 

--- a/apps/bajour/pages/[slug].tsx
+++ b/apps/bajour/pages/[slug].tsx
@@ -37,7 +37,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
         slug
       }
     })),
-    fallback: true
+    fallback: 'blocking'
   }
 }
 

--- a/apps/bajour/pages/a/[slug].tsx
+++ b/apps/bajour/pages/a/[slug].tsx
@@ -105,7 +105,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
         slug
       }
     })),
-    fallback: true
+    fallback: 'blocking'
   }
 }
 

--- a/apps/bajour/src/components/bajour/archive/archive-slider.tsx
+++ b/apps/bajour/src/components/bajour/archive/archive-slider.tsx
@@ -5,11 +5,12 @@ import {
   ApiV1,
   BuilderTeaserGridBlockProps,
   selectTeaserDate,
-  selectTeaserImage,
   useWebsiteBuilder
 } from '@wepublish/website'
 import {useKeenSlider} from 'keen-slider/react'
 import {DOMAttributes, useState} from 'react'
+
+import {selectBajourTeaserImage} from '../../website-builder-overwrites/blocks/select-teaser'
 
 type ArchiveSliderProps = {
   teasers: BuilderTeaserGridBlockProps['teasers']
@@ -142,7 +143,7 @@ const ArchiveSlide = ({teaser, onClick, isCurrent}: ArchiveSlideProps) => {
     date
   } = useWebsiteBuilder()
 
-  const img = teaser && selectTeaserImage(teaser)
+  const img = teaser && selectBajourTeaserImage(teaser)
   const publishDate = teaser && selectTeaserDate(teaser)
 
   return (

--- a/apps/bajour/src/components/bajour/archive/archive.tsx
+++ b/apps/bajour/src/components/bajour/archive/archive.tsx
@@ -3,8 +3,6 @@ import {
   ApiV2,
   BuilderTeaserGridBlockProps,
   selectTeaserAuthors,
-  selectTeaserLead,
-  selectTeaserTitle,
   selectTeaserUrl,
   useWebsiteBuilder
 } from '@wepublish/website'
@@ -13,6 +11,10 @@ import getConfig from 'next/config'
 import {useState} from 'react'
 
 import {ReactComponent as Logo} from '../../../logo.svg'
+import {
+  selectBajourTeaserLead,
+  selectBajourTeaserTitle
+} from '../../website-builder-overwrites/blocks/select-teaser'
 import {ArchiveSlider} from './archive-slider'
 
 export const ArchiveWrapper = styled('div')``
@@ -196,8 +198,8 @@ const Archive = ({teasers}: BuilderTeaserGridBlockProps) => {
   const {data} = ApiV2.useStatsQuery()
   const [currentTeaser, setCurrentTeaser] = useState(teasers[2])
 
-  const title = currentTeaser && selectTeaserTitle(currentTeaser)
-  const lead = currentTeaser && selectTeaserLead(currentTeaser)
+  const title = currentTeaser && selectBajourTeaserTitle(currentTeaser)
+  const lead = currentTeaser && selectBajourTeaserLead(currentTeaser)
   const href = (currentTeaser && selectTeaserUrl(currentTeaser)) ?? ''
   const authors = currentTeaser && selectTeaserAuthors(currentTeaser)
 

--- a/apps/bajour/src/components/bajour/best-of-wepublish/best-of-wepublish-teaser.tsx
+++ b/apps/bajour/src/components/bajour/best-of-wepublish/best-of-wepublish-teaser.tsx
@@ -3,12 +3,15 @@ import {NextWepublishLink} from '@wepublish/utils/website'
 import {
   ApiV1,
   BuilderTeaserProps,
-  selectTeaserImage,
-  selectTeaserTitle,
   selectTeaserUrl,
   TeaserWrapper,
   useWebsiteBuilder
 } from '@wepublish/website'
+
+import {
+  selectBajourTeaserImage,
+  selectBajourTeaserTitle
+} from '../../website-builder-overwrites/blocks/select-teaser'
 
 type BestOfWePublishTeaserProps = BuilderTeaserProps & {
   teaser: ApiV1.PeerArticleTeaser
@@ -108,9 +111,9 @@ export const BestOfWePublishTeaser = ({teaser, alignment}: BestOfWePublishTeaser
     elements: {Image}
   } = useWebsiteBuilder()
 
-  const title = teaser && selectTeaserTitle(teaser)
+  const title = teaser && selectBajourTeaserTitle(teaser)
   const href = (teaser && selectTeaserUrl(teaser)) ?? ''
-  const image = teaser && selectTeaserImage(teaser)
+  const image = teaser && selectBajourTeaserImage(teaser)
   const peerName = teaser.peer?.name
   const peerLogo = teaser.peer?.profile?.logo
 

--- a/apps/bajour/src/components/website-builder-overwrites/blocks/select-teaser.tsx
+++ b/apps/bajour/src/components/website-builder-overwrites/blocks/select-teaser.tsx
@@ -1,0 +1,59 @@
+import {
+  ApiV1,
+  isImageBlock,
+  isTitleBlock,
+  selectTeaserImage,
+  selectTeaserLead,
+  selectTeaserTitle
+} from '@wepublish/website'
+
+export const selectBajourTeaserTitle = (teaser: ApiV1.Teaser) => {
+  switch (teaser.__typename) {
+    case 'PageTeaser': {
+      const titleBlock = teaser.page?.blocks.find(isTitleBlock)
+      return teaser.title || teaser.page?.title || titleBlock?.title
+    }
+
+    case 'PeerArticleTeaser':
+    case 'ArticleTeaser': {
+      const titleBlock = teaser.article?.blocks.find(isTitleBlock)
+      return teaser.title || teaser.article?.title || titleBlock?.title
+    }
+  }
+
+  return selectTeaserTitle(teaser)
+}
+
+export const selectBajourTeaserLead = (teaser: ApiV1.Teaser) => {
+  switch (teaser.__typename) {
+    case 'PageTeaser': {
+      const titleBlock = teaser.page?.blocks.find(isTitleBlock)
+      return teaser.lead || teaser.page?.description || titleBlock?.lead
+    }
+
+    case 'PeerArticleTeaser':
+    case 'ArticleTeaser': {
+      const titleBlock = teaser.article?.blocks.find(isTitleBlock)
+      return teaser.lead || teaser.article?.lead || titleBlock?.lead
+    }
+  }
+
+  return selectTeaserLead(teaser)
+}
+
+export const selectBajourTeaserImage = (teaser: ApiV1.Teaser) => {
+  switch (teaser.__typename) {
+    case 'PageTeaser': {
+      const imageBlock = teaser.page?.blocks.find(isImageBlock)
+      return teaser.image ?? imageBlock?.image ?? teaser?.page?.image
+    }
+
+    case 'PeerArticleTeaser':
+    case 'ArticleTeaser': {
+      const imageBlock = teaser.article?.blocks.find(isImageBlock)
+      return teaser.image ?? imageBlock?.image ?? teaser?.article?.image
+    }
+  }
+
+  return selectTeaserImage(teaser)
+}

--- a/apps/bajour/src/components/website-builder-overwrites/blocks/teaser-overwrite.tsx
+++ b/apps/bajour/src/components/website-builder-overwrites/blocks/teaser-overwrite.tsx
@@ -3,14 +3,16 @@ import {
   hasBlockStyle,
   selectTeaserAuthors,
   selectTeaserDate,
-  selectTeaserImage,
-  selectTeaserLead,
   selectTeaserPreTitle,
-  selectTeaserTitle,
   selectTeaserUrl,
   useWebsiteBuilder
 } from '@wepublish/website'
 
+import {
+  selectBajourTeaserImage,
+  selectBajourTeaserLead,
+  selectBajourTeaserTitle
+} from './select-teaser'
 import {
   AuthorsAndDate,
   LinkAndGridContainer,
@@ -27,10 +29,10 @@ import {
 } from './teaser-overwrite.style'
 
 export function TeaserOverwrite({className, teaser, numColumns, blockStyle}: BuilderTeaserProps) {
-  const title = teaser && selectTeaserTitle(teaser)
+  const title = teaser && selectBajourTeaserTitle(teaser)
   const preTitle = teaser && selectTeaserPreTitle(teaser)
-  const lead = teaser && selectTeaserLead(teaser)
-  const image = teaser && selectTeaserImage(teaser)
+  const lead = teaser && selectBajourTeaserLead(teaser)
+  const image = teaser && selectBajourTeaserImage(teaser)
   const publishDate = teaser && selectTeaserDate(teaser)
   const authors = teaser && selectTeaserAuthors(teaser)
   const href = teaser && selectTeaserUrl(teaser)

--- a/apps/bajour/src/components/website-builder-overwrites/blocks/teaser-slider/teaser-slide.tsx
+++ b/apps/bajour/src/components/website-builder-overwrites/blocks/teaser-slider/teaser-slide.tsx
@@ -3,14 +3,13 @@ import {
   BuilderTeaserProps,
   selectTeaserAuthors,
   selectTeaserDate,
-  selectTeaserImage,
   selectTeaserLead,
-  selectTeaserTitle,
   selectTeaserUrl,
   useWebsiteBuilder
 } from '@wepublish/website'
 import {useMemo} from 'react'
 
+import {selectBajourTeaserImage, selectBajourTeaserTitle} from '../select-teaser'
 import {fluidTypography} from '../teaser-overwrite.style'
 
 export const TeaserSlideContainer = styled('div')`
@@ -69,10 +68,10 @@ const useButtonStyles = (theme: Theme) => {
 }
 
 export const TeaserSlide = ({teaser, className}: Omit<BuilderTeaserProps, 'alignment'>) => {
-  const title = teaser && selectTeaserTitle(teaser)
+  const title = teaser && selectBajourTeaserTitle(teaser)
   const lead = teaser && selectTeaserLead(teaser)
   const href = (teaser && selectTeaserUrl(teaser)) ?? ''
-  const image = teaser && selectTeaserImage(teaser)
+  const image = teaser && selectBajourTeaserImage(teaser)
   const publishDate = teaser && selectTeaserDate(teaser)
   const authors = teaser && selectTeaserAuthors(teaser)
 

--- a/apps/bajour/src/components/website-builder-styled/blocks/teaser-grid-styled.tsx
+++ b/apps/bajour/src/components/website-builder-styled/blocks/teaser-grid-styled.tsx
@@ -6,7 +6,7 @@ export const BajourTeaserGrid = styled(TeaserGridBlock)`
     numColumns > 1 &&
     css`
       grid-template-columns: repeat(12, 1fr);
-      row-gap: ${theme.spacing(2)};
+      row-gap: ${theme.spacing(3)};
       column-gap: ${theme.spacing(4)};
       align-items: center;
 
@@ -14,7 +14,6 @@ export const BajourTeaserGrid = styled(TeaserGridBlock)`
         grid-template-columns: repeat(12, 1fr);
         padding-left: calc(100% / 48);
         padding-right: calc(100% / 48);
-        row-gap: ${theme.spacing(3)};
       }
 
       ${theme.breakpoints.up('md')} {

--- a/apps/gruppetto/pages/[slug].tsx
+++ b/apps/gruppetto/pages/[slug].tsx
@@ -37,7 +37,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
         slug
       }
     })),
-    fallback: true
+    fallback: 'blocking'
   }
 }
 

--- a/apps/gruppetto/pages/_app.tsx
+++ b/apps/gruppetto/pages/_app.tsx
@@ -8,6 +8,7 @@ import {
   ThemeOptions,
   ThemeProvider
 } from '@mui/material'
+import {GoogleAnalytics} from '@next/third-parties/google'
 import {theme} from '@wepublish/ui'
 import {authLink, NextWepublishLink, SessionProvider} from '@wepublish/utils/website'
 import {
@@ -23,7 +24,6 @@ import i18next from 'i18next'
 import LanguageDetector from 'i18next-browser-languagedetector'
 import {AppProps} from 'next/app'
 import getConfig from 'next/config'
-import {GoogleAnalytics} from '@next/third-parties/google'
 import Head from 'next/head'
 import Script from 'next/script'
 import {initReactI18next} from 'react-i18next'

--- a/apps/gruppetto/pages/a/[slug].tsx
+++ b/apps/gruppetto/pages/a/[slug].tsx
@@ -75,7 +75,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
         slug
       }
     })),
-    fallback: true
+    fallback: 'blocking'
   }
 }
 

--- a/apps/tsri/pages/[slug].tsx
+++ b/apps/tsri/pages/[slug].tsx
@@ -37,7 +37,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
         slug
       }
     })),
-    fallback: true
+    fallback: 'blocking'
   }
 }
 

--- a/apps/tsri/pages/a/[slug].tsx
+++ b/apps/tsri/pages/a/[slug].tsx
@@ -94,7 +94,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
         slug
       }
     })),
-    fallback: true
+    fallback: 'blocking'
   }
 }
 

--- a/apps/website-example/pages/[slug].tsx
+++ b/apps/website-example/pages/[slug].tsx
@@ -37,7 +37,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
         slug
       }
     })),
-    fallback: true
+    fallback: 'blocking'
   }
 }
 

--- a/apps/website-example/pages/a/[slug].tsx
+++ b/apps/website-example/pages/a/[slug].tsx
@@ -94,7 +94,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
         slug
       }
     })),
-    fallback: true
+    fallback: 'blocking'
   }
 }
 

--- a/libs/article/website/src/lib/__snapshots__/article-container.spec.tsx.snap
+++ b/libs/article/website/src/lib/__snapshots__/article-container.spec.tsx.snap
@@ -456,7 +456,7 @@ exports[`Article Container should render ById 1`] = `
     >
       <img
         alt="DSC07717"
-        class="css-m3orio-ImageWrapper-ImageBlock e1shv2yg0"
+        class="css-cibo30-ImageWrapper e1shv2yg0"
         loading="lazy"
         srcset="https://unsplash.it/800/400 800w,
 https://unsplash.it/500/300 500w,
@@ -2716,7 +2716,7 @@ exports[`Article Container should render BySlug 1`] = `
     >
       <img
         alt="DSC07717"
-        class="css-m3orio-ImageWrapper-ImageBlock e1shv2yg0"
+        class="css-cibo30-ImageWrapper e1shv2yg0"
         loading="lazy"
         srcset="https://unsplash.it/800/400 800w,
 https://unsplash.it/500/300 500w,
@@ -4976,7 +4976,7 @@ exports[`Article Container should render WithChildren 1`] = `
     >
       <img
         alt="DSC07717"
-        class="css-m3orio-ImageWrapper-ImageBlock e1shv2yg0"
+        class="css-cibo30-ImageWrapper e1shv2yg0"
         loading="lazy"
         srcset="https://unsplash.it/800/400 800w,
 https://unsplash.it/500/300 500w,
@@ -7239,7 +7239,7 @@ exports[`Article Container should render WithClassName 1`] = `
     >
       <img
         alt="DSC07717"
-        class="css-m3orio-ImageWrapper-ImageBlock e1shv2yg0"
+        class="css-cibo30-ImageWrapper e1shv2yg0"
         loading="lazy"
         srcset="https://unsplash.it/800/400 800w,
 https://unsplash.it/500/300 500w,
@@ -9499,7 +9499,7 @@ exports[`Article Container should render WithEmotion 1`] = `
     >
       <img
         alt="DSC07717"
-        class="css-m3orio-ImageWrapper-ImageBlock e1shv2yg0"
+        class="css-cibo30-ImageWrapper e1shv2yg0"
         loading="lazy"
         srcset="https://unsplash.it/800/400 800w,
 https://unsplash.it/500/300 500w,

--- a/libs/article/website/src/lib/__snapshots__/article.spec.tsx.snap
+++ b/libs/article/website/src/lib/__snapshots__/article.spec.tsx.snap
@@ -456,7 +456,7 @@ exports[`Article should render Default 1`] = `
     >
       <img
         alt="DSC07717"
-        class="css-m3orio-ImageWrapper-ImageBlock e1shv2yg0"
+        class="css-cibo30-ImageWrapper e1shv2yg0"
         loading="lazy"
         srcset="https://unsplash.it/800/400 800w,
 https://unsplash.it/500/300 500w,
@@ -2809,7 +2809,7 @@ exports[`Article should render WithChildren 1`] = `
     >
       <img
         alt="DSC07717"
-        class="css-m3orio-ImageWrapper-ImageBlock e1shv2yg0"
+        class="css-cibo30-ImageWrapper e1shv2yg0"
         loading="lazy"
         srcset="https://unsplash.it/800/400 800w,
 https://unsplash.it/500/300 500w,
@@ -5165,7 +5165,7 @@ exports[`Article should render WithClassName 1`] = `
     >
       <img
         alt="DSC07717"
-        class="css-m3orio-ImageWrapper-ImageBlock e1shv2yg0"
+        class="css-cibo30-ImageWrapper e1shv2yg0"
         loading="lazy"
         srcset="https://unsplash.it/800/400 800w,
 https://unsplash.it/500/300 500w,
@@ -7518,7 +7518,7 @@ exports[`Article should render WithEmotion 1`] = `
     >
       <img
         alt="DSC07717"
-        class="css-m3orio-ImageWrapper-ImageBlock e1shv2yg0"
+        class="css-cibo30-ImageWrapper e1shv2yg0"
         loading="lazy"
         srcset="https://unsplash.it/800/400 800w,
 https://unsplash.it/500/300 500w,
@@ -9871,7 +9871,7 @@ exports[`Article should render WithoutAuthors 1`] = `
     >
       <img
         alt="DSC07717"
-        class="css-m3orio-ImageWrapper-ImageBlock e1shv2yg0"
+        class="css-cibo30-ImageWrapper e1shv2yg0"
         loading="lazy"
         srcset="https://unsplash.it/800/400 800w,
 https://unsplash.it/500/300 500w,
@@ -11986,7 +11986,7 @@ exports[`Article should render WithoutImageMetadata 1`] = `
     >
       <img
         alt="DSC07717"
-        class="css-m3orio-ImageWrapper-ImageBlock e1shv2yg0"
+        class="css-cibo30-ImageWrapper e1shv2yg0"
         loading="lazy"
         srcset="https://unsplash.it/800/400 800w,
 https://unsplash.it/500/300 500w,
@@ -14335,7 +14335,7 @@ exports[`Article should render WithoutLead 1`] = `
     >
       <img
         alt="DSC07717"
-        class="css-m3orio-ImageWrapper-ImageBlock e1shv2yg0"
+        class="css-cibo30-ImageWrapper e1shv2yg0"
         loading="lazy"
         srcset="https://unsplash.it/800/400 800w,
 https://unsplash.it/500/300 500w,
@@ -16688,7 +16688,7 @@ exports[`Article should render WithoutSocialMedia 1`] = `
     >
       <img
         alt="DSC07717"
-        class="css-m3orio-ImageWrapper-ImageBlock e1shv2yg0"
+        class="css-cibo30-ImageWrapper e1shv2yg0"
         loading="lazy"
         srcset="https://unsplash.it/800/400 800w,
 https://unsplash.it/500/300 500w,

--- a/libs/block-content/website/src/lib/__snapshots__/blocks.spec.tsx.snap
+++ b/libs/block-content/website/src/lib/__snapshots__/blocks.spec.tsx.snap
@@ -511,7 +511,7 @@ https://unsplash.it/200/100 200w"
   >
     <img
       alt="DSC07717"
-      class="css-m3orio-ImageWrapper-ImageBlock e1shv2yg0"
+      class="css-cibo30-ImageWrapper e1shv2yg0"
       loading="lazy"
       srcset="https://unsplash.it/800/400 800w,
 https://unsplash.it/500/300 500w,
@@ -2425,7 +2425,7 @@ https://unsplash.it/200/100 200w"
     >
       <img
         alt="DSC07717"
-        class="css-m3orio-ImageWrapper-ImageBlock e1shv2yg0"
+        class="css-cibo30-ImageWrapper e1shv2yg0"
         loading="lazy"
         srcset="https://unsplash.it/800/400 800w,
 https://unsplash.it/500/300 500w,

--- a/libs/block-content/website/src/lib/image/__snapshots__/image-block.spec.tsx.snap
+++ b/libs/block-content/website/src/lib/image/__snapshots__/image-block.spec.tsx.snap
@@ -7,7 +7,7 @@ exports[`Image Block should render Default 1`] = `
   >
     <img
       alt="An image description"
-      class="css-lsysey-ImageWrapper-ImageBlock e1shv2yg0"
+      class="css-19cwsz4-ImageWrapper e1shv2yg0"
       loading="lazy"
       srcset="https://unsplash.it/800/800 800w,
 https://unsplash.it/500/500 500w,
@@ -29,7 +29,7 @@ exports[`Image Block should render WithClassName 1`] = `
   >
     <img
       alt="An image description"
-      class="css-lsysey-ImageWrapper-ImageBlock e1shv2yg0"
+      class="css-19cwsz4-ImageWrapper e1shv2yg0"
       loading="lazy"
       srcset="https://unsplash.it/800/800 800w,
 https://unsplash.it/500/500 500w,
@@ -51,7 +51,7 @@ exports[`Image Block should render WithEmotion 1`] = `
   >
     <img
       alt="An image description"
-      class="css-lsysey-ImageWrapper-ImageBlock e1shv2yg0"
+      class="css-19cwsz4-ImageWrapper e1shv2yg0"
       loading="lazy"
       srcset="https://unsplash.it/800/800 800w,
 https://unsplash.it/500/500 500w,
@@ -73,7 +73,7 @@ exports[`Image Block should render WithoutCaption 1`] = `
   >
     <img
       alt="An image description"
-      class="css-lsysey-ImageWrapper-ImageBlock e1shv2yg0"
+      class="css-19cwsz4-ImageWrapper e1shv2yg0"
       loading="lazy"
       srcset="https://unsplash.it/800/800 800w,
 https://unsplash.it/500/500 500w,

--- a/libs/block-content/website/src/lib/image/image-block.tsx
+++ b/libs/block-content/website/src/lib/image/image-block.tsx
@@ -1,4 +1,4 @@
-import {css, styled} from '@mui/material'
+import {styled} from '@mui/material'
 import {BuilderImageBlockProps, useWebsiteBuilder} from '@wepublish/website/builder'
 import {Block, ImageBlock as ImageBlockType} from '@wepublish/website/api'
 
@@ -21,11 +21,6 @@ export const ImageBlockWrapper = styled('figure')`
 
 export const ImageBlockCaption = styled('figcaption')``
 
-const imageStyles = css`
-  object-fit: cover;
-  aspect-ratio: 1.85611511;
-`
-
 export const ImageBlock = ({caption, image, className}: BuilderImageBlockProps) => {
   const {
     elements: {Image}
@@ -33,7 +28,7 @@ export const ImageBlock = ({caption, image, className}: BuilderImageBlockProps) 
 
   return (
     <ImageBlockWrapper className={className}>
-      {image && <Image image={image} css={imageStyles} fetchPriority="high" />}
+      {image && <Image image={image} fetchPriority="high" />}
 
       {caption && <figcaption>{caption}</figcaption>}
     </ImageBlockWrapper>

--- a/libs/event/website/src/lib/event/__snapshots__/event-container.spec.tsx.snap
+++ b/libs/event/website/src/lib/event/__snapshots__/event-container.spec.tsx.snap
@@ -55,7 +55,7 @@ exports[`Event Container should render Default 1`] = `
     >
       <img
         alt="DSC07717"
-        class="css-m3orio-ImageWrapper-ImageBlock e1shv2yg0"
+        class="css-cibo30-ImageWrapper e1shv2yg0"
         loading="lazy"
         srcset="https://unsplash.it/800/400 800w,
 https://unsplash.it/500/300 500w,
@@ -535,7 +535,7 @@ exports[`Event Container should render WithClassName 1`] = `
     >
       <img
         alt="DSC07717"
-        class="css-m3orio-ImageWrapper-ImageBlock e1shv2yg0"
+        class="css-cibo30-ImageWrapper e1shv2yg0"
         loading="lazy"
         srcset="https://unsplash.it/800/400 800w,
 https://unsplash.it/500/300 500w,
@@ -1015,7 +1015,7 @@ exports[`Event Container should render WithEmotion 1`] = `
     >
       <img
         alt="DSC07717"
-        class="css-m3orio-ImageWrapper-ImageBlock e1shv2yg0"
+        class="css-cibo30-ImageWrapper e1shv2yg0"
         loading="lazy"
         srcset="https://unsplash.it/800/400 800w,
 https://unsplash.it/500/300 500w,

--- a/libs/event/website/src/lib/event/__snapshots__/event.spec.tsx.snap
+++ b/libs/event/website/src/lib/event/__snapshots__/event.spec.tsx.snap
@@ -55,7 +55,7 @@ exports[`Event should render Default 1`] = `
     >
       <img
         alt="DSC07717"
-        class="css-m3orio-ImageWrapper-ImageBlock e1shv2yg0"
+        class="css-cibo30-ImageWrapper e1shv2yg0"
         loading="lazy"
         srcset="https://unsplash.it/800/400 800w,
 https://unsplash.it/500/300 500w,
@@ -535,7 +535,7 @@ exports[`Event should render WithClassName 1`] = `
     >
       <img
         alt="DSC07717"
-        class="css-m3orio-ImageWrapper-ImageBlock e1shv2yg0"
+        class="css-cibo30-ImageWrapper e1shv2yg0"
         loading="lazy"
         srcset="https://unsplash.it/800/400 800w,
 https://unsplash.it/500/300 500w,
@@ -1015,7 +1015,7 @@ exports[`Event should render WithEmotion 1`] = `
     >
       <img
         alt="DSC07717"
-        class="css-m3orio-ImageWrapper-ImageBlock e1shv2yg0"
+        class="css-cibo30-ImageWrapper e1shv2yg0"
         loading="lazy"
         srcset="https://unsplash.it/800/400 800w,
 https://unsplash.it/500/300 500w,

--- a/libs/membership/website/src/lib/subscription-list/__snapshots__/subscription-list-container.spec.tsx.snap
+++ b/libs/membership/website/src/lib/subscription-list/__snapshots__/subscription-list-container.spec.tsx.snap
@@ -207,7 +207,29 @@ Compared values have no visual difference."
 
 exports[`SubscriptionList Container should render Pay 1`] = `
 "Snapshot Diff:
-Compared values have no visual difference."
+- First value
++ Second value
+
+@@ -73,11 +73,18 @@
+                />
+                <path
+                  d="M19 14V6c0-1.1-.9-2-2-2H3c-1.1 0-2 .9-2 2v8c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2zm-2 0H3V6h14v8zm-7-7c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3zm13 0v11c0 1.1-.9 2-2 2H4v-2h17V7h2z"
+                />
+              </svg>
+-              Abo ist unbezahlt
++             <span>
++               Bezahlt bis 
++               <time
++                 datetime="2032-01-01"
++               >
++                 01.01.2032 00:00
++               </time>
++             </span>
+            </li>
+            <li
+              class="css-ec7qyu-SubscriptionListItemMetaItem eere75z1"
+            >
+              <svg"
 `;
 
 exports[`SubscriptionList Container should render Unpaid 1`] = `

--- a/libs/page/website/src/lib/__snapshots__/page-container.spec.tsx.snap
+++ b/libs/page/website/src/lib/__snapshots__/page-container.spec.tsx.snap
@@ -424,7 +424,7 @@ exports[`Page Container should render ById 1`] = `
     >
       <img
         alt="DSC07717"
-        class="css-m3orio-ImageWrapper-ImageBlock e1shv2yg0"
+        class="css-cibo30-ImageWrapper e1shv2yg0"
         loading="lazy"
         srcset="https://unsplash.it/800/400 800w,
 https://unsplash.it/500/300 500w,
@@ -2306,7 +2306,7 @@ exports[`Page Container should render BySlug 1`] = `
     >
       <img
         alt="DSC07717"
-        class="css-m3orio-ImageWrapper-ImageBlock e1shv2yg0"
+        class="css-cibo30-ImageWrapper e1shv2yg0"
         loading="lazy"
         srcset="https://unsplash.it/800/400 800w,
 https://unsplash.it/500/300 500w,
@@ -4188,7 +4188,7 @@ exports[`Page Container should render WithChildren 1`] = `
     >
       <img
         alt="DSC07717"
-        class="css-m3orio-ImageWrapper-ImageBlock e1shv2yg0"
+        class="css-cibo30-ImageWrapper e1shv2yg0"
         loading="lazy"
         srcset="https://unsplash.it/800/400 800w,
 https://unsplash.it/500/300 500w,
@@ -6073,7 +6073,7 @@ exports[`Page Container should render WithClassName 1`] = `
     >
       <img
         alt="DSC07717"
-        class="css-m3orio-ImageWrapper-ImageBlock e1shv2yg0"
+        class="css-cibo30-ImageWrapper e1shv2yg0"
         loading="lazy"
         srcset="https://unsplash.it/800/400 800w,
 https://unsplash.it/500/300 500w,
@@ -7955,7 +7955,7 @@ exports[`Page Container should render WithEmotion 1`] = `
     >
       <img
         alt="DSC07717"
-        class="css-m3orio-ImageWrapper-ImageBlock e1shv2yg0"
+        class="css-cibo30-ImageWrapper e1shv2yg0"
         loading="lazy"
         srcset="https://unsplash.it/800/400 800w,
 https://unsplash.it/500/300 500w,

--- a/libs/page/website/src/lib/__snapshots__/page.spec.tsx.snap
+++ b/libs/page/website/src/lib/__snapshots__/page.spec.tsx.snap
@@ -424,7 +424,7 @@ exports[`Page should render Default 1`] = `
     >
       <img
         alt="DSC07717"
-        class="css-m3orio-ImageWrapper-ImageBlock e1shv2yg0"
+        class="css-cibo30-ImageWrapper e1shv2yg0"
         loading="lazy"
         srcset="https://unsplash.it/800/400 800w,
 https://unsplash.it/500/300 500w,
@@ -2507,7 +2507,7 @@ exports[`Page should render WithChildren 1`] = `
     >
       <img
         alt="DSC07717"
-        class="css-m3orio-ImageWrapper-ImageBlock e1shv2yg0"
+        class="css-cibo30-ImageWrapper e1shv2yg0"
         loading="lazy"
         srcset="https://unsplash.it/800/400 800w,
 https://unsplash.it/500/300 500w,
@@ -4593,7 +4593,7 @@ exports[`Page should render WithClassName 1`] = `
     >
       <img
         alt="DSC07717"
-        class="css-m3orio-ImageWrapper-ImageBlock e1shv2yg0"
+        class="css-cibo30-ImageWrapper e1shv2yg0"
         loading="lazy"
         srcset="https://unsplash.it/800/400 800w,
 https://unsplash.it/500/300 500w,
@@ -6676,7 +6676,7 @@ exports[`Page should render WithEmotion 1`] = `
     >
       <img
         alt="DSC07717"
-        class="css-m3orio-ImageWrapper-ImageBlock e1shv2yg0"
+        class="css-cibo30-ImageWrapper e1shv2yg0"
         loading="lazy"
         srcset="https://unsplash.it/800/400 800w,
 https://unsplash.it/500/300 500w,
@@ -8775,7 +8775,7 @@ exports[`Page should render WithoutDescription 1`] = `
     >
       <img
         alt="DSC07717"
-        class="css-m3orio-ImageWrapper-ImageBlock e1shv2yg0"
+        class="css-cibo30-ImageWrapper e1shv2yg0"
         loading="lazy"
         srcset="https://unsplash.it/800/400 800w,
 https://unsplash.it/500/300 500w,
@@ -10858,7 +10858,7 @@ exports[`Page should render WithoutImageMetadata 1`] = `
     >
       <img
         alt="DSC07717"
-        class="css-m3orio-ImageWrapper-ImageBlock e1shv2yg0"
+        class="css-cibo30-ImageWrapper e1shv2yg0"
         loading="lazy"
         srcset="https://unsplash.it/800/400 800w,
 https://unsplash.it/500/300 500w,
@@ -12933,7 +12933,7 @@ exports[`Page should render WithoutSocialMedia 1`] = `
     >
       <img
         alt="DSC07717"
-        class="css-m3orio-ImageWrapper-ImageBlock e1shv2yg0"
+        class="css-cibo30-ImageWrapper e1shv2yg0"
         loading="lazy"
         srcset="https://unsplash.it/800/400 800w,
 https://unsplash.it/500/300 500w,


### PR DESCRIPTION
1. Bajour didn't want the image cropping, since it caused issues with firefox we reverted it.
2. Fallback set back to blocking as it caused to call the API with null and then with the correct params.
3. Bajour relies on the image in the metadata instead of the image block, overriden for now until further discussion for default behaviour
