### PR TITLE
BA-204: Shorten briefing button label on mobile

### DIFF
--- a/apps/bajour/src/components/briefing/basel-briefing.tsx
+++ b/apps/bajour/src/components/briefing/basel-briefing.tsx
@@ -318,6 +318,14 @@ export const Avatar = styled(Image)`
   }
 `
 
+const DesktopOnly = styled('span')`
+  display: none;
+
+  ${({theme}) => theme.breakpoints.up('sm')} {
+    display: inline;
+  }
+`
+
 export const BaselBriefing = ({teasers, blockStyle}: BaselBriefingProps) => {
   let showFrom = undefined
   let showUntil = undefined
@@ -406,7 +414,7 @@ export const BaselBriefing = ({teasers, blockStyle}: BaselBriefingProps) => {
                   href="https://bajour.ch/basel-briefing-podcast"
                   target={'_blank'}>
                   <ReadMoreButton variant="outlined" color="inherit" size="small">
-                    Briefing hören
+                    <DesktopOnly>Briefing </DesktopOnly>hören
                   </ReadMoreButton>
                 </LinkWrapper>
               )}
@@ -416,7 +424,7 @@ export const BaselBriefing = ({teasers, blockStyle}: BaselBriefingProps) => {
                 href={briefingDynamicValues.contentUrl}
                 target={'_blank'}>
                 <ReadMoreButton variant="outlined" color="inherit" size="small">
-                  Briefing lesen
+                  <DesktopOnly>Briefing </DesktopOnly>lesen
                 </ReadMoreButton>
               </LinkWrapper>
             </ButtonRow>

--- a/apps/bajour/src/components/briefing/basel-briefing.tsx
+++ b/apps/bajour/src/components/briefing/basel-briefing.tsx
@@ -318,7 +318,7 @@ export const Avatar = styled(Image)`
   }
 `
 
-const DesktopOnly = styled('span')`
+const HideOnMobile = styled('span')`
   display: none;
 
   ${({theme}) => theme.breakpoints.up('sm')} {
@@ -414,7 +414,7 @@ export const BaselBriefing = ({teasers, blockStyle}: BaselBriefingProps) => {
                   href="https://bajour.ch/basel-briefing-podcast"
                   target={'_blank'}>
                   <ReadMoreButton variant="outlined" color="inherit" size="small">
-                    <DesktopOnly>Briefing </DesktopOnly>hören
+                    <HideOnMobile>Briefing </HideOnMobile>hören
                   </ReadMoreButton>
                 </LinkWrapper>
               )}
@@ -424,7 +424,7 @@ export const BaselBriefing = ({teasers, blockStyle}: BaselBriefingProps) => {
                 href={briefingDynamicValues.contentUrl}
                 target={'_blank'}>
                 <ReadMoreButton variant="outlined" color="inherit" size="small">
-                  <DesktopOnly>Briefing </DesktopOnly>lesen
+                  <HideOnMobile>Briefing </HideOnMobile>lesen
                 </ReadMoreButton>
               </LinkWrapper>
             </ButtonRow>


### PR DESCRIPTION
This reduces the size of the briefing buttons on mobile devices and makes sure they do not wrap their content on two lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced briefing buttons to display extended text on larger screens, providing a clearer and more responsive user interface across different devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->