### PR TITLE
refactor(api,editor): make style, template & layout options deprecated

### DIFF
--- a/apps/bajour/src/components/payment-method-picker/payment-method-picker.tsx
+++ b/apps/bajour/src/components/payment-method-picker/payment-method-picker.tsx
@@ -6,12 +6,12 @@ import {
 } from '@wepublish/website'
 import {ComponentProps, forwardRef, PropsWithChildren, useEffect, useId} from 'react'
 
+import {ReactComponent as Invoice} from './invoice.svg'
 import {ReactComponent as Mastercard} from './mastercard.svg'
 import {ReactComponent as PayPal} from './paypal.svg'
 import {ReactComponent as PostFinance} from './post-finance.svg'
 import {ReactComponent as Twint} from './twint.svg'
 import {ReactComponent as Visa} from './visa.svg'
-import {ReactComponent as Invoice} from './invoice.svg'
 
 const PaymentRadioWrapper = styled('div')<{active?: boolean}>`
   display: grid;

--- a/apps/editor/src/app/locales/de.json
+++ b/apps/editor/src/app/locales/de.json
@@ -47,7 +47,6 @@
         "contentUrl": "Inhalt URL",
         "createdAt": "{{createdAt, ccc PP p}}",
         "dateExplanationPopOver": "Dies kann verwendet werden, um auf Artikel zu verweisen, die zu einem späteren Zeitpunkt veröffentlicht werden sollen. Dies ist z. B. hilfreich, wenn Beiträge in sozialen Medien für den nächsten Morgen im Voraus geplant werden.",
-        "default": "Default",
         "displayOptions": "Anzeigeoptionen",
         "dontChangeSlug": "Slug nach dem Publizieren nicht mehr ändern.",
         "draft": "Entwurf",
@@ -69,7 +68,6 @@
         "key": "Key",
         "lead": "Lead",
         "leadHelpBlock": "Verwende einen SEO-optimierten Lead",
-        "light": "Light",
         "loading": "Laden ...",
         "loadMore": "Mehr laden",
         "noDataToDisplay": "Keine Daten zum Anzeigen",
@@ -108,10 +106,8 @@
         "statePending": "Status: Geplant",
         "statePublished": "Status: Publiziert",
         "status": "{{stateJoin}}",
-        "style": "Style",
         "tags": "Tags",
         "teaserStyle": "Style: {{label}}",
-        "text": "Text",
         "title": "Titel",
         "titleHelpBlock": "Verwende einen SEO-optimierten Titel",
         "totalCharCount": "Anzahl Zeichen {{totalCharCount}}",
@@ -635,14 +631,6 @@
     },
     "linkPageBreakEditPanel": {
       "close": "Schliessen",
-      "layout": {
-        "center": "Zentriert",
-        "default": "Standardlayout",
-        "image-left": "Bild links",
-        "image-right": "Bild rechts",
-        "label": "Layouts",
-        "right": "Rechtsbündig"
-      },
       "link": {
         "buttonLabel": "CTA-Button-Label",
         "hideToggleLabel": "CTA-Button ausblenden",
@@ -651,19 +639,6 @@
         "targetLabelBlank": "Neuer Browser-Tab",
         "targetLabelSelf": "Dieser Browser-Tab",
         "urlLabel": "CTA-URL"
-      },
-      "style": {
-        "dark": "Dark Style",
-        "default": "Standardstyle",
-        "image": "Bildhintergrund",
-        "label": "Styles"
-      },
-      "template": {
-        "donation": "Spende",
-        "label": "Vorlagen",
-        "membership": "Mitgliedschaft",
-        "none": "Keine",
-        "subscription": "Abonnement"
       },
       "title": "Einstellungen"
     },

--- a/apps/editor/src/app/locales/en.json
+++ b/apps/editor/src/app/locales/en.json
@@ -47,7 +47,6 @@
         "contentUrl": "Content URL",
         "createdAt": "{{createdAt, ccc PP p}}",
         "dateExplanationPopOver": "This can be used to reference articles that will be published at a later time. For example, helpful when scheduling social media posts in advance for the next morning.",
-        "default": "Default",
         "displayOptions": "Display Options",
         "dontChangeSlug": "Please don't change the slug once the article is published.",
         "draft": "Draft",
@@ -69,7 +68,6 @@
         "key": "Key",
         "lead": "Lead",
         "leadHelpBlock": "Please use an SEO-optimised lead",
-        "light": "Light",
         "loading": "Loading ...",
         "loadMore": "Load More",
         "noDataToDisplay": "No data to display",
@@ -108,10 +106,8 @@
         "statePending": "Status: Pending",
         "statePublished": "Status: Published",
         "status": "{{stateJoin}}",
-        "style": "Style",
         "tags": "Tags",
         "teaserStyle": "Style: {{label}}",
-        "text": "Text",
         "title": "Title",
         "titleHelpBlock": "Please use an SEO-optimised title",
         "totalCharCount": "Total characters count is {{totalCharCount}}",
@@ -640,14 +636,6 @@
     },
     "linkPageBreakEditPanel": {
       "close": "Close",
-      "layout": {
-        "center": "Centered",
-        "default": "Default Layout",
-        "image-left": "Image Left",
-        "image-right": "Image Right",
-        "label": "Layouts",
-        "right": "Right Aligned"
-      },
       "link": {
         "buttonLabel": "CTA Button label",
         "hideToggleLabel": "Hide CTA Button",
@@ -656,19 +644,6 @@
         "targetLabelBlank": "new browser tab",
         "targetLabelSelf": "this browser tab",
         "urlLabel": "CTA URL"
-      },
-      "style": {
-        "dark": "Dark Style",
-        "default": "Default Style",
-        "image": "Image Background",
-        "label": "Styles"
-      },
-      "template": {
-        "donation": "Donation",
-        "label": "Templates",
-        "membership": "Membership",
-        "none": "None",
-        "subscription": "Subscription"
       },
       "title": "Settings"
     },

--- a/apps/editor/src/app/locales/fr.json
+++ b/apps/editor/src/app/locales/fr.json
@@ -48,7 +48,6 @@
         "contentUrl": "URL du contenu",
         "createdAt": "{{createdAt, ccc PP p}}",
         "dateExplanationPopOver": "Ceci peut être utilisé pour faire référence à des articles qui seront publiés ultérieurement. Par exemple, lorsque des posts pour les réseaux sociaux sont programmés pour êtres publiés le lendemain matin.",
-        "default": "Défaut",
         "displayOptions": "Options d'affichage",
         "dontChangeSlug": "Veuillez ne pas changer le slug une fois l'article publié.",
         "draft": "Brouillon",
@@ -71,7 +70,6 @@
         "key": "Clé",
         "lead": "Lead",
         "leadHelpBlock": "Veuillez utiliser un lead optimisé pour le référencement",
-        "light": "Light",
         "loading": "Chargement ...",
         "loadMore": "Charger plus",
         "noDataToDisplay": "Pas de données à afficher",
@@ -113,10 +111,8 @@
         "statePending": "Statut : En attente",
         "statePublished": "Statut : Publié",
         "status": "{{stateJoin}}",
-        "style": "Style",
         "tags": "Tags",
         "teaserStyle": "Style: {{label}}",
-        "text": "Texte",
         "title": "Titre",
         "titleHelpBlock": "Veuillez utiliser un titre optimisé pour le référencement seo",
         "totalCharCount": "Le nombre total de caractères est de {{totalCharCount}}",
@@ -641,14 +637,6 @@
     },
     "linkPageBreakEditPanel": {
       "close": "Fermer",
-      "layout": {
-        "center": "Centré",
-        "default": "Mise en page par défaut",
-        "image-left": "Image à gauche",
-        "image-right": "Image à droite",
-        "label": "Mise en page",
-        "right": "Aligné à droite"
-      },
       "link": {
         "buttonLabel": "Étiquette du bouton CTA",
         "hideToggleLabel": "Masquer le bouton CTA",
@@ -657,19 +645,6 @@
         "targetLabelBlank": "nouvel onglet de navigateur",
         "targetLabelSelf": "cet onglet du navigateur",
         "urlLabel": "URL CTA"
-      },
-      "style": {
-        "dark": "Style sombre",
-        "default": "Style par défaut",
-        "image": "Fond de l'image",
-        "label": "Styles"
-      },
-      "template": {
-        "donation": "Donation",
-        "label": "Modèles",
-        "membership": "Adhésion",
-        "none": "Aucun",
-        "subscription": "Abonnement"
       },
       "title": "Paramètres"
     },

--- a/libs/api/src/lib/graphql/blocks.ts
+++ b/libs/api/src/lib/graphql/blocks.ts
@@ -118,7 +118,10 @@ export const GraphQLRichTextBlock = new GraphQLObjectType<RichTextBlock>({
 export const GraphQLArticleTeaser = new GraphQLObjectType<ArticleTeaser, Context>({
   name: 'ArticleTeaser',
   fields: () => ({
-    style: {type: new GraphQLNonNull(GraphQLTeaserStyle)},
+    style: {
+      type: new GraphQLNonNull(GraphQLTeaserStyle),
+      deprecationReason: 'Use block styles instead of this'
+    },
     image: {
       type: GraphQLImage,
       resolve: createProxyingResolver(({imageID}, _, {loaders}) =>
@@ -143,7 +146,10 @@ export const GraphQLArticleTeaser = new GraphQLObjectType<ArticleTeaser, Context
 export const GraphQLPeerArticleTeaser = new GraphQLObjectType<PeerArticleTeaser, Context>({
   name: 'PeerArticleTeaser',
   fields: () => ({
-    style: {type: new GraphQLNonNull(GraphQLTeaserStyle)},
+    style: {
+      type: new GraphQLNonNull(GraphQLTeaserStyle),
+      deprecationReason: 'Use block styles instead of this'
+    },
 
     image: {
       type: GraphQLImage,
@@ -181,7 +187,10 @@ export const GraphQLPeerArticleTeaser = new GraphQLObjectType<PeerArticleTeaser,
 export const GraphQLPageTeaser = new GraphQLObjectType<PageTeaser, Context>({
   name: 'PageTeaser',
   fields: () => ({
-    style: {type: new GraphQLNonNull(GraphQLTeaserStyle)},
+    style: {
+      type: new GraphQLNonNull(GraphQLTeaserStyle),
+      deprecationReason: 'Use block styles instead of this'
+    },
 
     image: {
       type: GraphQLImage,
@@ -208,7 +217,10 @@ export const GraphQLPageTeaser = new GraphQLObjectType<PageTeaser, Context>({
 export const GraphQLEventTeaser = new GraphQLObjectType<EventTeaser, Context>({
   name: 'EventTeaser',
   fields: () => ({
-    style: {type: new GraphQLNonNull(GraphQLTeaserStyle)},
+    style: {
+      type: new GraphQLNonNull(GraphQLTeaserStyle),
+      deprecationReason: 'Use block styles instead of this'
+    },
 
     image: {
       type: GraphQLImage,
@@ -235,7 +247,10 @@ export const GraphQLEventTeaser = new GraphQLObjectType<EventTeaser, Context>({
 export const GraphQLCustomTeaser = new GraphQLObjectType<CustomTeaser, Context>({
   name: 'CustomTeaser',
   fields: () => ({
-    style: {type: new GraphQLNonNull(GraphQLTeaserStyle)},
+    style: {
+      type: new GraphQLNonNull(GraphQLTeaserStyle),
+      deprecationReason: 'Use block styles instead of this'
+    },
 
     image: {
       type: GraphQLImage,
@@ -329,7 +344,10 @@ export const GraphQLTeaserGridFlexBlock = new GraphQLObjectType<TeaserGridFlexBl
 export const GraphQLPublicArticleTeaser = new GraphQLObjectType<ArticleTeaser, Context>({
   name: 'ArticleTeaser',
   fields: () => ({
-    style: {type: new GraphQLNonNull(GraphQLTeaserStyle)},
+    style: {
+      type: new GraphQLNonNull(GraphQLTeaserStyle),
+      deprecationReason: 'Use block styles instead of this'
+    },
 
     image: {
       type: GraphQLImage,
@@ -357,7 +375,10 @@ export const GraphQLPublicArticleTeaser = new GraphQLObjectType<ArticleTeaser, C
 export const GraphQLPublicPeerArticleTeaser = new GraphQLObjectType<PeerArticleTeaser, Context>({
   name: 'PeerArticleTeaser',
   fields: () => ({
-    style: {type: new GraphQLNonNull(GraphQLTeaserStyle)},
+    style: {
+      type: new GraphQLNonNull(GraphQLTeaserStyle),
+      deprecationReason: 'Use block styles instead of this'
+    },
 
     image: {
       type: GraphQLImage,
@@ -406,7 +427,10 @@ export const GraphQLPublicPeerArticleTeaser = new GraphQLObjectType<PeerArticleT
 export const GraphQLPublicPageTeaser = new GraphQLObjectType<PageTeaser, Context>({
   name: 'PageTeaser',
   fields: () => ({
-    style: {type: new GraphQLNonNull(GraphQLTeaserStyle)},
+    style: {
+      type: new GraphQLNonNull(GraphQLTeaserStyle),
+      deprecationReason: 'Use block styles instead of this'
+    },
 
     image: {
       type: GraphQLImage,
@@ -434,7 +458,10 @@ export const GraphQLPublicPageTeaser = new GraphQLObjectType<PageTeaser, Context
 export const GraphQLPublicEventTeaser = new GraphQLObjectType<EventTeaser, Context>({
   name: 'EventTeaser',
   fields: () => ({
-    style: {type: new GraphQLNonNull(GraphQLTeaserStyle)},
+    style: {
+      type: new GraphQLNonNull(GraphQLTeaserStyle),
+      deprecationReason: 'Use block styles instead of this'
+    },
 
     image: {
       type: GraphQLImage,
@@ -462,7 +489,10 @@ export const GraphQLPublicEventTeaser = new GraphQLObjectType<EventTeaser, Conte
 export const GraphQLPublicCustomTeaser = new GraphQLObjectType<CustomTeaser, Context>({
   name: 'CustomTeaser',
   fields: () => ({
-    style: {type: new GraphQLNonNull(GraphQLTeaserStyle)},
+    style: {
+      type: new GraphQLNonNull(GraphQLTeaserStyle),
+      deprecationReason: 'Use block styles instead of this'
+    },
 
     image: {
       type: GraphQLImage,
@@ -1243,9 +1273,9 @@ export const GraphQLLinkPageBreakBlock = new GraphQLObjectType<LinkPageBreakBloc
     linkText: {type: GraphQLString},
     linkTarget: {type: GraphQLString},
     hideButton: {type: new GraphQLNonNull(GraphQLBoolean)},
-    styleOption: {type: GraphQLString},
-    layoutOption: {type: GraphQLString},
-    templateOption: {type: GraphQLString},
+    styleOption: {type: GraphQLString, deprecationReason: 'Use block styles instead of this'},
+    layoutOption: {type: GraphQLString, deprecationReason: 'Use block styles instead of this'},
+    templateOption: {type: GraphQLString, deprecationReason: 'Use block styles instead of this'},
     image: {
       type: GraphQLImage,
       resolve: createProxyingResolver(({imageID}, _args, {loaders}) => {
@@ -1378,9 +1408,9 @@ export const GraphQLLinkPageBreakBlockInput = new GraphQLInputObjectType({
     linkText: {type: GraphQLString},
     linkTarget: {type: GraphQLString},
     hideButton: {type: new GraphQLNonNull(GraphQLBoolean)},
-    styleOption: {type: GraphQLString},
-    templateOption: {type: GraphQLString},
-    layoutOption: {type: GraphQLString},
+    styleOption: {type: GraphQLString, deprecationReason: 'Use block styles instead of this'},
+    templateOption: {type: GraphQLString, deprecationReason: 'Use block styles instead of this'},
+    layoutOption: {type: GraphQLString, deprecationReason: 'Use block styles instead of this'},
     imageID: {type: GraphQLID}
   }
 })
@@ -1534,7 +1564,10 @@ export const GraphQLCommentBlockInput = new GraphQLInputObjectType({
 export const GraphQLArticleTeaserInput = new GraphQLInputObjectType({
   name: 'ArticleTeaserInput',
   fields: {
-    style: {type: new GraphQLNonNull(GraphQLTeaserStyle)},
+    style: {
+      type: GraphQLTeaserStyle,
+      deprecationReason: 'Use block styles instead of this'
+    },
     imageID: {type: GraphQLID},
     preTitle: {type: GraphQLString},
     title: {type: GraphQLString},
@@ -1546,7 +1579,10 @@ export const GraphQLArticleTeaserInput = new GraphQLInputObjectType({
 export const GraphQLPeerArticleTeaserInput = new GraphQLInputObjectType({
   name: 'PeerArticleTeaserInput',
   fields: {
-    style: {type: new GraphQLNonNull(GraphQLTeaserStyle)},
+    style: {
+      type: GraphQLTeaserStyle,
+      deprecationReason: 'Use block styles instead of this'
+    },
     imageID: {type: GraphQLID},
     preTitle: {type: GraphQLString},
     title: {type: GraphQLString},
@@ -1559,7 +1595,10 @@ export const GraphQLPeerArticleTeaserInput = new GraphQLInputObjectType({
 export const GraphQLPageTeaserInput = new GraphQLInputObjectType({
   name: 'PageTeaserInput',
   fields: {
-    style: {type: new GraphQLNonNull(GraphQLTeaserStyle)},
+    style: {
+      type: GraphQLTeaserStyle,
+      deprecationReason: 'Use block styles instead of this'
+    },
     imageID: {type: GraphQLID},
     preTitle: {type: GraphQLString},
     title: {type: GraphQLString},
@@ -1571,7 +1610,10 @@ export const GraphQLPageTeaserInput = new GraphQLInputObjectType({
 export const GraphQLEventTeaserInput = new GraphQLInputObjectType({
   name: 'EventTeaserInput',
   fields: {
-    style: {type: new GraphQLNonNull(GraphQLTeaserStyle)},
+    style: {
+      type: GraphQLTeaserStyle,
+      deprecationReason: 'Use block styles instead of this'
+    },
     imageID: {type: GraphQLID},
     preTitle: {type: GraphQLString},
     title: {type: GraphQLString},
@@ -1583,7 +1625,10 @@ export const GraphQLEventTeaserInput = new GraphQLInputObjectType({
 export const GraphQLCustomTeaserInput = new GraphQLInputObjectType({
   name: 'CustomTeaserInput',
   fields: {
-    style: {type: new GraphQLNonNull(GraphQLTeaserStyle)},
+    style: {
+      type: GraphQLTeaserStyle,
+      deprecationReason: 'Use block styles instead of this'
+    },
     imageID: {type: GraphQLID},
     preTitle: {type: GraphQLString},
     title: {type: GraphQLString},

--- a/libs/ui/editor/src/lib/panel/linkPageBreakEditPanel.tsx
+++ b/libs/ui/editor/src/lib/panel/linkPageBreakEditPanel.tsx
@@ -1,5 +1,5 @@
 import {useTranslation} from 'react-i18next'
-import {Button, Drawer, Form, Radio, RadioGroup, SelectPicker, Toggle} from 'rsuite'
+import {Button, Drawer, Form, Radio, RadioGroup, Toggle} from 'rsuite'
 
 import {LinkPageBreakBlockValue} from '../blocks/types'
 
@@ -49,61 +49,6 @@ export function LinkPageBreakEditPanel({value, onClose, onChange}: LinkPageBreak
 
       <Drawer.Body>
         <Form fluid>
-          <Form.Group controlId="styleLabel">
-            <Form.ControlLabel>{t('linkPageBreakEditPanel.style.label')}</Form.ControlLabel>
-            <SelectPicker
-              block
-              virtualized
-              data={STYLE_OPTIONS.map(style => ({
-                value: style.id,
-                label: t(`linkPageBreakEditPanel.style.${style.id}`)
-              }))}
-              value={styleOption}
-              onChange={styleOption =>
-                onChange?.({
-                  ...value,
-                  styleOption: styleOption ?? undefined,
-                  layoutOption:
-                    styleOption === STYLE_OPTIONS[2].id ? LAYOUT_OPTIONS[0].id : value.layoutOption
-                })
-              }
-            />
-          </Form.Group>
-
-          <Form.Group controlId="layoutLabel">
-            <Form.ControlLabel>{t('linkPageBreakEditPanel.layout.label')}</Form.ControlLabel>
-            <SelectPicker
-              block
-              virtualized
-              data={LAYOUT_OPTIONS.filter(
-                layout => styleOption !== STYLE_OPTIONS[2].id || !layout.disabledIfImageStyle
-              ).map(layout => ({
-                value: layout.id,
-                label: t(`linkPageBreakEditPanel.layout.${layout.id}`)
-              }))}
-              value={layoutOption}
-              onChange={layoutOption =>
-                onChange?.({...value, layoutOption: layoutOption ?? undefined})
-              }
-            />
-          </Form.Group>
-
-          <Form.Group controlId="templateLabel">
-            <Form.ControlLabel>{t('linkPageBreakEditPanel.template.label')}</Form.ControlLabel>
-            <SelectPicker
-              block
-              virtualized
-              data={TEMPLATE_OPTIONS.map(template => ({
-                value: template.id,
-                label: t(`linkPageBreakEditPanel.template.${template?.id}`)
-              }))}
-              value={templateOption}
-              onChange={templateOption =>
-                onChange?.({...value, templateOption: templateOption ?? undefined})
-              }
-            />
-          </Form.Group>
-
           <Form.Group controlId="linkUrlLabel">
             <Form.ControlLabel>{t('linkPageBreakEditPanel.link.urlLabel')}</Form.ControlLabel>
             <Form.Control

--- a/libs/ui/editor/src/lib/panel/teaserEditPanel.tsx
+++ b/libs/ui/editor/src/lib/panel/teaserEditPanel.tsx
@@ -1,18 +1,9 @@
 import styled from '@emotion/styled'
-import {TeaserStyle, TeaserType} from '@wepublish/editor/api'
+import {TeaserType} from '@wepublish/editor/api'
 import {useState} from 'react'
 import {useTranslation} from 'react-i18next'
 import {TFunction} from 'i18next'
-import {
-  Button,
-  Drawer,
-  Form,
-  Input,
-  Panel as RPanel,
-  Radio,
-  RadioGroup,
-  Toggle as RToggle
-} from 'rsuite'
+import {Button, Drawer, Form, Input, Panel as RPanel, Toggle as RToggle} from 'rsuite'
 
 import {ChooseEditImage} from '../atoms/chooseEditImage'
 import {DescriptionList, DescriptionListItem} from '../atoms/descriptionList'
@@ -133,17 +124,6 @@ export function TeaserEditPanel({
         {previewForTeaser(initialTeaser, t)}
         <RPanel header={t('articleEditor.panels.displayOptions')}>
           <Form fluid>
-            <Group controlId="articleStyle">
-              <ControlLabel>{t('articleEditor.panels.style')}</ControlLabel>
-              <RadioGroup
-                inline
-                value={style}
-                onChange={teaserStyle => setStyle(teaserStyle as TeaserStyle)}>
-                <Radio value={TeaserStyle.Default}>{t('articleEditor.panels.default')}</Radio>
-                <Radio value={TeaserStyle.Light}>{t('articleEditor.panels.light')}</Radio>
-                <Radio value={TeaserStyle.Text}>{t('articleEditor.panels.text')}</Radio>
-              </RadioGroup>
-            </Group>
             <Group controlId="articlePreTitle">
               <ControlLabel>{t('articleEditor.panels.preTitle')}</ControlLabel>
               <Control

--- a/libs/ui/editor/src/lib/panel/teaserSelectPanel.tsx
+++ b/libs/ui/editor/src/lib/panel/teaserSelectPanel.tsx
@@ -37,8 +37,6 @@ import {
   Nav as RNav,
   Notification,
   Panel,
-  Radio,
-  RadioGroup,
   toaster,
   Toggle as RToggle,
   Loader as RLoader
@@ -569,17 +567,6 @@ export function TeaserSelectPanel({onClose, onSelect}: TeaserSelectPanelProps) {
 
             <Panel header={t('articleEditor.panels.displayOptions')}>
               <Form fluid>
-                <Form.Group controlId="articleStyle">
-                  <Form.ControlLabel>{t('articleEditor.panels.style')}</Form.ControlLabel>
-                  <RadioGroup
-                    inline
-                    value={style}
-                    onChange={teaserStyle => setStyle(teaserStyle as TeaserStyle)}>
-                    <Radio value={TeaserStyle.Default}>{t('articleEditor.panels.default')}</Radio>
-                    <Radio value={TeaserStyle.Light}>{t('articleEditor.panels.light')}</Radio>
-                    <Radio value={TeaserStyle.Text}>{t('articleEditor.panels.text')}</Radio>
-                  </RadioGroup>
-                </Form.Group>
                 <Form.Group controlId="articlePreTitle">
                   <Form.ControlLabel>{t('articleEditor.panels.preTitle')}</Form.ControlLabel>
                   <Form.Control


### PR DESCRIPTION
Also did the same thing for teasers.


BREAKING CHANGE: Style, template & layout options on break block is deprecated and not editable via the interface anymore. Still accessible through the API for now with deprecation notice.
BREAKING CHANGE: Style options on teasers is deprecated and not editable via the interface anymore. Still accessible through the API for now with deprecation notice.