### PR TITLE
BA-159: Remove height limit from context box

### DIFF
--- a/apps/bajour/src/components/frage-des-tages/info-box.tsx
+++ b/apps/bajour/src/components/frage-des-tages/info-box.tsx
@@ -15,6 +15,7 @@ export const InfoBoxWrapper = styled('aside')<{expanded: boolean}>`
   grid-template-columns: 1fr 1fr;
   gap: ${({theme}) => theme.spacing(1)};
   height: ${({theme}) => theme.spacing(28)};
+  interpolate-size: allow-keywords;
   transition: height 0.3s ease;
   background-color: ${({theme}) => theme.palette.common.white};
   padding: ${({theme}) => theme.spacing(1.5)};
@@ -48,9 +49,9 @@ const AllAbout = styled('div')`
 
 const RichTextBlockWrapper = styled('div')<{expanded: boolean}>`
   height: ${({theme}) => theme.spacing(14)};
-  max-height: ${({theme}) => theme.spacing(14)};
   overflow: hidden;
-  transition: max-height 0.3s ease-in-out;
+  interpolate-size: allow-keywords;
+  transition: height 0.3s ease-in-out;
   span {
     font-weight: 300;
   }
@@ -59,7 +60,6 @@ const RichTextBlockWrapper = styled('div')<{expanded: boolean}>`
     expanded &&
     css`
       height: auto;
-      max-height: ${theme.spacing(100)};
     `}
 `
 

--- a/apps/bajour/src/styles/theme.ts
+++ b/apps/bajour/src/styles/theme.ts
@@ -84,6 +84,13 @@ const theme = createTheme({}, WepTheme, {
             backgroundColor: 'transparent',
             borderWidth: '3px'
           }
+        },
+        contained: {
+          '@media (hover: none)': {
+            ':hover': {
+              backgroundColor: '#ffbaba'
+            }
+          }
         }
       }
     }

--- a/libs/block-content/website/src/lib/block-styles/context-box/context-box.tsx
+++ b/libs/block-content/website/src/lib/block-styles/context-box/context-box.tsx
@@ -29,16 +29,15 @@ export const ContextBoxTitle = styled('div')`
 
 export const ContextBoxCollapse = styled('div')<{expanded: boolean}>`
   height: ${({theme}) => theme.spacing(15)};
-  max-height: ${({theme}) => theme.spacing(15)};
   overflow: hidden;
-  transition: max-height 0.3s ease-in-out;
+  interpolate-size: allow-keywords;
+  transition: height 0.3s ease-in-out;
   font-style: italic;
 
   ${({theme, expanded}) =>
     expanded &&
     css`
       height: auto;
-      max-height: ${theme.spacing(100)};
     `}
 `
 


### PR DESCRIPTION
The context box had a height limit of 800 px when expanded. This doesn't really make sense, because some content might still be hidden. This removes the limit, making the component more flexible, and it is now the responsibility of the media to make sure it fits into their design.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

This release focuses on improved visual interactions and smoother transitions, enhancing the overall user experience.

- **Style**
	- Components now adjust their height more fluidly when expanded for enhanced content display.
	- Buttons display refined background changes on interaction, particularly on devices without hover support.
	- Transition animations have been smoothed out for a more seamless user interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->