### PR TITLE
enh(website-example): remove ugly serif font family from website-example

### DIFF
--- a/apps/website-example/src/theme.tsx
+++ b/apps/website-example/src/theme.tsx
@@ -1,18 +1,10 @@
 import {createTheme, Theme, ThemeOptions} from '@mui/material'
 import {theme as WePTheme} from '@wepublish/ui'
-import {Hanken_Grotesk, Merriweather} from 'next/font/google'
+import {Hanken_Grotesk} from 'next/font/google'
 import {PartialDeep} from 'type-fest'
 
 const hankenGrotesk = Hanken_Grotesk({
   weight: ['100', '300', '400', '500', '600', '700'],
-  style: ['italic', 'normal'],
-  subsets: ['latin'],
-  display: 'swap',
-  preload: true
-})
-
-const merriweather = Merriweather({
-  weight: ['300', '400', '700', '900'],
   style: ['italic', 'normal'],
   subsets: ['latin'],
   display: 'swap',
@@ -40,19 +32,19 @@ const theme = createTheme(WePTheme, {
       fontFamily: [hankenGrotesk.style.fontFamily, 'sans-serif'].join(',')
     },
     body1: {
-      fontFamily: [merriweather.style.fontFamily, 'sans-serif'].join(',')
+      fontFamily: [hankenGrotesk.style.fontFamily, 'sans-serif'].join(',')
     },
     body2: {
-      fontFamily: [merriweather.style.fontFamily, 'sans-serif'].join(',')
+      fontFamily: [hankenGrotesk.style.fontFamily, 'sans-serif'].join(',')
     },
     button: {
-      fontFamily: [merriweather.style.fontFamily, 'sans-serif'].join(',')
+      fontFamily: [hankenGrotesk.style.fontFamily, 'sans-serif'].join(',')
     },
     caption: {
-      fontFamily: [merriweather.style.fontFamily, 'sans-serif'].join(',')
+      fontFamily: [hankenGrotesk.style.fontFamily, 'sans-serif'].join(',')
     },
     overline: {
-      fontFamily: [merriweather.style.fontFamily, 'sans-serif'].join(',')
+      fontFamily: [hankenGrotesk.style.fontFamily, 'sans-serif'].join(',')
     },
     subtitle1: {
       fontFamily: [hankenGrotesk.style.fontFamily, 'sans-serif'].join(',')
@@ -60,7 +52,7 @@ const theme = createTheme(WePTheme, {
     subtitle2: {
       fontFamily: [hankenGrotesk.style.fontFamily, 'sans-serif'].join(',')
     },
-    fontFamily: [merriweather.style.fontFamily, 'sans-serif'].join(',')
+    fontFamily: [hankenGrotesk.style.fontFamily, 'sans-serif'].join(',')
   }
 } as PartialDeep<Theme> | ThemeOptions)
 


### PR DESCRIPTION
Only using the nice non-serif font family for the example website. So it's less code and we can show off our site to new media :)