### PR TITLE
feat(membership-website): redesigned subscribe page

### DIFF
--- a/libs/membership/website/src/lib/memberplan-picker/memberplan-picker.tsx
+++ b/libs/membership/website/src/lib/memberplan-picker/memberplan-picker.tsx
@@ -1,4 +1,5 @@
 import {FormControlLabel, RadioGroup, styled} from '@mui/material'
+import {toPlaintext} from '@wepublish/richtext'
 import {BuilderMemberPlanPickerProps, useWebsiteBuilder} from '@wepublish/website/builder'
 import {forwardRef, useEffect} from 'react'
 
@@ -38,6 +39,8 @@ export const MemberPlanPicker = forwardRef<HTMLButtonElement, BuilderMemberPlanP
 
     const showRadioButtons = memberPlans.length > 1
     const selectedMemberPlan = memberPlans.find(({id}) => id === value)
+    const showPicker =
+      showRadioButtons || toPlaintext(selectedMemberPlan?.description) || selectedMemberPlan?.image
 
     useEffect(() => {
       if (memberPlans.length && !selectedMemberPlan) {
@@ -46,34 +49,38 @@ export const MemberPlanPicker = forwardRef<HTMLButtonElement, BuilderMemberPlanP
     }, [memberPlans, onChange, selectedMemberPlan])
 
     return (
-      <MemberPlanPickerWrapper className={className}>
-        {showRadioButtons && (
-          <MemberPlanPickerRadios
-            name={name}
-            onChange={event => onChange(event.target.value)}
-            value={value ? value : ''}
-            ref={ref}>
-            {memberPlans.map(memberPlan => (
-              <FormControlLabel
-                key={memberPlan.id}
-                value={memberPlan.id}
-                control={
-                  <MemberPlanItem
-                    key={memberPlan.id}
-                    checked={memberPlan.id === value}
-                    name={memberPlan.name}
-                    amountPerMonthMin={memberPlan.amountPerMonthMin}
-                  />
-                }
-                label={memberPlan.name}
-              />
-            ))}
-          </MemberPlanPickerRadios>
-        )}
+      showPicker && (
+        <MemberPlanPickerWrapper className={className}>
+          {showRadioButtons && (
+            <MemberPlanPickerRadios
+              name={name}
+              onChange={event => onChange(event.target.value)}
+              value={value ? value : ''}
+              ref={ref}>
+              {memberPlans.map(memberPlan => (
+                <FormControlLabel
+                  key={memberPlan.id}
+                  value={memberPlan.id}
+                  control={
+                    <MemberPlanItem
+                      key={memberPlan.id}
+                      checked={memberPlan.id === value}
+                      name={memberPlan.name}
+                      amountPerMonthMin={memberPlan.amountPerMonthMin}
+                    />
+                  }
+                  label={memberPlan.name}
+                />
+              ))}
+            </MemberPlanPickerRadios>
+          )}
 
-        {selectedMemberPlan?.image && <Image image={selectedMemberPlan.image} />}
-        {selectedMemberPlan?.description && <RichText richText={selectedMemberPlan.description} />}
-      </MemberPlanPickerWrapper>
+          {selectedMemberPlan?.image && <Image image={selectedMemberPlan.image} />}
+          {selectedMemberPlan?.description && (
+            <RichText richText={selectedMemberPlan.description} />
+          )}
+        </MemberPlanPickerWrapper>
+      )
     )
   }
 )

--- a/libs/membership/website/src/lib/payment-method-picker/payment-method-picker.stories.tsx
+++ b/libs/membership/website/src/lib/payment-method-picker/payment-method-picker.stories.tsx
@@ -2,7 +2,12 @@ import {ApolloError} from '@apollo/client'
 import {css} from '@emotion/react'
 import {action} from '@storybook/addon-actions'
 import {Meta, StoryObj} from '@storybook/react'
-import {Exact, FullPaymentMethodFragment, PaymentPeriodicity} from '@wepublish/website/api'
+import {
+  Exact,
+  FullImageFragment,
+  FullPaymentMethodFragment,
+  PaymentPeriodicity
+} from '@wepublish/website/api'
 import {useState} from 'react'
 import {PaymentMethodPicker} from './payment-method-picker'
 
@@ -25,22 +30,57 @@ export default {
   }
 } as Meta<typeof PaymentMethodPicker>
 
