### PR TITLE
feat(bajour): Show image credits in search slider

### DIFF
--- a/apps/bajour/src/components/search-slider/search-slider.tsx
+++ b/apps/bajour/src/components/search-slider/search-slider.tsx
@@ -518,6 +518,9 @@ export function SearchSlider({article, includeSEO}: SearchSliderProps) {
                       <SlideTitle>{article?.title}</SlideTitle>
                     </SlideItemOverlay>
                   )}
+                  {slidesDetails?.[idx].abs === currentSlide && (
+                    <SlideTitle>Bild: {article?.image.source}</SlideTitle>
+                  )}
                 </>
               )}
             </SlideItem>

--- a/apps/bajour/src/components/search-slider/search-slider.tsx
+++ b/apps/bajour/src/components/search-slider/search-slider.tsx
@@ -518,7 +518,7 @@ export function SearchSlider({article, includeSEO}: SearchSliderProps) {
                       <SlideTitle>{article?.title}</SlideTitle>
                     </SlideItemOverlay>
                   )}
-                  {slidesDetails?.[idx].abs === currentSlide && (
+                  {slidesDetails?.[idx].abs === currentSlide && article?.image.source && (
                     <SlideTitle>Bild: {article?.image.source}</SlideTitle>
                   )}
                 </>

--- a/apps/bajour/src/components/search-slider/search-slider.tsx
+++ b/apps/bajour/src/components/search-slider/search-slider.tsx
@@ -519,7 +519,7 @@ export function SearchSlider({article, includeSEO}: SearchSliderProps) {
                     </SlideItemOverlay>
                   )}
                   {slidesDetails?.[idx].abs === currentSlide && article.image.source && (
-                    <SlideTitle>Bild: {article?.image.source}</SlideTitle>
+                    <SlideTitle>Bild: {article.image.source}</SlideTitle>
                   )}
                 </>
               )}

--- a/apps/bajour/src/components/search-slider/search-slider.tsx
+++ b/apps/bajour/src/components/search-slider/search-slider.tsx
@@ -518,7 +518,7 @@ export function SearchSlider({article, includeSEO}: SearchSliderProps) {
                       <SlideTitle>{article?.title}</SlideTitle>
                     </SlideItemOverlay>
                   )}
-                  {slidesDetails?.[idx].abs === currentSlide && article?.image.source && (
+                  {slidesDetails?.[idx].abs === currentSlide && article.image.source && (
                     <SlideTitle>Bild: {article?.image.source}</SlideTitle>
                   )}
                 </>


### PR DESCRIPTION
This commit adds the image credits to the search slider. The currently active image now shows the image source that is defined in the editor.