### PR TITLE
fix(api): publishedAt migration should only run if not null

### DIFF
--- a/libs/api/prisma/migrations/20241126132733_migrate_articles_and_pages_to_leave_revision_history/migration.sql
+++ b/libs/api/prisma/migrations/20241126132733_migrate_articles_and_pages_to_leave_revision_history/migration.sql
@@ -43,7 +43,7 @@ WHERE "publishedAt" IS NULL;
 UPDATE "articles" a
 SET "publishedAt" = ar."publishedAt"
 FROM "articles.revisions" ar
-WHERE ar.id = a."publishedId";
+WHERE ar.id = a."publishedId" AND ar."publishedAt" NOT NULL;
 
 -- Fix duplicate slugs
 WITH DuplicateSlugs AS (
@@ -159,7 +159,7 @@ WHERE "publishedAt" IS NULL;
 UPDATE "pages" p
 SET "publishedAt" = pr."publishedAt"
 FROM "pages.revisions" pr
-WHERE pr.id = p."publishedId";
+WHERE pr.id = p."publishedId" AND pr."publishedAt" NOT NULL;
 
 -- Fix duplicate slugs
 WITH DuplicateSlugs AS (

--- a/libs/api/prisma/migrations/20241126132733_migrate_articles_and_pages_to_leave_revision_history/migration.sql
+++ b/libs/api/prisma/migrations/20241126132733_migrate_articles_and_pages_to_leave_revision_history/migration.sql
@@ -43,7 +43,7 @@ WHERE "publishedAt" IS NULL;
 UPDATE "articles" a
 SET "publishedAt" = ar."publishedAt"
 FROM "articles.revisions" ar
-WHERE ar.id = a."publishedId" AND ar."publishedAt" NOT NULL;
+WHERE ar.id = a."publishedId" AND ar."publishedAt" IS NOT NULL;
 
 -- Fix duplicate slugs
 WITH DuplicateSlugs AS (
@@ -159,7 +159,7 @@ WHERE "publishedAt" IS NULL;
 UPDATE "pages" p
 SET "publishedAt" = pr."publishedAt"
 FROM "pages.revisions" pr
-WHERE pr.id = p."publishedId" AND pr."publishedAt" NOT NULL;
+WHERE pr.id = p."publishedId" AND pr."publishedAt" IS NOT NULL;
 
 -- Fix duplicate slugs
 WITH DuplicateSlugs AS (


### PR DESCRIPTION
Articles/Pages that were pending during the migration got their `publishedAt` date overwritten