+const image = {
+  __typename: 'Image',
+  id: 'ljh9FHAvHAs0AxC',
+  mimeType: 'image/jpg',
+  format: 'jpg',
+  createdAt: '2023-04-18T12:38:56.369Z',
+  modifiedAt: '2023-04-18T12:38:56.371Z',
+  filename: 'DSC07717',
+  extension: '.JPG',
+  width: 4000,
+  height: 6000,
+  fileSize: 8667448,
+  description: null,
+  tags: [],
+  source: null,
+  link: null,
+  license: null,
+  focalPoint: {
+    x: 0.5,
+    y: 0.5
+  },
+  title: null,
+  url: 'https://unsplash.it/500/281',
+  bigURL: 'https://unsplash.it/800/400',
+  largeURL: 'https://unsplash.it/500/300',
+  mediumURL: 'https://unsplash.it/300/200',
+  smallURL: 'https://unsplash.it/200/100',
+  squareBigURL: 'https://unsplash.it/800/800',
+  squareLargeURL: 'https://unsplash.it/500/500',
+  squareMediumURL: 'https://unsplash.it/300/300',
+  squareSmallURL: 'https://unsplash.it/200/200'
+} as FullImageFragment
+
 const stripePaymentMethod = {
   __typename: 'PaymentMethod',
   id: '1234',
   description: 'Mit Kreditkarte (Visa, Mastercard)',
   name: 'Stripe',
   slug: 'stripe',
-  paymentProviderID: '2'
+  paymentProviderID: '2',
+  image
 } as Exact<FullPaymentMethodFragment>
 
 const payrexxPaymentMethod = {
+  __typename: 'PaymentMethod',
   id: '12345',
   description: 'Mit TWINT, Paypal, Postfinance, usw.',
   name: 'Payrexx',
   slug: 'payrexx',
   paymentProviderID: '1',
-  __typename: 'PaymentMethod'
+  image
 } as Exact<FullPaymentMethodFragment>
 
 export const Default: StoryObj<typeof PaymentMethodPicker> = {

--- a/libs/membership/website/src/lib/payment-method-picker/payment-method-picker.tsx
+++ b/libs/membership/website/src/lib/payment-method-picker/payment-method-picker.tsx
@@ -1,16 +1,66 @@
-import {FormControl, InputLabel, Select, styled} from '@mui/material'
-import {PaymentPeriodicity} from '@wepublish/website/api'
-import {BuilderPaymentMethodPickerProps} from '@wepublish/website/builder'
-import {forwardRef, useEffect, useId} from 'react'
+import {
+  FormControl,
+  FormControlLabel,
+  Radio,
+  RadioGroup,
+  css,
+  styled,
+  useRadioGroup
+} from '@mui/material'
+import {BuilderPaymentMethodPickerProps, useWebsiteBuilder} from '@wepublish/website/builder'
+import {ComponentProps, PropsWithChildren, forwardRef, useEffect, useId} from 'react'
 
 export const PaymentMethodPickerWrapper = styled(FormControl)`
   display: grid;
 `
 
+export const PaymentRadioWrapper = styled('div')<{active?: boolean}>`
+  display: grid;
+  grid-auto-flow: column;
+  gap: ${({theme}) => theme.spacing(1)};
+  align-items: center;
+  padding: ${({theme}) => theme.spacing(2)};
+  border: 1px solid ${({theme}) => theme.palette.divider};
+  border-radius: ${({theme}) => theme.shape.borderRadius}px;
+  color: ${({theme}) => theme.palette.primary.main};
+
+  ${({active}) =>
+    active &&
+    css`
+      border-color: currentColor;
+    `};
+`
+
+const icon = css`
+  height: 40px;
+`
+
+const hiddenRadio = css`
+  visibility: hidden;
+  width: 0;
+  height: 0;
+`
+
+export function PaymentRadio({
+  children,
+  ...props
+}: PropsWithChildren<ComponentProps<typeof Radio>>) {
+  const radio = useRadioGroup()
+
+  return (
+    <>
+      <Radio {...props} css={hiddenRadio} />
+      <PaymentRadioWrapper active={radio?.value === props.value}>{children}</PaymentRadioWrapper>
+    </>
+  )
+}
+
 export const PaymentMethodPicker = forwardRef<HTMLButtonElement, BuilderPaymentMethodPickerProps>(
   function PaymentMethodPicker({paymentMethods, onChange, value, className, name}, ref) {
     const id = useId()
-    const show = paymentMethods && paymentMethods.length > 1
+    const {
+      elements: {Image}
+    } = useWebsiteBuilder()
 
     useEffect(() => {
       if (paymentMethods?.length && !paymentMethods.some(({id}) => id === value)) {
@@ -18,30 +68,27 @@ export const PaymentMethodPicker = forwardRef<HTMLButtonElement, BuilderPaymentM
       }
     }, [paymentMethods, onChange, value])
 
-    if (!show) {
-      return null
-    }
-
     return (
       <PaymentMethodPickerWrapper className={className}>
-        <>
-          <InputLabel htmlFor={id}>Zahlungsmethode</InputLabel>
-
-          <Select
-            native
-            label={'Zahlungsmethode'}
-            ref={ref}
-            name={name}
-            onChange={event => onChange(event.target.value as PaymentPeriodicity)}
-            value={value ? value : ''}
-            id={id}>
-            {paymentMethods.map(method => (
-              <option key={method.id} value={method.id}>
-                {method.description}
-              </option>
-            ))}
-          </Select>
-        </>
+        <RadioGroup
+          id={id}
+          ref={ref}
+          name={name}
+          value={value ? value : ''}
+          onChange={event => onChange(event.target.value as string)}
+          row>
+          {paymentMethods?.map(method => (
+            <FormControlLabel
+              key={method.id}
+              value={method.id}
+              label=""
+              control={
+                <PaymentRadio aria-label={`${method.description} ${method.name}`}>
+                  {method.image && <Image image={method.image} css={icon} />}
+                </PaymentRadio>
+              }></FormControlLabel>
+          ))}
+        </RadioGroup>
       </PaymentMethodPickerWrapper>
     )
   }

--- a/libs/membership/website/src/lib/subscribe/subscribe-container.tsx
+++ b/libs/membership/website/src/lib/subscribe/subscribe-container.tsx
@@ -22,7 +22,7 @@ import {OptionalKeysOf} from 'type-fest'
 export type SubscribeContainerProps<
   T extends OptionalKeysOf<RegisterMutationVariables> = OptionalKeysOf<RegisterMutationVariables>
 > = BuilderContainerProps &
-  Pick<BuilderSubscribeProps<T>, 'fields' | 'schema' | 'defaults'> & {
+  Pick<BuilderSubscribeProps<T>, 'fields' | 'schema' | 'defaults' | 'extraMoneyOffset'> & {
     successURL: string
     failureURL: string
     filter?: (memberPlans: MemberPlan[]) => MemberPlan[]
@@ -30,6 +30,7 @@ export type SubscribeContainerProps<
 
 export const SubscribeContainer = <T extends OptionalKeysOf<RegisterMutationVariables>>({
   className,
+  extraMoneyOffset,
   failureURL,
   successURL,
   defaults,
@@ -110,6 +111,7 @@ export const SubscribeContainer = <T extends OptionalKeysOf<RegisterMutationVari
 
       <Subscribe
         className={className}
+        extraMoneyOffset={extraMoneyOffset}
         defaults={defaults}
         fields={fields}
         schema={schema}

--- a/libs/membership/website/src/lib/subscribe/subscribe.stories.tsx
+++ b/libs/membership/website/src/lib/subscribe/subscribe.stories.tsx
@@ -91,6 +91,7 @@ const memberPlan = {
           name: 'Payrexx',
           slug: 'payrexx',
           paymentProviderID: '1',
+          image,
           __typename: 'PaymentMethod'
         },
         {
@@ -99,6 +100,7 @@ const memberPlan = {
           name: 'Payrexx',
           slug: 'payrexx',
           paymentProviderID: '1',
+          image,
           __typename: 'PaymentMethod'
         }
       ]
@@ -113,6 +115,7 @@ const memberPlan = {
           name: 'Stripe',
           slug: 'stripe',
           paymentProviderID: '2',
+          image,
           __typename: 'PaymentMethod'
         }
       ]
@@ -127,6 +130,7 @@ const memberPlan = {
           name: 'Stripe',
           slug: 'stripe',
           paymentProviderID: '2',
+          image,
           __typename: 'PaymentMethod'
         }
       ]
@@ -374,13 +378,10 @@ const changePaymentMethod =
   async ({canvasElement, step}) => {
     const canvas = within(canvasElement)
 
-    const input = canvas.getByLabelText('Zahlungsmethode', {
-      selector: 'select'
-    })
+    const input = canvas.getByLabelText(`${paymentMethod.description} ${paymentMethod.name}`)
 
     await step('Change Paymentmethod', async () => {
       await userEvent.click(input)
-      await userEvent.selectOptions(input, paymentMethod.description)
       await wait(10) // wait for reset to happen
     })
   }

--- a/libs/website/api/src/lib/schemas/membership.graphql
+++ b/libs/website/api/src/lib/schemas/membership.graphql
@@ -4,6 +4,9 @@ fragment FullPaymentMethod on PaymentMethod {
   name
   slug
   description
+  image {
+    ...FullImage
+  }
 }
 
 fragment FullAvailablePaymentMethod on AvailablePaymentMethod {

--- a/libs/website/builder/src/lib/membership.interface.ts
+++ b/libs/website/builder/src/lib/membership.interface.ts
@@ -98,4 +98,5 @@ export type BuilderSubscribeProps<
     name: string
     firstName: string
   }>
+  extraMoneyOffset?: number
 } & Pick<BuilderRegistrationFormProps<T>, 'schema' | 'fields'>


### PR DESCRIPTION
1. Hide auto renew when forceAutorenew is set
2. Membership picker now fully hides when no content is present and it's the only one
3. Paymentmethod picker now supports images
4. Bonus money is gone and now part of the slider which shows how much you are paying
