### PR TITLE
feat(flimmer): Move banner close button up and to the right

### DIFF
--- a/apps/flimmer/src/components/tsri-banner.tsx
+++ b/apps/flimmer/src/components/tsri-banner.tsx
@@ -18,8 +18,8 @@ const TsriBanner = styled(Banner)(
   }
 
   ${BannerCloseButton} {
-    top: ${theme.spacing(2)};
-    right: ${theme.spacing(2)};
+    top: ${theme.spacing(1)};
+    right: ${theme.spacing(1)};
 
     ${theme.breakpoints.up('md')} {
       top: ${theme.spacing(6)};


### PR DESCRIPTION
For longer banner titles, the title overlaps the close button on mobile devices. In those cases, the close button must be moved further into the corner.