### PR TITLE
temporarily remove profile picture

### DIFF
--- a/libs/user/website/src/lib/personal-data-form/personal-data-form.tsx
+++ b/libs/user/website/src/lib/personal-data-form/personal-data-form.tsx
@@ -172,7 +172,8 @@ export function PersonalDataForm<T extends BuilderPersonalDataFormFields>({
   return (
     <PersonalDataFormWrapper className={className} onSubmit={onSubmit}>
       <PersonalDataInputForm>
-        {fieldsToDisplay.image && (
+        {/* todo: temporarily removed ability to change own profile picture. will be available again after v1 to v2 api migration is complete.  */}
+        {false && fieldsToDisplay.image && (
           <PersonalDataImageInputWrapper>
             <ImageUpload image={user.image} onUpload={callAction(onImageUpload)} />
           </PersonalDataImageInputWrapper>


### PR DESCRIPTION
Until we've done with v1/v2 api migration, we cannot upload profile image picture. to avoid constant user feedback un-commented it.