### PR TITLE
fix(bajour): make primary banner optional

### DIFF
--- a/apps/api-example/schema-v2.graphql
+++ b/apps/api-example/schema-v2.graphql
@@ -501,7 +501,7 @@ type Query {
 
   """Returns a paginated list of poll votes"""
   pollVotes(cursorId: ID, filter: PollVoteFilter, order: SortOrder = Ascending, skip: Int = 0, sort: PollVoteSort = CreatedAt, take: Int = 10): PaginatedPollVotes!
-  primaryBanner(documentId: ID!, documentType: BannerDocumentType!, loggedIn: Boolean!): Banner!
+  primaryBanner(documentId: ID!, documentType: BannerDocumentType!, loggedIn: Boolean!): Banner
   provider: MailProviderModel!
 
   "\n      Returns all renewing subscribers in a given timeframe.\n    "

--- a/libs/api/__tests__/api/public/index.ts
+++ b/libs/api/__tests__/api/public/index.ts
@@ -1750,7 +1750,7 @@ export type Query = {
   poll: FullPoll;
   /** Returns a paginated list of poll votes */
   pollVotes: PaginatedPollVotes;
-  primaryBanner: Banner;
+  primaryBanner?: Maybe<Banner>;
   provider: MailProviderModel;
   ratingSystem: FullCommentRatingSystem;
   /**

--- a/libs/banner/api/src/lib/banner.resolver.spec.ts
+++ b/libs/banner/api/src/lib/banner.resolver.spec.ts
@@ -75,8 +75,7 @@ describe('BannerResolver', () => {
 
     it('should throw NotFoundException when banner not found', async () => {
       mockBannerService.findOne.mockResolvedValue(null)
-      const result = await resolver.banner('1')
-      expect(result).toEqual(null)
+      await expect(resolver.banner('1')).rejects.toThrow()
     })
   })
 
@@ -91,7 +90,7 @@ describe('BannerResolver', () => {
       expect(result).toEqual(mockBanner)
     })
 
-    it('should throw NotFoundException when no primary banner found', async () => {
+    it('should return null when no primary banner found', async () => {
       mockBannerService.findFirst.mockResolvedValue(null)
       const result = await resolver.primaryBanner({
         documentType: BannerDocumentType.ARTICLE,

--- a/libs/banner/api/src/lib/banner.resolver.ts
+++ b/libs/banner/api/src/lib/banner.resolver.ts
@@ -19,6 +19,7 @@ import {
   Permissions,
   Public
 } from '@wepublish/permissions/api'
+import {NotFoundException} from '@nestjs/common'
 
 @Resolver(() => Banner)
 export class BannerResolver {
@@ -34,9 +35,13 @@ export class BannerResolver {
   }
 
   @Permissions(CanGetBanner)
-  @Query(() => Banner, {nullable: true})
-  async banner(@Args('id') args: string): Promise<Banner | null> {
-    return await this.bannerService.findOne(args)
+  @Query(() => Banner)
+  async banner(@Args('id') args: string): Promise<Banner> {
+    const banner = await this.bannerService.findOne(args)
+    if (!banner) {
+      throw new NotFoundException()
+    }
+    return banner
   }
 
   @Public()

--- a/libs/banner/api/src/lib/banner.resolver.ts
+++ b/libs/banner/api/src/lib/banner.resolver.ts
@@ -39,7 +39,7 @@ export class BannerResolver {
   async banner(@Args('id') args: string): Promise<Banner> {
     const banner = await this.bannerService.findOne(args)
     if (!banner) {
-      throw new NotFoundException()
+      throw new NotFoundException(`Banner with id ${args} not found`)
     }
     return banner
   }

--- a/libs/banner/website/src/lib/banner.tsx
+++ b/libs/banner/website/src/lib/banner.tsx
@@ -82,7 +82,7 @@ const BannerWrapper = styled('div')<BannerWrapperProps>(
 
 export const Banner = ({data, loading, error, className}: BuilderBannerProps) => {
   const [collapsed, setCollapsed] = useState(true)
-  const storageKey = `banner-last-closed-${data?.primaryBanner.id}`
+  const storageKey = `banner-last-closed-${data?.primaryBanner?.id}`
 
   useEffect(() => {
     const lastClosedTime = Number(localStorage.getItem(storageKey)) ?? 0

--- a/libs/editor/api-v2/src/lib/graphql.ts
+++ b/libs/editor/api-v2/src/lib/graphql.ts
@@ -1752,7 +1752,7 @@ export type Query = {
   poll: FullPoll;
   /** Returns a paginated list of poll votes */
   pollVotes: PaginatedPollVotes;
-  primaryBanner: Banner;
+  primaryBanner?: Maybe<Banner>;
   provider: MailProviderModel;
   ratingSystem: FullCommentRatingSystem;
   /**

--- a/libs/website/api/src/lib/graphql.ts
+++ b/libs/website/api/src/lib/graphql.ts
@@ -1752,7 +1752,7 @@ export type Query = {
   poll: FullPoll;
   /** Returns a paginated list of poll votes */
   pollVotes: PaginatedPollVotes;
-  primaryBanner: Banner;
+  primaryBanner?: Maybe<Banner>;
   provider: MailProviderModel;
   ratingSystem: FullCommentRatingSystem;
   /**
@@ -2605,7 +2605,7 @@ export type PrimaryBannerQueryVariables = Exact<{
 }>;
 
 
-export type PrimaryBannerQuery = { __typename?: 'Query', primaryBanner: { __typename?: 'Banner', id: string, title: string, text: string, cta?: string | null, showOnArticles: boolean, showOnPages?: Array<{ __typename?: 'PageModel', id: string }> | null, image?: { __typename?: 'Image', id: string, createdAt: string, modifiedAt: string, filename?: string | null, format: string, mimeType: string, extension: string, width: number, height: number, fileSize: number, title?: string | null, description?: string | null, tags: Array<string>, source?: string | null, link?: string | null, license?: string | null, url?: string | null, xl?: string | null, l?: string | null, m?: string | null, s?: string | null, xs?: string | null, xxs?: string | null, xlSquare?: string | null, lSquare?: string | null, mSquare?: string | null, sSquare?: string | null, xsSquare?: string | null, xxsSquare?: string | null, focalPoint?: { __typename?: 'FocalPoint', x: number, y: number } | null } | null, actions?: Array<{ __typename?: 'BannerAction', id: string, label: string, url: string, style: string, role: BannerActionRole }> | null } };
+export type PrimaryBannerQuery = { __typename?: 'Query', primaryBanner?: { __typename?: 'Banner', id: string, title: string, text: string, cta?: string | null, showOnArticles: boolean, showOnPages?: Array<{ __typename?: 'PageModel', id: string }> | null, image?: { __typename?: 'Image', id: string, createdAt: string, modifiedAt: string, filename?: string | null, format: string, mimeType: string, extension: string, width: number, height: number, fileSize: number, title?: string | null, description?: string | null, tags: Array<string>, source?: string | null, link?: string | null, license?: string | null, url?: string | null, xl?: string | null, l?: string | null, m?: string | null, s?: string | null, xs?: string | null, xxs?: string | null, xlSquare?: string | null, lSquare?: string | null, mSquare?: string | null, sSquare?: string | null, xsSquare?: string | null, xxsSquare?: string | null, focalPoint?: { __typename?: 'FocalPoint', x: number, y: number } | null } | null, actions?: Array<{ __typename?: 'BannerAction', id: string, label: string, url: string, style: string, role: BannerActionRole }> | null } | null };
 
 type BlockWithoutTeaser_BildwurfAdBlock_Fragment = { __typename: 'BildwurfAdBlock', blockStyle?: string | null, zoneID: string };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated primary banner handling to gracefully manage cases when a banner isn’t available, ensuring a smoother and more reliable display.
  - Enhanced banner display safety so that interfaces render consistently without runtime issues when banner data is missing.
- **New Features**
  - The `primaryBanner` query now allows for a null return value, indicating that a primary banner may not always be present.
  - Improved error handling in the banner resolver to throw an exception when a requested banner is not found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->