### PR TITLE
fix: preview when draft, earlier publishing (TSRI-134), teaser grid

### DIFF
--- a/apps/babanews/pages/[slug].tsx
+++ b/apps/babanews/pages/[slug].tsx
@@ -5,6 +5,7 @@ import {
   getV1ApiClient,
   NavigationListDocument,
   PageDocument,
+  PageQuery,
   PeerProfileDocument
 } from '@wepublish/website/api'
 import {GetStaticProps} from 'next'
@@ -14,13 +15,12 @@ import {ComponentProps} from 'react'
 
 export default function PageBySlugOrId() {
   const {
-    query: {slug, id, token}
+    query: {slug, id}
   } = useRouter()
 
   const containerProps = {
     slug,
-    id,
-    token
+    id
   } as ComponentProps<typeof PageContainer>
 
   return <PageContainer {...containerProps} />
@@ -33,8 +33,8 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
   const {publicRuntimeConfig} = getConfig()
 
   const client = getV1ApiClient(publicRuntimeConfig.env.API_URL!, [])
-  await Promise.all([
-    client.query({
+  const [page] = await Promise.all([
+    client.query<PageQuery>({
       query: PageDocument,
       variables: {
         slug
@@ -52,6 +52,6 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
 
   return {
     props,
-    revalidate: 60 // every 60 seconds
+    revalidate: !page.data?.page ? 1 : 60 // every 60 seconds
   }
 }

--- a/apps/babanews/pages/a/[slug].tsx
+++ b/apps/babanews/pages/a/[slug].tsx
@@ -110,7 +110,7 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
     })
   ])
 
-  if (article.data.article) {
+  if (article.data?.article) {
     await Promise.all([
       client.query({
         query: ArticleListDocument,
@@ -134,6 +134,6 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
 
   return {
     props,
-    revalidate: 60 // every 60 seconds
+    revalidate: !article.data?.article ? 1 : 60 // every 60 seconds
   }
 }

--- a/apps/bajour/pages/[slug].tsx
+++ b/apps/bajour/pages/[slug].tsx
@@ -5,6 +5,7 @@ import {
   getV1ApiClient,
   NavigationListDocument,
   PageDocument,
+  PageQuery,
   PeerProfileDocument
 } from '@wepublish/website/api'
 import {GetStaticProps} from 'next'
@@ -32,8 +33,8 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
 
   const {publicRuntimeConfig} = getConfig()
   const client = getV1ApiClient(publicRuntimeConfig.env.API_URL!, [])
-  await Promise.all([
-    client.query({
+  const [page] = await Promise.all([
+    client.query<PageQuery>({
       query: PageDocument,
       variables: {
         slug
@@ -51,6 +52,6 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
 
   return {
     props,
-    revalidate: 60 // every 60 seconds
+    revalidate: !page.data?.page ? 1 : 60 // every 60 seconds
   }
 }

--- a/apps/bajour/pages/a/[slug].tsx
+++ b/apps/bajour/pages/a/[slug].tsx
@@ -73,7 +73,7 @@ export const AuthorWrapper = styled(ContentWrapper)`
 
 export default function ArticleBySlugOrId() {
   const {
-    query: {slug, id, token}
+    query: {slug, id}
   } = useRouter()
   const {
     elements: {H5}
@@ -89,8 +89,7 @@ export default function ArticleBySlugOrId() {
 
   const containerProps = {
     slug,
-    id,
-    token
+    id
   } as ComponentProps<typeof ArticleContainer>
 
   const isFDT = data?.article?.tags.some(({tag}) => tag === 'frage-des-tages')
@@ -204,7 +203,7 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
     })
   ])
 
-  if (article.data.article) {
+  if (article.data?.article) {
     await Promise.all([
       client.query({
         query: ArticleListDocument,
@@ -242,6 +241,6 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
 
   return {
     props,
-    revalidate: 60 // every 60 seconds
+    revalidate: !article.data?.article ? 1 : 60 // every 60 seconds
   }
 }

--- a/apps/cultur/pages/[slug].tsx
+++ b/apps/cultur/pages/[slug].tsx
@@ -5,6 +5,7 @@ import {
   getV1ApiClient,
   NavigationListDocument,
   PageDocument,
+  PageQuery,
   PeerProfileDocument
 } from '@wepublish/website/api'
 import {GetStaticProps} from 'next'
@@ -14,13 +15,12 @@ import {ComponentProps} from 'react'
 
 export default function PageBySlugOrId() {
   const {
-    query: {slug, id, token}
+    query: {slug, id}
   } = useRouter()
 
   const containerProps = {
     slug,
-    id,
-    token
+    id
   } as ComponentProps<typeof PageContainer>
 
   return <PageContainer {...containerProps} />
@@ -33,8 +33,8 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
   const {publicRuntimeConfig} = getConfig()
 
   const client = getV1ApiClient(publicRuntimeConfig.env.API_URL!, [])
-  await Promise.all([
-    client.query({
+  const [page] = await Promise.all([
+    client.query<PageQuery>({
       query: PageDocument,
       variables: {
         slug
@@ -52,6 +52,6 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
 
   return {
     props,
-    revalidate: 60 // every 60 seconds
+    revalidate: !page.data?.page ? 1 : 60 // every 60 seconds
   }
 }

--- a/apps/cultur/pages/a/[slug].tsx
+++ b/apps/cultur/pages/a/[slug].tsx
@@ -89,7 +89,7 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
     })
   ])
 
-  if (article.data.article) {
+  if (article.data?.article) {
     await Promise.all([
       client.query({
         query: ArticleListDocument,
@@ -113,6 +113,6 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
 
   return {
     props,
-    revalidate: 60 // every 60 seconds
+    revalidate: !article.data?.article ? 1 : 60 // every 60 seconds
   }
 }

--- a/apps/flimmer/pages/[slug].tsx
+++ b/apps/flimmer/pages/[slug].tsx
@@ -5,6 +5,7 @@ import {
   getV1ApiClient,
   NavigationListDocument,
   PageDocument,
+  PageQuery,
   PeerProfileDocument
 } from '@wepublish/website/api'
 import {GetStaticProps} from 'next'
@@ -12,15 +13,14 @@ import getConfig from 'next/config'
 import {useRouter} from 'next/router'
 import {ComponentProps} from 'react'
 
-export default function PageBySlugIdOrToken() {
+export default function PageBySlugOrId() {
   const {
-    query: {slug, id, token}
+    query: {slug, id}
   } = useRouter()
 
   const containerProps = {
     slug,
-    id,
-    token
+    id
   } as ComponentProps<typeof PageContainer>
 
   return <PageContainer {...containerProps} />
@@ -33,8 +33,8 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
   const {publicRuntimeConfig} = getConfig()
 
   const client = getV1ApiClient(publicRuntimeConfig.env.API_URL!, [])
-  await Promise.all([
-    client.query({
+  const [page] = await Promise.all([
+    client.query<PageQuery>({
       query: PageDocument,
       variables: {
         slug
@@ -52,6 +52,6 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
 
   return {
     props,
-    revalidate: 60 // every 60 seconds
+    revalidate: !page.data?.page ? 1 : 60 // every 60 seconds
   }
 }

--- a/apps/flimmer/pages/a/[slug].tsx
+++ b/apps/flimmer/pages/a/[slug].tsx
@@ -36,9 +36,9 @@ export const AuthorWrapper = styled(ContentWrapper)`
   }
 `
 
-export default function ArticleBySlugIdOrToken() {
+export default function ArticleBySlugOrId() {
   const {
-    query: {slug, id, token}
+    query: {slug, id}
   } = useRouter()
 
   const {data} = useArticleQuery({
@@ -51,8 +51,7 @@ export default function ArticleBySlugIdOrToken() {
 
   const containerProps = {
     slug,
-    id,
-    token
+    id
   } as ComponentProps<typeof ArticleContainer>
 
   return (
@@ -100,7 +99,7 @@ export default function ArticleBySlugIdOrToken() {
 export const getStaticPaths = getArticlePathsBasedOnPage('')
 
 export const getStaticProps: GetStaticProps = async ({params}) => {
-  const {slug, id, token} = params || {}
+  const {slug, id} = params || {}
   const {publicRuntimeConfig} = getConfig()
 
   const client = getV1ApiClient(publicRuntimeConfig.env.API_URL!, [])
@@ -110,8 +109,7 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
       query: ArticleDocument,
       variables: {
         slug,
-        id,
-        token
+        id
       }
     }),
     client.query({
@@ -146,6 +144,6 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
 
   return {
     props,
-    revalidate: 60 // every 60 seconds
+    revalidate: !article.data?.article ? 1 : 60 // every 60 seconds
   }
 }

--- a/apps/gruppetto/pages/[slug].tsx
+++ b/apps/gruppetto/pages/[slug].tsx
@@ -5,6 +5,7 @@ import {
   getV1ApiClient,
   NavigationListDocument,
   PageDocument,
+  PageQuery,
   PeerProfileDocument
 } from '@wepublish/website/api'
 import {GetStaticProps} from 'next'
@@ -14,13 +15,12 @@ import {ComponentProps} from 'react'
 
 export default function PageBySlugOrId() {
   const {
-    query: {slug, id, token}
+    query: {slug, id}
   } = useRouter()
 
   const containerProps = {
     slug,
-    id,
-    token
+    id
   } as ComponentProps<typeof PageContainer>
 
   return <PageContainer {...containerProps} />
@@ -33,8 +33,8 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
   const {publicRuntimeConfig} = getConfig()
 
   const client = getV1ApiClient(publicRuntimeConfig.env.API_URL!, [])
-  await Promise.all([
-    client.query({
+  const [page] = await Promise.all([
+    client.query<PageQuery>({
       query: PageDocument,
       variables: {
         slug
@@ -52,6 +52,6 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
 
   return {
     props,
-    revalidate: 60 // every 60 seconds
+    revalidate: !page.data?.page ? 1 : 60 // every 60 seconds
   }
 }

--- a/apps/gruppetto/pages/a/[slug].tsx
+++ b/apps/gruppetto/pages/a/[slug].tsx
@@ -90,7 +90,7 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
     })
   ])
 
-  if (article.data.article) {
+  if (article.data?.article) {
     await Promise.all([
       client.query({
         query: ArticleListDocument,
@@ -114,6 +114,6 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
 
   return {
     props,
-    revalidate: 60 // every 60 seconds
+    revalidate: !article.data?.article ? 1 : 60 // every 60 seconds
   }
 }

--- a/apps/hauptstadt/pages/[slug].tsx
+++ b/apps/hauptstadt/pages/[slug].tsx
@@ -5,6 +5,7 @@ import {
   getV1ApiClient,
   NavigationListDocument,
   PageDocument,
+  PageQuery,
   PeerProfileDocument
 } from '@wepublish/website/api'
 import {GetStaticProps} from 'next'
@@ -14,13 +15,12 @@ import {ComponentProps} from 'react'
 
 export default function PageBySlugOrId() {
   const {
-    query: {slug, id, token}
+    query: {slug, id}
   } = useRouter()
 
   const containerProps = {
     slug,
-    id,
-    token
+    id
   } as ComponentProps<typeof PageContainer>
 
   return <PageContainer {...containerProps} />
@@ -33,8 +33,8 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
   const {publicRuntimeConfig} = getConfig()
 
   const client = getV1ApiClient(publicRuntimeConfig.env.API_URL!, [])
-  await Promise.all([
-    client.query({
+  const [page] = await Promise.all([
+    client.query<PageQuery>({
       query: PageDocument,
       variables: {
         slug
@@ -52,6 +52,6 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
 
   return {
     props,
-    revalidate: 60 // every 60 seconds
+    revalidate: !page.data?.page ? 1 : 60 // every 60 seconds
   }
 }

--- a/apps/hauptstadt/pages/a/[slug].tsx
+++ b/apps/hauptstadt/pages/a/[slug].tsx
@@ -55,7 +55,7 @@ export default function ArticleBySlugOrId() {
         </ArticleWrapper>
       )}
 
-      {!data?.article?.disableComments && (
+      {data?.article && !data.article.disableComments && (
         <ArticleWrapper>
           <H3 component={'h2'}>Kommentare</H3>
           <CommentListContainer id={data!.article!.id} type={CommentItemType.Article} />
@@ -89,7 +89,7 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
     })
   ])
 
-  if (article.data.article) {
+  if (article.data?.article) {
     await Promise.all([
       client.query({
         query: ArticleListDocument,
@@ -113,6 +113,6 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
 
   return {
     props,
-    revalidate: 60 // every 60 seconds
+    revalidate: !article.data?.article ? 1 : 60 // every 60 seconds
   }
 }

--- a/apps/mannschaft/pages/[slug].tsx
+++ b/apps/mannschaft/pages/[slug].tsx
@@ -5,6 +5,7 @@ import {
   getV1ApiClient,
   NavigationListDocument,
   PageDocument,
+  PageQuery,
   PeerProfileDocument
 } from '@wepublish/website/api'
 import {GetStaticProps} from 'next'
@@ -14,13 +15,12 @@ import {ComponentProps} from 'react'
 
 export default function PageBySlugOrId() {
   const {
-    query: {slug, id, token}
+    query: {slug, id}
   } = useRouter()
 
   const containerProps = {
     slug,
-    id,
-    token
+    id
   } as ComponentProps<typeof PageContainer>
 
   return <PageContainer {...containerProps} />
@@ -33,8 +33,8 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
   const {publicRuntimeConfig} = getConfig()
 
   const client = getV1ApiClient(publicRuntimeConfig.env.API_URL!, [])
-  await Promise.all([
-    client.query({
+  const [page] = await Promise.all([
+    client.query<PageQuery>({
       query: PageDocument,
       variables: {
         slug
@@ -52,6 +52,6 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
 
   return {
     props,
-    revalidate: 60 // every 60 seconds
+    revalidate: !page.data?.page ? 1 : 60 // every 60 seconds
   }
 }

--- a/apps/mannschaft/pages/a/[slug].tsx
+++ b/apps/mannschaft/pages/a/[slug].tsx
@@ -121,7 +121,7 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
     })
   ])
 
-  if (article.data.article) {
+  if (article.data?.article) {
     await Promise.all([
       client.query({
         query: ArticleListDocument,
@@ -145,6 +145,6 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
 
   return {
     props,
-    revalidate: 60 // every 60 seconds
+    revalidate: !article.data?.article ? 1 : 60 // every 60 seconds
   }
 }

--- a/apps/onlinereports/pages/[slug].tsx
+++ b/apps/onlinereports/pages/[slug].tsx
@@ -5,6 +5,7 @@ import {
   getV1ApiClient,
   NavigationListDocument,
   PageDocument,
+  PageQuery,
   PeerProfileDocument
 } from '@wepublish/website/api'
 import {GetStaticProps} from 'next'
@@ -14,13 +15,12 @@ import {ComponentProps} from 'react'
 
 export default function PageBySlugOrId() {
   const {
-    query: {slug, id, token}
+    query: {slug, id}
   } = useRouter()
 
   const containerProps = {
     slug,
-    id,
-    token
+    id
   } as ComponentProps<typeof PageContainer>
 
   return <PageContainer {...containerProps} />
@@ -33,8 +33,8 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
   const {publicRuntimeConfig} = getConfig()
 
   const client = getV1ApiClient(publicRuntimeConfig.env.API_URL!, [])
-  await Promise.all([
-    client.query({
+  const [page] = await Promise.all([
+    client.query<PageQuery>({
       query: PageDocument,
       variables: {
         slug
@@ -52,6 +52,6 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
 
   return {
     props,
-    revalidate: 60 // every 60 seconds
+    revalidate: !page.data?.page ? 1 : 60 // every 60 seconds
   }
 }

--- a/apps/onlinereports/pages/a/[slug].tsx
+++ b/apps/onlinereports/pages/a/[slug].tsx
@@ -55,7 +55,7 @@ export default function ArticleBySlugOrId() {
         </ArticleWrapper>
       )}
 
-      {!data?.article?.disableComments && (
+      {data?.article && !data.article.disableComments && (
         <ArticleWrapper>
           <H3 component={'h2'}>Kommentare</H3>
           <CommentListContainer id={data!.article!.id} type={CommentItemType.Article} />
@@ -89,7 +89,7 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
     })
   ])
 
-  if (article.data.article) {
+  if (article.data?.article) {
     await Promise.all([
       client.query({
         query: ArticleListDocument,
@@ -113,6 +113,6 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
 
   return {
     props,
-    revalidate: 60 // every 60 seconds
+    revalidate: !article.data?.article ? 1 : 60 // every 60 seconds
   }
 }

--- a/apps/tsri/pages/[slug].tsx
+++ b/apps/tsri/pages/[slug].tsx
@@ -5,6 +5,7 @@ import {
   getV1ApiClient,
   NavigationListDocument,
   PageDocument,
+  PageQuery,
   PeerProfileDocument
 } from '@wepublish/website/api'
 import {GetStaticProps} from 'next'

--- a/apps/tsri/pages/[slug].tsx
+++ b/apps/tsri/pages/[slug].tsx
@@ -32,8 +32,8 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
   const {publicRuntimeConfig} = getConfig()
 
   const client = getV1ApiClient(publicRuntimeConfig.env.API_URL!, [])
-  await Promise.all([
-    client.query({
+  const [page] = await Promise.all([
+    client.query<PageQuery>({
       query: PageDocument,
       variables: {
         slug
@@ -51,6 +51,6 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
 
   return {
     props,
-    revalidate: 60 // every 60 seconds
+    revalidate: !page.data?.page ? 1 : 60 // every 60 seconds
   }
 }

--- a/apps/tsri/pages/a/[slug].tsx
+++ b/apps/tsri/pages/a/[slug].tsx
@@ -147,6 +147,6 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
 
   return {
     props,
-    revalidate: 60 // every 60 seconds
+    revalidate: !article.data?.article ? 1 : 60 // every 60 seconds
   }
 }

--- a/apps/we-publish/pages/[slug].tsx
+++ b/apps/we-publish/pages/[slug].tsx
@@ -5,6 +5,7 @@ import {
   getV1ApiClient,
   NavigationListDocument,
   PageDocument,
+  PageQuery,
   PeerProfileDocument
 } from '@wepublish/website/api'
 import {GetStaticProps} from 'next'
@@ -14,13 +15,12 @@ import {ComponentProps} from 'react'
 
 export default function PageBySlugOrId() {
   const {
-    query: {slug, id, token}
+    query: {slug, id}
   } = useRouter()
 
   const containerProps = {
     slug,
-    id,
-    token
+    id
   } as ComponentProps<typeof PageContainer>
 
   return <PageContainer {...containerProps} />
@@ -33,8 +33,8 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
   const {publicRuntimeConfig} = getConfig()
 
   const client = getV1ApiClient(publicRuntimeConfig.env.API_URL!, [])
-  await Promise.all([
-    client.query({
+  const [page] = await Promise.all([
+    client.query<PageQuery>({
       query: PageDocument,
       variables: {
         slug
@@ -52,6 +52,6 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
 
   return {
     props,
-    revalidate: 60 // every 60 seconds
+    revalidate: !page.data?.page ? 1 : 60 // every 60 seconds
   }
 }

--- a/apps/we-publish/pages/a/[slug].tsx
+++ b/apps/we-publish/pages/a/[slug].tsx
@@ -89,7 +89,7 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
     })
   ])
 
-  if (article.data.article) {
+  if (article.data?.article) {
     await Promise.all([
       client.query({
         query: ArticleListDocument,
@@ -113,6 +113,6 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
 
   return {
     props,
-    revalidate: 60 // every 60 seconds
+    revalidate: !article.data?.article ? 1 : 60 // every 60 seconds
   }
 }

--- a/apps/website-example/pages/[slug].tsx
+++ b/apps/website-example/pages/[slug].tsx
@@ -5,6 +5,7 @@ import {
   getV1ApiClient,
   NavigationListDocument,
   PageDocument,
+  PageQuery,
   PeerProfileDocument
 } from '@wepublish/website/api'
 import {GetStaticProps} from 'next'
@@ -14,13 +15,12 @@ import {ComponentProps} from 'react'
 
 export default function PageBySlugOrId() {
   const {
-    query: {slug, id, token}
+    query: {slug, id}
   } = useRouter()
 
   const containerProps = {
     slug,
-    id,
-    token
+    id
   } as ComponentProps<typeof PageContainer>
 
   return <PageContainer {...containerProps} />
@@ -33,8 +33,8 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
   const {publicRuntimeConfig} = getConfig()
 
   const client = getV1ApiClient(publicRuntimeConfig.env.API_URL!, [])
-  await Promise.all([
-    client.query({
+  const [page] = await Promise.all([
+    client.query<PageQuery>({
       query: PageDocument,
       variables: {
         slug
@@ -52,6 +52,6 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
 
   return {
     props,
-    revalidate: 60 // every 60 seconds
+    revalidate: !page.data?.page ? 1 : 60 // every 60 seconds
   }
 }

--- a/apps/website-example/pages/a/[slug].tsx
+++ b/apps/website-example/pages/a/[slug].tsx
@@ -55,7 +55,7 @@ export default function ArticleBySlugOrId() {
         </ArticleWrapper>
       )}
 
-      {!data?.article?.disableComments && (
+      {data?.article && !data?.article?.disableComments && (
         <ArticleWrapper>
           <H3 component={'h2'}>Kommentare</H3>
           <CommentListContainer id={data!.article!.id} type={CommentItemType.Article} />
@@ -89,7 +89,7 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
     })
   ])
 
-  if (article.data.article) {
+  if (article.data?.article) {
     await Promise.all([
       client.query({
         query: ArticleListDocument,
@@ -113,6 +113,6 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
 
   return {
     props,
-    revalidate: 60 // every 60 seconds
+    revalidate: !article.data?.article ? 1 : 60 // every 60 seconds
   }
 }

--- a/apps/wnti/pages/[slug].tsx
+++ b/apps/wnti/pages/[slug].tsx
@@ -6,6 +6,7 @@ import {
   getV1ApiClient,
   NavigationListDocument,
   PageDocument,
+  PageQuery,
   PeerProfileDocument
 } from '@wepublish/website/api'
 import {GetStaticProps} from 'next'
@@ -15,13 +16,12 @@ import {ComponentProps} from 'react'
 
 export default function PageBySlugOrId() {
   const {
-    query: {slug, id, token}
+    query: {slug, id}
   } = useRouter()
 
   const containerProps = {
     slug,
-    id,
-    token
+    id
   } as ComponentProps<typeof PageContainer>
 
   return (
@@ -38,8 +38,8 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
   const {publicRuntimeConfig} = getConfig()
 
   const client = getV1ApiClient(publicRuntimeConfig.env.API_URL!, [])
-  await Promise.all([
-    client.query({
+  const [page] = await Promise.all([
+    client.query<PageQuery>({
       query: PageDocument,
       variables: {
         slug
@@ -57,6 +57,6 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
 
   return {
     props,
-    revalidate: 60 // every 60 seconds
+    revalidate: !page.data?.page ? 1 : 60 // every 60 seconds
   }
 }

--- a/apps/wnti/pages/a/[slug].tsx
+++ b/apps/wnti/pages/a/[slug].tsx
@@ -148,6 +148,6 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
 
   return {
     props,
-    revalidate: 60 // every 60 seconds
+    revalidate: !article.data?.article ? 1 : 60 // every 60 seconds
   }
 }

--- a/apps/zwoelf/pages/[slug].tsx
+++ b/apps/zwoelf/pages/[slug].tsx
@@ -5,6 +5,7 @@ import {
   getV1ApiClient,
   NavigationListDocument,
   PageDocument,
+  PageQuery,
   PeerProfileDocument
 } from '@wepublish/website/api'
 import {GetStaticProps} from 'next'
@@ -14,13 +15,12 @@ import {ComponentProps} from 'react'
 
 export default function PageBySlugOrId() {
   const {
-    query: {slug, id, token}
+    query: {slug, id}
   } = useRouter()
 
   const containerProps = {
     slug,
-    id,
-    token
+    id
   } as ComponentProps<typeof PageContainer>
 
   return <PageContainer {...containerProps} />
@@ -33,8 +33,8 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
   const {publicRuntimeConfig} = getConfig()
 
   const client = getV1ApiClient(publicRuntimeConfig.env.API_URL!, [])
-  await Promise.all([
-    client.query({
+  const [page] = await Promise.all([
+    client.query<PageQuery>({
       query: PageDocument,
       variables: {
         slug
@@ -52,6 +52,6 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
 
   return {
     props,
-    revalidate: 60 // every 60 seconds
+    revalidate: !page.data?.page ? 1 : 60 // every 60 seconds
   }
 }

--- a/apps/zwoelf/pages/a/[slug].tsx
+++ b/apps/zwoelf/pages/a/[slug].tsx
@@ -55,7 +55,7 @@ export default function ArticleBySlugOrId() {
         </ArticleWrapper>
       )}
 
-      {!data?.article?.disableComments && (
+      {data?.article && !data.article.disableComments && (
         <ArticleWrapper>
           <H3 component={'h2'}>Kommentare</H3>
           <CommentListContainer id={data!.article!.id} type={CommentItemType.Article} />
@@ -89,7 +89,7 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
     })
   ])
 
-  if (article.data.article) {
+  if (article.data?.article) {
     await Promise.all([
       client.query({
         query: ArticleListDocument,
@@ -113,6 +113,6 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
 
   return {
     props,
-    revalidate: 60 // every 60 seconds
+    revalidate: !article.data?.article ? 1 : 60 // every 60 seconds
   }
 }

--- a/libs/article/api/src/lib/article.service.ts
+++ b/libs/article/api/src/lib/article.service.ts
@@ -285,12 +285,15 @@ export class ArticleService {
       }
     })
 
+    const articlePublishedAt =
+      !article.publishedAt || article.publishedAt > publishedAt ? publishedAt : article.publishedAt
+
     return this.prisma.article.update({
       where: {
         id
       },
       data: {
-        publishedAt: article.publishedAt ?? publishedAt,
+        publishedAt: articlePublishedAt,
         modifiedAt: new Date(),
         revisions: {
           update: {

--- a/libs/block-content/api/src/lib/teaser/teaser-flex.model.ts
+++ b/libs/block-content/api/src/lib/teaser/teaser-flex.model.ts
@@ -31,7 +31,7 @@ export class FlexTeaser {
   alignment!: FlexAlignment
 
   @Field(() => Teaser, {nullable: true})
-  teaser?: typeof Teaser
+  teaser?: typeof Teaser | null
 }
 
 @InputType()

--- a/libs/block-content/api/src/lib/teaser/teaser-grid.model.ts
+++ b/libs/block-content/api/src/lib/teaser/teaser-grid.model.ts
@@ -11,7 +11,7 @@ export class TeaserGridBlock extends BaseBlock<BlockType.TeaserGrid> {
   numColumns!: number
 
   @Field(() => [Teaser], {nullable: 'items'})
-  teasers!: Array<typeof Teaser | undefined>
+  teasers!: Array<typeof Teaser | null>
 }
 
 @InputType()
@@ -21,5 +21,5 @@ export class TeaserGridBlockInput extends OmitType(
   InputType
 ) {
   @Field(() => [TeaserInput], {nullable: 'items'})
-  teasers!: Array<TeaserInput | undefined>
+  teasers!: Array<TeaserInput | null>
 }

--- a/libs/block-content/api/src/lib/teaser/teaser.model.ts
+++ b/libs/block-content/api/src/lib/teaser/teaser.model.ts
@@ -150,9 +150,9 @@ export class TeaserInput {
   [TeaserType.Custom]?: CustomTeaserInput
 }
 
-export function mapTeaserUnionMap(value: TeaserInput | undefined): typeof Teaser | undefined {
+export function mapTeaserUnionMap(value: TeaserInput | undefined | null): typeof Teaser | null {
   if (!value) {
-    return undefined
+    return null
   }
 
   const valueKeys = Object.keys(value) as TeaserType[]

--- a/libs/page/api/src/lib/page.service.ts
+++ b/libs/page/api/src/lib/page.service.ts
@@ -202,12 +202,15 @@ export class PageService {
       }
     })
 
+    const pagePublishedAt =
+      !page.publishedAt || page.publishedAt > publishedAt ? publishedAt : page.publishedAt
+
     return this.prisma.page.update({
       where: {
         id
       },
       data: {
-        publishedAt: page.publishedAt ?? publishedAt,
+        publishedAt: pagePublishedAt,
         modifiedAt: new Date(),
         revisions: {
           update: {

--- a/libs/ui/editor/src/lib/blocks/types.ts
+++ b/libs/ui/editor/src/lib/blocks/types.ts
@@ -750,7 +750,7 @@ export function unionMapForBlock(block: BlockValue): BlockContentInput {
                 }
             }
 
-            return {}
+            return null
           }),
           numColumns: block.value.numColumns,
           blockStyle: block.value.blockStyle
@@ -1118,7 +1118,7 @@ export function blockForQueryBlock(block: FullBlockFragment | null): BlockValue 
     case 'TeaserGridBlock':
       return {
         key,
-        type: EditorBlockType.TeaserGrid1,
+        type: block.numColumns === 1 ? EditorBlockType.TeaserGrid1 : EditorBlockType.TeaserGrid6,
         value: {
           blockStyle: block.blockStyle,
           numColumns: block.numColumns,


### PR DESCRIPTION
Thanks to @tomaszdurka as one of the issues was fixed via: https://github.com/wepublish/wepublish/pull/1849

Tests:
- [x] Bajour preview of articles & pages that are in draft
- [x] Tsri preview of articles & pages that are in draft
- [x] Gruppetto preview of articles & pages that are in draft
- [x] Editor teaser grid 1
- [x] Editor teaser grid 6
- [x] Api earlier publishing