### PR TITLE
feat(bajour): Remove whitespace in basel briefing

### DIFF
--- a/apps/bajour/src/components/briefing/basel-briefing.tsx
+++ b/apps/bajour/src/components/briefing/basel-briefing.tsx
@@ -137,7 +137,6 @@ const getValuesBasedOnBriefing = (briefing: BriefingType) => {
 export const BaselBriefingStyled = styled('div')`
   display: grid;
   column-gap: 16px;
-  row-gap: 40px;
   grid-template-columns: 1fr;
   align-items: stretch;
   position: relative;
@@ -236,7 +235,8 @@ const BaselBriefingTitle = styled('span')`
   font-weight: bold;
   font-size: ${({theme}) => theme.spacing(4)};
   text-transform: uppercase;
-  text-shadow: 1px 1px 2px black, 0 0 1em black, 0 0 0.2em black;
+  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.35), 0 0 1em rgba(0, 0, 0, 0.35),
+    0 0 0.2em rgba(0, 0, 0, 0.35);
 
   ${({theme}) => theme.breakpoints.up('lg')} {
     font-size: 3rem;
@@ -247,7 +247,8 @@ const BaselBriefingSubtitle = styled('span')`
   font-weight: bold;
   font-size: 0.8rem;
   text-transform: uppercase;
-  text-shadow: 1px 1px 2px black, 0 0 1em black, 0 0 0.2em black;
+  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.35), 0 0 1em rgba(0, 0, 0, 0.35),
+    0 0 0.2em rgba(0, 0, 0, 0.35);
 
   ${({theme}) => theme.breakpoints.up('lg')} {
     font-size: 1 ${({theme}) => theme.spacing(4)};


### PR DESCRIPTION
Commit 9ee0bb3275e1f1a75ee14017d7dd7195abe92e7a introduced an unwanted whitespace between the banner and the authors. This removes the whitespaces and reverts to the  existing design.