### PR TITLE
fix: display tag name in tag deletion dialog

### DIFF
--- a/apps/editor/src/app/routes/tags/tagList.tsx
+++ b/apps/editor/src/app/routes/tags/tagList.tsx
@@ -383,7 +383,9 @@ const TagList = memo<TagListProps>(({type}) => {
 
       <Modal open={!!tagToDelete} backdrop="static" size="xs" onClose={() => setTagToDelete(null)}>
         <Modal.Title>{t('tags.overview.areYouSure')}</Modal.Title>
-        <Modal.Body>{t('tags.overview.areYouSureBody', {tag: formValue[tagToDelete!]})}</Modal.Body>
+        <Modal.Body>
+          {t('tags.overview.areYouSureBody', {tag: formValue[tagToDelete!].tag})}
+        </Modal.Body>
         <Modal.Footer>
           <Button
             color="red"


### PR DESCRIPTION
The deletion dialog for the tags should display the name of the tag that is to be deleted. After this change, the dialog displays the tags name instead of [Object object].