### PR TITLE
fix(api): article/page might having wrong publishedAt

### DIFF
--- a/libs/article/api/src/lib/article.service.ts
+++ b/libs/article/api/src/lib/article.service.ts
@@ -293,8 +293,13 @@ export class ArticleService {
       }
     })
 
+    const articlePublishedAtInTheFuture = article.publishedAt && article.publishedAt > new Date()
+    const newPublishedAtEarlier = article.publishedAt && article.publishedAt > publishedAt
+
     const articlePublishedAt =
-      !article.publishedAt || article.publishedAt > publishedAt ? publishedAt : article.publishedAt
+      articlePublishedAtInTheFuture || newPublishedAtEarlier
+        ? publishedAt
+        : article.publishedAt ?? publishedAt
 
     return this.prisma.article.update({
       where: {

--- a/libs/page/api/src/lib/page.service.ts
+++ b/libs/page/api/src/lib/page.service.ts
@@ -215,8 +215,13 @@ export class PageService {
       }
     })
 
+    const pagePublishedAtInTheFuture = page.publishedAt && page.publishedAt > new Date()
+    const newPublishedAtEarlier = page.publishedAt && page.publishedAt > publishedAt
+
     const pagePublishedAt =
-      !page.publishedAt || page.publishedAt > publishedAt ? publishedAt : page.publishedAt
+      pagePublishedAtInTheFuture || newPublishedAtEarlier
+        ? publishedAt
+        : page.publishedAt ?? publishedAt
 
     return this.prisma.page.update({
       where: {


### PR DESCRIPTION
If you publish an article in the future and then publish it even later, the publishedAt wasn't updated.
This caused the application to think that the article is published when it's in fact pending
