### PR TITLE
SHARE-10: Make tests independent of current date

### DIFF
--- a/apps/editor/__tests__/specs/subscriptionEditView.test.tsx
+++ b/apps/editor/__tests__/specs/subscriptionEditView.test.tsx
@@ -57,6 +57,27 @@ jest.mock('react-router-dom', () => ({
   useParams: jest.fn()
 }))
 
+let OriginalDate: DateConstructor
+
+const mockCurrentDate = (mockDate: string) => {
+  const currentDate = new Date(mockDate)
+  OriginalDate = Date
+
+  global.Date = class extends Date {
+    constructor() {
+      super(currentDate as any)
+    }
+
+    static now() {
+      return currentDate.getTime()
+    }
+  } as any
+}
+
+const restoreOriginalDate = () => {
+  global.Date = OriginalDate
+}
+
 describe('Subscription edit view', () => {
   const mocks = [userListQuery, invoicesQuery, memberPlanListQuery, paymentMethodListQuery]
 
@@ -65,6 +86,8 @@ describe('Subscription edit view', () => {
   )
 
   test('should render', async () => {
+    mockCurrentDate('2024-05-21T12:00:00Z')
+
     const {asFragment} = render(
       <AuthContext.Provider value={sessionWithPermissions}>
         <MockedProvider mocks={mocks} addTypename={false}>
@@ -75,6 +98,8 @@ describe('Subscription edit view', () => {
       </AuthContext.Provider>
     )
     await actWait()
+
+    restoreOriginalDate()
 
     expect(asFragment()).toMatchSnapshot()
   })


### PR DESCRIPTION
The snapshots of the SubscriptionEditView were broken because they depended on a date picker that displayed the current date. When running the tests on a date other than 2024-05-21, the rendered DOM was different than the snapshotted version and the tests failed. This change mocks the date to a static date and makes the tests work.