### PR TITLE
BA-33: Move nav in front of banner

### DIFF
--- a/apps/bajour/pages/_app.tsx
+++ b/apps/bajour/pages/_app.tsx
@@ -68,7 +68,7 @@ type CustomAppProps = AppProps<{
 
 const NavBar = styled(NavbarContainer)`
   grid-column: -1/1;
-  z-index: 11;
+  z-index: 12;
 `
 
 const Footer = styled(FooterContainer)`

--- a/apps/editor/src/app/locales/en.json
+++ b/apps/editor/src/app/locales/en.json
@@ -221,9 +221,9 @@
         "delete": "Delete banner"
       },
       "form": {
-        "title": "Title",
-        "text": "Text",
-        "cta": "Call to action",
+        "title": "Title (maximized only)",
+        "text": "Text (maximized only)",
+        "cta": "Call to action (minimized only)",
         "active": "Active",
         "showOnArticles": "Display on articles",
         "showOnPages": "Display on those pages",


### PR DESCRIPTION
The banner was placed in front of the Bajour navigation, because it needed to be in front of the footer. This change moves the navbar one layer to the front.