### PR TITLE
WPC-1419: full text improvements followup

### DIFF
--- a/libs/api/__tests__/specs/phrase.test.ts
+++ b/libs/api/__tests__/specs/phrase.test.ts
@@ -61,6 +61,11 @@ describe('Phrases', () => {
       match: false
     },
     {
+      titleQuery: 'quick fox lazy hedgehog',
+      bodyQuery: 'quick fox lazy hedgehog',
+      match: true
+    },
+    {
       name: "If ! is used the code word can't be present in either body or title",
       query: '!bunny',
       match: false

--- a/libs/api/src/lib/graphql/phrase/phrase.public-queries.ts
+++ b/libs/api/src/lib/graphql/phrase/phrase.public-queries.ts
@@ -18,7 +18,7 @@ export const queryPhrase = async (
   order: SortOrder
 ) => {
   // Default add & if no specific query is given to prevent search to fail!
-  query = query.replace(' ', '&')
+  query = query.replace(/\s+/g, '&')
 
   const [foundArticleIds, foundPageIds] = await Promise.all([
     prisma.$queryRaw<{id: string}[]>`


### PR DESCRIPTION
This is a follow up to WPC-1419 and #1124, where the full text search was improved. The existing code did only replace the first space of the search query with an ampersand. This commit replaces all spaces and makes queries with more than one space possible.