### PR TITLE
fix(websites): SSR beaking broken (race condition)

### DIFF
--- a/apps/babanews/pages/a/[slug].tsx
+++ b/apps/babanews/pages/a/[slug].tsx
@@ -83,7 +83,7 @@ export default function ArticleBySlugIdOrToken() {
 export const getStaticPaths = getArticlePathsBasedOnPage('')
 
 export const getStaticProps: GetStaticProps = async ({params}) => {
-  const {slug} = params || {}
+  const {slug, id, token} = params || {}
   const {publicRuntimeConfig} = getConfig()
 
   const client = ApiV1.getV1ApiClient(publicRuntimeConfig.env.API_URL!, [])
@@ -92,7 +92,9 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
     client.query({
       query: ApiV1.ArticleDocument,
       variables: {
-        slug
+        slug,
+        id,
+        token
       }
     }),
     client.query({

--- a/apps/babanews/pages/a/preview/[token].tsx
+++ b/apps/babanews/pages/a/preview/[token].tsx
@@ -9,7 +9,7 @@ export default function PreviewArticleByToken() {
 }
 
 export const getServerSideProps = (async ({params}) => {
-  const {token} = params || {}
+  const {slug, id, token} = params || {}
   const {publicRuntimeConfig} = getConfig()
 
   const client = ApiV1.getV1ApiClient(publicRuntimeConfig.env.API_URL!, [])
@@ -18,6 +18,8 @@ export const getServerSideProps = (async ({params}) => {
     client.query({
       query: ApiV1.ArticleDocument,
       variables: {
+        slug,
+        id,
         token
       }
     }),

--- a/apps/bajour/pages/a/[slug].tsx
+++ b/apps/bajour/pages/a/[slug].tsx
@@ -154,16 +154,18 @@ export default function ArticleBySlugIdOrToken() {
 export const getStaticPaths = getArticlePathsBasedOnPage('home')
 
 export const getStaticProps: GetStaticProps = async ({params}) => {
-  const {slug} = params || {}
-
+  const {slug, id, token} = params || {}
   const {publicRuntimeConfig} = getConfig()
+
   const client = ApiV1.getV1ApiClient(publicRuntimeConfig.env.API_URL!, [])
 
   const [article] = await Promise.all([
     client.query({
       query: ApiV1.ArticleDocument,
       variables: {
-        slug
+        slug,
+        id,
+        token
       }
     }),
     client.query({

--- a/apps/bajour/pages/a/preview/[token].tsx
+++ b/apps/bajour/pages/a/preview/[token].tsx
@@ -9,7 +9,7 @@ export default function PreviewArticleByToken() {
 }
 
 export const getServerSideProps = (async ({params}) => {
-  const {token} = params || {}
+  const {slug, id, token} = params || {}
   const {publicRuntimeConfig} = getConfig()
 
   const client = ApiV1.getV1ApiClient(publicRuntimeConfig.env.API_URL!, [])
@@ -18,6 +18,8 @@ export const getServerSideProps = (async ({params}) => {
     client.query({
       query: ApiV1.ArticleDocument,
       variables: {
+        slug,
+        id,
         token
       }
     }),

--- a/apps/cultur/pages/a/[slug].tsx
+++ b/apps/cultur/pages/a/[slug].tsx
@@ -63,7 +63,7 @@ export default function ArticleBySlugIdOrToken() {
 export const getStaticPaths = getArticlePathsBasedOnPage('')
 
 export const getStaticProps: GetStaticProps = async ({params}) => {
-  const {slug} = params || {}
+  const {slug, id, token} = params || {}
   const {publicRuntimeConfig} = getConfig()
 
   const client = ApiV1.getV1ApiClient(publicRuntimeConfig.env.API_URL!, [])
@@ -72,7 +72,9 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
     client.query({
       query: ApiV1.ArticleDocument,
       variables: {
-        slug
+        slug,
+        id,
+        token
       }
     }),
     client.query({

--- a/apps/cultur/pages/a/preview/[token].tsx
+++ b/apps/cultur/pages/a/preview/[token].tsx
@@ -9,7 +9,7 @@ export default function PreviewArticleByToken() {
 }
 
 export const getServerSideProps = (async ({params}) => {
-  const {token} = params || {}
+  const {slug, id, token} = params || {}
   const {publicRuntimeConfig} = getConfig()
 
   const client = ApiV1.getV1ApiClient(publicRuntimeConfig.env.API_URL!, [])
@@ -18,6 +18,8 @@ export const getServerSideProps = (async ({params}) => {
     client.query({
       query: ApiV1.ArticleDocument,
       variables: {
+        slug,
+        id,
         token
       }
     }),

--- a/apps/demo/pages/a/[slug].tsx
+++ b/apps/demo/pages/a/[slug].tsx
@@ -63,7 +63,7 @@ export default function ArticleBySlugIdOrToken() {
 export const getStaticPaths = getArticlePathsBasedOnPage('')
 
 export const getStaticProps: GetStaticProps = async ({params}) => {
-  const {slug} = params || {}
+  const {slug, id, token} = params || {}
   const {publicRuntimeConfig} = getConfig()
 
   const client = ApiV1.getV1ApiClient(publicRuntimeConfig.env.API_URL!, [])
@@ -72,7 +72,9 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
     client.query({
       query: ApiV1.ArticleDocument,
       variables: {
-        slug
+        slug,
+        id,
+        token
       }
     }),
     client.query({

--- a/apps/demo/pages/a/preview/[token].tsx
+++ b/apps/demo/pages/a/preview/[token].tsx
@@ -9,7 +9,7 @@ export default function PreviewArticleByToken() {
 }
 
 export const getServerSideProps = (async ({params}) => {
-  const {token} = params || {}
+  const {slug, id, token} = params || {}
   const {publicRuntimeConfig} = getConfig()
 
   const client = ApiV1.getV1ApiClient(publicRuntimeConfig.env.API_URL!, [])
@@ -18,6 +18,8 @@ export const getServerSideProps = (async ({params}) => {
     client.query({
       query: ApiV1.ArticleDocument,
       variables: {
+        slug,
+        id,
         token
       }
     }),

--- a/apps/gruppetto/pages/a/[slug].tsx
+++ b/apps/gruppetto/pages/a/[slug].tsx
@@ -64,7 +64,7 @@ export default function ArticleBySlugIdOrToken() {
 export const getStaticPaths = getArticlePathsBasedOnPage('')
 
 export const getStaticProps: GetStaticProps = async ({params}) => {
-  const {slug} = params || {}
+  const {slug, id, token} = params || {}
   const {publicRuntimeConfig} = getConfig()
 
   const client = ApiV1.getV1ApiClient(publicRuntimeConfig.env.API_URL!, [])
@@ -73,7 +73,9 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
     client.query({
       query: ApiV1.ArticleDocument,
       variables: {
-        slug
+        slug,
+        id,
+        token
       }
     }),
     client.query({

--- a/apps/gruppetto/pages/a/preview/[token].tsx
+++ b/apps/gruppetto/pages/a/preview/[token].tsx
@@ -9,7 +9,7 @@ export default function PreviewArticleByToken() {
 }
 
 export const getServerSideProps = (async ({params}) => {
-  const {token} = params || {}
+  const {slug, id, token} = params || {}
   const {publicRuntimeConfig} = getConfig()
 
   const client = ApiV1.getV1ApiClient(publicRuntimeConfig.env.API_URL!, [])
@@ -18,6 +18,8 @@ export const getServerSideProps = (async ({params}) => {
     client.query({
       query: ApiV1.ArticleDocument,
       variables: {
+        slug,
+        id,
         token
       }
     }),

--- a/apps/mannschaft/pages/a/[slug].tsx
+++ b/apps/mannschaft/pages/a/[slug].tsx
@@ -92,7 +92,7 @@ export default function ArticleBySlugIdOrToken() {
 export const getStaticPaths = getPagePathsBasedOnPage('')
 
 export const getStaticProps: GetStaticProps = async ({params}) => {
-  const {slug} = params || {}
+  const {slug, id, token} = params || {}
   const {publicRuntimeConfig} = getConfig()
 
   const client = ApiV1.getV1ApiClient(publicRuntimeConfig.env.API_URL!, [])
@@ -101,7 +101,9 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
     client.query({
       query: ApiV1.ArticleDocument,
       variables: {
-        slug
+        slug,
+        id,
+        token
       }
     }),
     client.query({

--- a/apps/mannschaft/pages/a/preview/[token].tsx
+++ b/apps/mannschaft/pages/a/preview/[token].tsx
@@ -9,7 +9,7 @@ export default function PreviewArticleByToken() {
 }
 
 export const getServerSideProps = (async ({params}) => {
-  const {token} = params || {}
+  const {slug, id, token} = params || {}
   const {publicRuntimeConfig} = getConfig()
 
   const client = ApiV1.getV1ApiClient(publicRuntimeConfig.env.API_URL!, [])
@@ -18,6 +18,8 @@ export const getServerSideProps = (async ({params}) => {
     client.query({
       query: ApiV1.ArticleDocument,
       variables: {
+        slug,
+        id,
         token
       }
     }),

--- a/apps/onlinereports/pages/a/[slug].tsx
+++ b/apps/onlinereports/pages/a/[slug].tsx
@@ -63,7 +63,7 @@ export default function ArticleBySlugIdOrToken() {
 export const getStaticPaths = getArticlePathsBasedOnPage('')
 
 export const getStaticProps: GetStaticProps = async ({params}) => {
-  const {slug} = params || {}
+  const {slug, id, token} = params || {}
   const {publicRuntimeConfig} = getConfig()
 
   const client = ApiV1.getV1ApiClient(publicRuntimeConfig.env.API_URL!, [])
@@ -72,7 +72,9 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
     client.query({
       query: ApiV1.ArticleDocument,
       variables: {
-        slug
+        slug,
+        id,
+        token
       }
     }),
     client.query({

--- a/apps/onlinereports/pages/a/preview/[token].tsx
+++ b/apps/onlinereports/pages/a/preview/[token].tsx
@@ -9,7 +9,7 @@ export default function PreviewArticleByToken() {
 }
 
 export const getServerSideProps = (async ({params}) => {
-  const {token} = params || {}
+  const {slug, id, token} = params || {}
   const {publicRuntimeConfig} = getConfig()
 
   const client = ApiV1.getV1ApiClient(publicRuntimeConfig.env.API_URL!, [])
@@ -18,6 +18,8 @@ export const getServerSideProps = (async ({params}) => {
     client.query({
       query: ApiV1.ArticleDocument,
       variables: {
+        slug,
+        id,
         token
       }
     }),

--- a/apps/tsri/pages/a/[slug].tsx
+++ b/apps/tsri/pages/a/[slug].tsx
@@ -98,7 +98,7 @@ export default function ArticleBySlugIdOrToken() {
 export const getStaticPaths = getArticlePathsBasedOnPage('')
 
 export const getStaticProps: GetStaticProps = async ({params}) => {
-  const {slug} = params || {}
+  const {slug, id, token} = params || {}
   const {publicRuntimeConfig} = getConfig()
 
   const client = ApiV1.getV1ApiClient(publicRuntimeConfig.env.API_URL!, [])
@@ -107,7 +107,9 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
     client.query({
       query: ApiV1.ArticleDocument,
       variables: {
-        slug
+        slug,
+        id,
+        token
       }
     }),
     client.query({

--- a/apps/tsri/pages/a/preview/[token].tsx
+++ b/apps/tsri/pages/a/preview/[token].tsx
@@ -9,7 +9,7 @@ export default function PreviewArticleByToken() {
 }
 
 export const getServerSideProps = (async ({params}) => {
-  const {token} = params || {}
+  const {slug, id, token} = params || {}
   const {publicRuntimeConfig} = getConfig()
 
   const client = ApiV1.getV1ApiClient(publicRuntimeConfig.env.API_URL!, [])
@@ -18,6 +18,8 @@ export const getServerSideProps = (async ({params}) => {
     client.query({
       query: ApiV1.ArticleDocument,
       variables: {
+        slug,
+        id,
         token
       }
     }),

--- a/apps/we-publish/pages/a/[slug].tsx
+++ b/apps/we-publish/pages/a/[slug].tsx
@@ -63,7 +63,7 @@ export default function ArticleBySlugIdOrToken() {
 export const getStaticPaths = getArticlePathsBasedOnPage('')
 
 export const getStaticProps: GetStaticProps = async ({params}) => {
-  const {slug} = params || {}
+  const {slug, id, token} = params || {}
   const {publicRuntimeConfig} = getConfig()
 
   const client = ApiV1.getV1ApiClient(publicRuntimeConfig.env.API_URL!, [])
@@ -72,7 +72,9 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
     client.query({
       query: ApiV1.ArticleDocument,
       variables: {
-        slug
+        slug,
+        id,
+        token
       }
     }),
     client.query({

--- a/apps/website-example/pages/a/[slug].tsx
+++ b/apps/website-example/pages/a/[slug].tsx
@@ -63,7 +63,7 @@ export default function ArticleBySlugIdOrToken() {
 export const getStaticPaths = getArticlePathsBasedOnPage('')
 
 export const getStaticProps: GetStaticProps = async ({params}) => {
-  const {slug} = params || {}
+  const {slug, id, token} = params || {}
   const {publicRuntimeConfig} = getConfig()
 
   const client = ApiV1.getV1ApiClient(publicRuntimeConfig.env.API_URL!, [])
@@ -72,7 +72,9 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
     client.query({
       query: ApiV1.ArticleDocument,
       variables: {
-        slug
+        slug,
+        id,
+        token
       }
     }),
     client.query({

--- a/apps/website-example/pages/a/preview/[token].tsx
+++ b/apps/website-example/pages/a/preview/[token].tsx
@@ -9,7 +9,7 @@ export default function PreviewArticleByToken() {
 }
 
 export const getServerSideProps = (async ({params}) => {
-  const {token} = params || {}
+  const {slug, id, token} = params || {}
   const {publicRuntimeConfig} = getConfig()
 
   const client = ApiV1.getV1ApiClient(publicRuntimeConfig.env.API_URL!, [])
@@ -18,6 +18,8 @@ export const getServerSideProps = (async ({params}) => {
     client.query({
       query: ApiV1.ArticleDocument,
       variables: {
+        slug,
+        id,
         token
       }
     }),

--- a/apps/wnti/pages/a/[slug].tsx
+++ b/apps/wnti/pages/a/[slug].tsx
@@ -98,7 +98,7 @@ export default function ArticleBySlugIdOrToken() {
 export const getStaticPaths = getArticlePathsBasedOnPage('')
 
 export const getStaticProps: GetStaticProps = async ({params}) => {
-  const {slug} = params || {}
+  const {slug, id, token} = params || {}
   const {publicRuntimeConfig} = getConfig()
 
   const client = ApiV1.getV1ApiClient(publicRuntimeConfig.env.API_URL!, [])
@@ -107,7 +107,9 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
     client.query({
       query: ApiV1.ArticleDocument,
       variables: {
-        slug
+        slug,
+        id,
+        token
       }
     }),
     client.query({

--- a/apps/wnti/pages/a/preview/[token].tsx
+++ b/apps/wnti/pages/a/preview/[token].tsx
@@ -9,7 +9,7 @@ export default function PreviewArticleByToken() {
 }
 
 export const getServerSideProps = (async ({params}) => {
-  const {token} = params || {}
+  const {slug, id, token} = params || {}
   const {publicRuntimeConfig} = getConfig()
 
   const client = ApiV1.getV1ApiClient(publicRuntimeConfig.env.API_URL!, [])
@@ -18,6 +18,8 @@ export const getServerSideProps = (async ({params}) => {
     client.query({
       query: ApiV1.ArticleDocument,
       variables: {
+        slug,
+        id,
         token
       }
     }),

--- a/apps/zwoelf/pages/a/[slug].tsx
+++ b/apps/zwoelf/pages/a/[slug].tsx
@@ -63,7 +63,7 @@ export default function ArticleBySlugIdOrToken() {
 export const getStaticPaths = getArticlePathsBasedOnPage('')
 
 export const getStaticProps: GetStaticProps = async ({params}) => {
-  const {slug} = params || {}
+  const {slug, id, token} = params || {}
   const {publicRuntimeConfig} = getConfig()
 
   const client = ApiV1.getV1ApiClient(publicRuntimeConfig.env.API_URL!, [])
@@ -72,7 +72,9 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
     client.query({
       query: ApiV1.ArticleDocument,
       variables: {
-        slug
+        slug,
+        id,
+        token
       }
     }),
     client.query({

--- a/apps/zwoelf/pages/a/preview/[token].tsx
+++ b/apps/zwoelf/pages/a/preview/[token].tsx
@@ -9,7 +9,7 @@ export default function PreviewArticleByToken() {
 }
 
 export const getServerSideProps = (async ({params}) => {
-  const {token} = params || {}
+  const {slug, id, token} = params || {}
   const {publicRuntimeConfig} = getConfig()
 
   const client = ApiV1.getV1ApiClient(publicRuntimeConfig.env.API_URL!, [])
@@ -18,6 +18,8 @@ export const getServerSideProps = (async ({params}) => {
     client.query({
       query: ApiV1.ArticleDocument,
       variables: {
+        slug,
+        id,
         token
       }
     }),


### PR DESCRIPTION
As the keys id/token were also sent (token for preview etc) and were potentially undefined,
they also have to be set in the original query for the apollo cache, as else the query variables won't lign up and it can't find it in the cache.


