### PR TITLE
fix(website): client cache reimplemented & fixed

### DIFF
--- a/libs/website/api/src/lib/client.tsx
+++ b/libs/website/api/src/lib/client.tsx
@@ -10,7 +10,7 @@ import {
   split
 } from '@apollo/client'
 import {BatchHttpLink} from '@apollo/client/link/batch-http'
-import {mergeDeepLeft} from 'ramda'
+import {mergeDeepRight} from 'ramda'
 import possibleTypes from './graphql'
 
 import {ComponentType, memo, useMemo} from 'react'
@@ -90,12 +90,12 @@ export const getV1ApiClient = (
 ) => {
   const client =
     !CACHED_CLIENT || typeof window === 'undefined'
-      ? createV1ApiClient(apiUrl, links, cacheConfig, cache)
+      ? (CACHED_CLIENT = createV1ApiClient(apiUrl, links, cacheConfig, cache))
       : CACHED_CLIENT
 
   if (cache) {
     const existingCache = client.extract()
-    const data = mergeDeepLeft(existingCache, cache) as NormalizedCacheObject
+    const data = mergeDeepRight(existingCache, cache) as NormalizedCacheObject
 
     client.cache.restore(data)
   }


### PR DESCRIPTION
mergeDeepLeft should have been mergeDeepRight. mergeDeepLeft merges from left to right and I interpreted it from merging right into the left object.
I reverted the cache a few weeks back as it caused weird re-renders, this is fixed with mergeDeepRight
