### PR TITLE
WPC-1419: Add page info to full text search

### DIFF
--- a/libs/api/__tests__/api/public/index.ts
+++ b/libs/api/__tests__/api/public/index.ts
@@ -929,8 +929,22 @@ export type PeerProfile = {
 
 export type Phrase = {
   __typename?: 'Phrase';
-  articles: Array<Article>;
-  pages: Array<Page>;
+  articles?: Maybe<PhraseResultArticleContent>;
+  pages?: Maybe<PhraseResultPageContent>;
+};
+
+export type PhraseResultArticleContent = {
+  __typename?: 'PhraseResultArticleContent';
+  nodes: Array<Article>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int'];
+};
+
+export type PhraseResultPageContent = {
+  __typename?: 'PhraseResultPageContent';
+  nodes: Array<Page>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int'];
 };
 
 export type Point = {
@@ -1718,10 +1732,12 @@ export type PeerQuery = { __typename?: 'Query', peer?: { __typename?: 'Peer', id
 
 export type PhraseQueryVariables = Exact<{
   query: Scalars['String'];
+  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']>;
 }>;
 
 
-export type PhraseQuery = { __typename?: 'Query', phrase?: { __typename?: 'Phrase', articles: Array<{ __typename?: 'Article', id: string, slug: string, title: string, blocks: Array<{ __typename?: 'BildwurfAdBlock' } | { __typename?: 'CommentBlock' } | { __typename?: 'EmbedBlock' } | { __typename?: 'EventBlock' } | { __typename?: 'FacebookPostBlock' } | { __typename?: 'FacebookVideoBlock' } | { __typename?: 'HTMLBlock' } | { __typename?: 'ImageBlock' } | { __typename?: 'ImageGalleryBlock' } | { __typename?: 'InstagramPostBlock' } | { __typename?: 'LinkPageBreakBlock' } | { __typename?: 'ListicleBlock' } | { __typename?: 'PolisConversationBlock' } | { __typename?: 'PollBlock' } | { __typename?: 'QuoteBlock' } | { __typename?: 'RichTextBlock', richText: Node[] } | { __typename?: 'SoundCloudTrackBlock' } | { __typename?: 'TeaserGridBlock' } | { __typename?: 'TeaserGridFlexBlock' } | { __typename?: 'TeaserListBlock' } | { __typename?: 'TikTokVideoBlock' } | { __typename?: 'TitleBlock' } | { __typename?: 'TwitterTweetBlock' } | { __typename?: 'VimeoVideoBlock' } | { __typename?: 'YouTubeVideoBlock' }> }>, pages: Array<{ __typename?: 'Page', id: string, slug: string, title: string, blocks: Array<{ __typename?: 'BildwurfAdBlock' } | { __typename?: 'CommentBlock' } | { __typename?: 'EmbedBlock' } | { __typename?: 'EventBlock' } | { __typename?: 'FacebookPostBlock' } | { __typename?: 'FacebookVideoBlock' } | { __typename?: 'HTMLBlock' } | { __typename?: 'ImageBlock' } | { __typename?: 'ImageGalleryBlock' } | { __typename?: 'InstagramPostBlock' } | { __typename?: 'LinkPageBreakBlock' } | { __typename?: 'ListicleBlock' } | { __typename?: 'PolisConversationBlock' } | { __typename?: 'PollBlock' } | { __typename?: 'QuoteBlock' } | { __typename?: 'RichTextBlock', richText: Node[] } | { __typename?: 'SoundCloudTrackBlock' } | { __typename?: 'TeaserGridBlock' } | { __typename?: 'TeaserGridFlexBlock' } | { __typename?: 'TeaserListBlock' } | { __typename?: 'TikTokVideoBlock' } | { __typename?: 'TitleBlock' } | { __typename?: 'TwitterTweetBlock' } | { __typename?: 'VimeoVideoBlock' } | { __typename?: 'YouTubeVideoBlock' }> }> } | null };
+export type PhraseQuery = { __typename?: 'Query', phrase?: { __typename?: 'Phrase', articles?: { __typename?: 'PhraseResultArticleContent', totalCount: number, nodes: Array<{ __typename?: 'Article', id: string, slug: string, title: string, blocks: Array<{ __typename?: 'BildwurfAdBlock' } | { __typename?: 'CommentBlock' } | { __typename?: 'EmbedBlock' } | { __typename?: 'EventBlock' } | { __typename?: 'FacebookPostBlock' } | { __typename?: 'FacebookVideoBlock' } | { __typename?: 'HTMLBlock' } | { __typename?: 'ImageBlock' } | { __typename?: 'ImageGalleryBlock' } | { __typename?: 'InstagramPostBlock' } | { __typename?: 'LinkPageBreakBlock' } | { __typename?: 'ListicleBlock' } | { __typename?: 'PolisConversationBlock' } | { __typename?: 'PollBlock' } | { __typename?: 'QuoteBlock' } | { __typename?: 'RichTextBlock', richText: Node[] } | { __typename?: 'SoundCloudTrackBlock' } | { __typename?: 'TeaserGridBlock' } | { __typename?: 'TeaserGridFlexBlock' } | { __typename?: 'TeaserListBlock' } | { __typename?: 'TikTokVideoBlock' } | { __typename?: 'TitleBlock' } | { __typename?: 'TwitterTweetBlock' } | { __typename?: 'VimeoVideoBlock' } | { __typename?: 'YouTubeVideoBlock' }> }>, pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean } } | null, pages?: { __typename?: 'PhraseResultPageContent', totalCount: number, nodes: Array<{ __typename?: 'Page', id: string, slug: string, title: string, blocks: Array<{ __typename?: 'BildwurfAdBlock' } | { __typename?: 'CommentBlock' } | { __typename?: 'EmbedBlock' } | { __typename?: 'EventBlock' } | { __typename?: 'FacebookPostBlock' } | { __typename?: 'FacebookVideoBlock' } | { __typename?: 'HTMLBlock' } | { __typename?: 'ImageBlock' } | { __typename?: 'ImageGalleryBlock' } | { __typename?: 'InstagramPostBlock' } | { __typename?: 'LinkPageBreakBlock' } | { __typename?: 'ListicleBlock' } | { __typename?: 'PolisConversationBlock' } | { __typename?: 'PollBlock' } | { __typename?: 'QuoteBlock' } | { __typename?: 'RichTextBlock', richText: Node[] } | { __typename?: 'SoundCloudTrackBlock' } | { __typename?: 'TeaserGridBlock' } | { __typename?: 'TeaserGridFlexBlock' } | { __typename?: 'TeaserListBlock' } | { __typename?: 'TikTokVideoBlock' } | { __typename?: 'TitleBlock' } | { __typename?: 'TwitterTweetBlock' } | { __typename?: 'VimeoVideoBlock' } | { __typename?: 'YouTubeVideoBlock' }> }>, pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean } } | null } | null };
 
 export type FullUserFragment = { __typename?: 'User', name: string, email: string };
 
@@ -2281,27 +2297,45 @@ export const Peer = gql`
 }
     ${PeerRef}`;
 export const Phrase = gql`
-    query Phrase($query: String!) {
-  phrase(query: $query) {
+    query Phrase($query: String!, $take: Int, $skip: Int) {
+  phrase(query: $query, take: $take, skip: $skip) {
     articles {
-      id
-      slug
-      title
-      blocks {
-        ... on RichTextBlock {
-          richText
+      nodes {
+        id
+        slug
+        title
+        blocks {
+          ... on RichTextBlock {
+            richText
+          }
         }
       }
+      pageInfo {
+        startCursor
+        endCursor
+        hasNextPage
+        hasPreviousPage
+      }
+      totalCount
     }
     pages {
-      id
-      slug
-      title
-      blocks {
-        ... on RichTextBlock {
-          richText
+      nodes {
+        id
+        slug
+        title
+        blocks {
+          ... on RichTextBlock {
+            richText
+          }
         }
       }
+      pageInfo {
+        startCursor
+        endCursor
+        hasNextPage
+        hasPreviousPage
+      }
+      totalCount
     }
   }
 }

--- a/libs/api/__tests__/api/public/phrase.graphql
+++ b/libs/api/__tests__/api/public/phrase.graphql
@@ -1,25 +1,47 @@
-query Phrase($query: String!) {
-  phrase(query: $query) {
+query Phrase($query: String!, $take: Int, $skip: Int) {
+  phrase(query: $query, take: $take, skip: $skip) {
     articles {
-      id
-      slug
-      title
-      blocks {
-        ... on RichTextBlock {
-          richText
+      nodes {
+        id
+        slug
+        title
+        blocks {
+          ... on RichTextBlock {
+            richText
+          }
         }
       }
+
+      pageInfo {
+        startCursor
+        endCursor
+        hasNextPage
+        hasPreviousPage
+      }
+
+      totalCount
     }
 
     pages {
-      id
-      slug
-      title
-      blocks {
-        ... on RichTextBlock {
-          richText
+      nodes {
+        id
+        slug
+        title
+        blocks {
+          ... on RichTextBlock {
+            richText
+          }
         }
       }
+
+      pageInfo {
+        startCursor
+        endCursor
+        hasNextPage
+        hasPreviousPage
+      }
+
+      totalCount
     }
   }
 }

--- a/libs/api/__tests__/specs/phrase.test.ts
+++ b/libs/api/__tests__/specs/phrase.test.ts
@@ -3,15 +3,18 @@ import {ApolloServer} from 'apollo-server-express'
 import {createGraphQLTestClientWithPrisma, generateRandomString} from '../utility'
 import {CreateArticle, PublishArticle, CreatePage, PublishPage} from '../api/private/index'
 import {Phrase} from '../api/public/index'
+import {PrismaClient} from '@prisma/client'
 
 let testServerPrivate: ApolloServer
 let testServerPublic: ApolloServer
+let prisma: PrismaClient
 
 beforeAll(async () => {
   try {
     const setupClient = await createGraphQLTestClientWithPrisma()
     testServerPrivate = setupClient.testServerPrivate
     testServerPublic = setupClient.testServerPublic
+    prisma = setupClient.prisma
   } catch (error) {
     console.log('Error', error)
     throw new Error('Error during test setup')
@@ -133,9 +136,10 @@ describe('Phrases', () => {
       })
     ])
 
-    const result = [...bodyRes.data.phrase.articles, ...titleRes.data.phrase.articles].filter(
-      article => article.id === articleRes.data.createArticle.id
-    )
+    const result = [
+      ...bodyRes.data.phrase.articles.nodes,
+      ...titleRes.data.phrase.articles.nodes
+    ].filter(article => article.id === articleRes.data.createArticle.id)
 
     if (match) {
       expect(result.length).toBeTruthy()
@@ -245,7 +249,7 @@ describe('Phrases', () => {
       })
     ])
 
-    const result = [...bodyRes.data.phrase.pages, ...titleRes.data.phrase.pages].filter(
+    const result = [...bodyRes.data.phrase.pages.nodes, ...titleRes.data.phrase.pages.nodes].filter(
       page => page.id === pageRes.data.createPage.id
     )
 
@@ -254,5 +258,111 @@ describe('Phrases', () => {
     } else {
       expect(result.length).toBeFalsy()
     }
+  })
+
+  describe('reports pageInfo and totalCount', () => {
+    beforeEach(async () => {
+      await prisma.article.deleteMany({})
+
+      for (let i = 0; i < 10; i++) {
+        const res = await testServerPrivate.executeOperation({
+          query: CreateArticle,
+          variables: {
+            input: {
+              slug: generateRandomString(),
+              title: 'The quick brown bunny jumps over the lazy hedgehog',
+              lead: '',
+              seoTitle: '',
+              authorIDs: [],
+              breaking: false,
+              shared: false,
+              hidden: false,
+              tags: [],
+              canonicalUrl: '',
+              properties: [],
+              blocks: [
+                {
+                  richText: {
+                    richText: [
+                      {
+                        type: 'paragraph',
+                        children: [
+                          {
+                            text: 'The quick brown fox jumps over the lazy dog'
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ],
+              hideAuthor: false,
+              socialMediaAuthorIDs: []
+            }
+          }
+        })
+
+        await testServerPrivate.executeOperation({
+          query: PublishArticle,
+          variables: {
+            id: res.data.createArticle.id,
+            publishAt: '2022-12-30T11:16:19.554Z',
+            publishedAt: '2022-12-30T11:16:19.554Z',
+            updatedAt: '2022-12-30T11:16:19.554Z'
+          }
+        })
+      }
+    })
+
+    test('honors take parameter', async () => {
+      const res = await testServerPublic.executeOperation({
+        query: Phrase,
+        variables: {
+          query: 'fox',
+          skip: 0,
+          take: 5
+        }
+      })
+
+      const articles = res.data!.phrase.articles
+      expect(articles.totalCount).toEqual(10)
+      expect(articles.nodes.length).toEqual(5)
+      expect(articles.pageInfo.hasPreviousPage).toEqual(false)
+      expect(articles.pageInfo.hasNextPage).toEqual(true)
+    })
+
+    test('honors skip parameter', async () => {
+      const res = await testServerPublic.executeOperation({
+        query: Phrase,
+        variables: {
+          query: 'fox',
+          skip: 8,
+          take: 5
+        }
+      })
+
+      const articles = res.data!.phrase.articles
+      expect(articles.totalCount).toEqual(10)
+      expect(articles.nodes.length).toEqual(2)
+      expect(articles.pageInfo.hasPreviousPage).toEqual(true)
+      expect(articles.pageInfo.hasNextPage).toEqual(false)
+    })
+
+    test('returns empty at end of result set', async () => {
+      const res = await testServerPublic.executeOperation({
+        query: Phrase,
+        variables: {
+          query: 'fox',
+          skip: 10,
+          take: 5
+        }
+      })
+
+      const articles = res.data!.phrase.articles
+      expect(articles.totalCount).toEqual(10)
+      expect(articles.nodes.length).toEqual(0)
+      expect(articles.pageInfo.hasPreviousPage).toEqual(true)
+      expect(articles.pageInfo.hasNextPage).toEqual(false)
+    })
   })
 })

--- a/libs/api/src/lib/graphql/phrase/phrase.ts
+++ b/libs/api/src/lib/graphql/phrase/phrase.ts
@@ -1,20 +1,40 @@
-import {GraphQLObjectType, GraphQLNonNull, GraphQLList} from 'graphql'
+import {GraphQLObjectType, GraphQLNonNull, GraphQLList, GraphQLInt} from 'graphql'
 import {Context} from '../../context'
 import {GraphQLPublicArticle} from '../article'
 import {PublicArticle} from '../../db/article'
 import {PublicPage} from '../../db/page'
 import {GraphQLPublicPage} from '../page'
+import {GraphQLPageInfo} from '../common'
+import {ConnectionResult} from '../../db/common'
+
+const GraphQLPhraseResultArticleContent = new GraphQLObjectType({
+  name: 'PhraseResultArticleContent',
+  fields: {
+    nodes: {type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(GraphQLPublicArticle)))},
+    pageInfo: {type: new GraphQLNonNull(GraphQLPageInfo)},
+    totalCount: {type: new GraphQLNonNull(GraphQLInt)}
+  }
+})
+
+const GraphQLPhraseResultPageContent = new GraphQLObjectType({
+  name: 'PhraseResultPageContent',
+  fields: {
+    nodes: {type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(GraphQLPublicPage)))},
+    pageInfo: {type: new GraphQLNonNull(GraphQLPageInfo)},
+    totalCount: {type: new GraphQLNonNull(GraphQLInt)}
+  }
+})
 
 export const GraphQLPublicPhrase = new GraphQLObjectType<
   {
-    articles: PublicArticle[]
-    pages: PublicPage[]
+    articles: ConnectionResult<PublicArticle>
+    pages: ConnectionResult<PublicPage>
   },
   Context
 >({
   name: 'Phrase',
   fields: {
-    articles: {type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(GraphQLPublicArticle)))},
-    pages: {type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(GraphQLPublicPage)))}
+    articles: {type: GraphQLPhraseResultArticleContent},
+    pages: {type: GraphQLPhraseResultPageContent}
   }
 })

--- a/libs/website/api/src/lib/graphql.ts
+++ b/libs/website/api/src/lib/graphql.ts
@@ -931,8 +931,22 @@ export type PeerProfile = {
 
 export type Phrase = {
   __typename?: 'Phrase';
-  articles: Array<Article>;
-  pages: Array<Page>;
+  articles?: Maybe<PhraseResultArticleContent>;
+  pages?: Maybe<PhraseResultPageContent>;
+};
+
+export type PhraseResultArticleContent = {
+  __typename?: 'PhraseResultArticleContent';
+  nodes: Array<Article>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int'];
+};
+
+export type PhraseResultPageContent = {
+  __typename?: 'PhraseResultPageContent';
+  nodes: Array<Page>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int'];
 };
 
 export type Point = {


### PR DESCRIPTION
This adds the values required for pagination to the result of the phrase query. In order to display a pagination component, at least the total number of results is required. A first query is run without any pagination settings applied. This produces a list of ids, and indirectly the total count of matches. For loading the content, another query is run with the pagination and sort orders applied.