### PR TITLE
fix(wp): remove migration payment method implemented twice

### DIFF
--- a/libs/membership/editor/src/lib/memberplan/memberplan-form.tsx
+++ b/libs/membership/editor/src/lib/memberplan/memberplan-form.tsx
@@ -456,27 +456,6 @@ export function MemberPlanForm({
                 />
               </Row>
             </Col>
-
-            <Col xs={12}>
-              <ControlLabel>{t('memberplanForm.migratePMTitle')}</ControlLabel>
-              <Control
-                name="migrateToTargetPaymentMethodID"
-                block
-                virtualized
-                disabled={loading}
-                data={paymentMethods.map(pm => ({value: pm.id, label: pm.name}))}
-                value={memberPlan?.migrateToTargetPaymentMethodID}
-                accepter={SelectPicker}
-                placement="auto"
-                onChange={migrateToTargetPaymentMethodID =>
-                  setMemberPlan({
-                    ...(memberPlan as FullMemberPlanFragment),
-                    migrateToTargetPaymentMethodID: migrateToTargetPaymentMethodID || null
-                  })
-                }
-              />
-              <HelpText>{t('memberplanForm.migratePMHelptext')}</HelpText>
-            </Col>
           </Row>
         </Panel>
       </Col>


### PR DESCRIPTION
This pr removes a part of the member plan form, where the migration of subscriptions to a target payment method was displayed twice. Probably due to a merge mistake.
![image](https://github.com/user-attachments/assets/1a87a7f7-452d-48ed-ac61-584f4910265c)