### PR TITLE
This is a follow up to WPC-1419 and #1124, where the full text search…

### DIFF
--- a/libs/api/src/lib/graphql/phrase/phrase.public-queries.ts
+++ b/libs/api/src/lib/graphql/phrase/phrase.public-queries.ts
@@ -18,7 +18,7 @@ export const queryPhrase = async (
   order: SortOrder
 ) => {
   // Default add & if no specific query is given to prevent search to fail!
-  query = query.replace(' ', '&')
+  query = query.replace(/ /g, '&')
 
   const [foundArticleIds, foundPageIds] = await Promise.all([
     prisma.$queryRaw<{id: string}[]>`


### PR DESCRIPTION
… was

improved. The existing code did only replace the first space of the search query with an ampersand. This commit replaces all spaces and makes queries with more than one space possible.