### PR TITLE
revert(website): article list container

### DIFF
--- a/libs/article/website/src/lib/article-list/article-list-container.tsx
+++ b/libs/article/website/src/lib/article-list/article-list-container.tsx
@@ -19,19 +19,8 @@ export function ArticleListContainer({
   filter
 }: ArticleListContainerProps) {
   const {ArticleList} = useWebsiteBuilder()
-  const {data, loading, error, refetch} = useArticleListQuery({
-    variables,
-    onCompleted: async data => {
-      // refetch if there are less than 4 articles
-      if (data.articles?.nodes.length < 4) {
-        await refetch({
-          filter: {
-            tags: []
-          },
-          take: 4
-        })
-      }
-    }
+  const {data, loading, error} = useArticleListQuery({
+    variables
   })
 
   const filteredArticles = useMemo(


### PR DESCRIPTION
This change affected more than it intended to as it was meant to just fetch more articles for related articles.
But this:

1. Doesn't work for SSR where it's needed
2. Affects more than just related articles (author pages now load unrelated articles, tag pages, and if your medium doesn't have more than 4 articles it will cause an endless loop).
3. 4 is arbitrary for a general solution

This change also wasn't reviewed as it came in after my approval: https://github.com/wepublish/wepublish/pull/1776/files/8e8615fc5fea102907d17d6de0c3b2ccb62a71ab..85800d5d5c8833e079c1d150cbd80612c665a4e7#diff-0ea864e735d786ab1d732f3f96c51c41c9baa9f5622bc8f5ec852920b9921dcf