### PR TITLE
feat(all): Add video player to search slider

### DIFF
--- a/apps/bajour/src/components/search-slider/search-slider.tsx
+++ b/apps/bajour/src/components/search-slider/search-slider.tsx
@@ -1,7 +1,7 @@
 import 'keen-slider/keen-slider.min.css'
 
 import {styled} from '@mui/material'
-import {H1, H4} from '@wepublish/ui'
+import {Button, H1, H4} from '@wepublish/ui'
 import {
   ApiV1,
   CommentListItemShare,
@@ -195,6 +195,25 @@ const SlideTitle = styled('span')`
   text-shadow: 2px 2px 2px rgba(0, 0, 0, 0.58);
 `
 
+const FullScreenVideoContainer = styled('div')`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: black;
+  z-index: 13;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`
+
+const FullScreenVideo = styled('video')`
+  width: 90vw;
+  height: 85vh;
+  margin: 5vh 5vw 0 5vw;
+`
+
 export type SliderArticle = Omit<ApiV1.Article, 'comments' | 'socialMediaAuthors'> & {
   blocks: ApiV1.Block[]
 }
@@ -220,6 +239,7 @@ export function SearchSlider({article}: SearchSliderProps) {
   const [slidesDetails, setSlidesDetails] = useState<TrackDetails['slides']>()
   const [searchQuery, setSearchQuery] = useState<string | null>()
   const [searchHits, setSearchHits] = useState<number | undefined>(undefined)
+  const [videoUrl, setVideoUrl] = useState<string | null>(null)
 
   // getting the first tag from initial article which is not the technical search-slider tag.
   const tag = useMemo(() => article?.tags.find(tag => tag.tag !== SEARCH_SLIDER_TAG), [article])
@@ -474,6 +494,13 @@ export function SearchSlider({article}: SearchSliderProps) {
               className={`keen-slider__slide`}
               mainImage={mainArticle.id === article?.id}
               onClick={() => {
+                // Click on current slide
+                if (currentSlide === idx) {
+                  const videoProperty = article?.properties.find(p => p.key === 'video')
+                  if (videoProperty) {
+                    setVideoUrl(videoProperty.value)
+                  }
+                }
                 keenSliderRef.current?.moveToIdx(idx)
                 // used for the stuck slider elements on the very right side, if slider can't be moved further to the right.
                 setCurrentSlide(idx)
@@ -493,6 +520,13 @@ export function SearchSlider({article}: SearchSliderProps) {
           )
         })}
       </SliderContainer>
+
+      {videoUrl && (
+        <FullScreenVideoContainer>
+          <FullScreenVideo src={videoUrl} controls autoPlay />
+          <Button onClick={() => setVideoUrl(null)}>Schliessen</Button>
+        </FullScreenVideoContainer>
+      )}
 
       <TextContainer>
         <div>{mainArticle.preTitle && <H5 gutterBottom>{mainArticle.preTitle} </H5>}</div>


### PR DESCRIPTION
This change allows media to add a "video" property to their search slider articles. If such a property is present, clicking on the current slide of  the search slider opens a full screen video player.