### PR TITLE
fix(bajour): Do not wrap payment provider list (BA-222)

### DIFF
--- a/libs/membership/website/src/lib/payment-method-picker/payment-method-picker.tsx
+++ b/libs/membership/website/src/lib/payment-method-picker/payment-method-picker.tsx
@@ -26,6 +26,7 @@ export const PaymentRadioWrapper = styled('div')<{active?: boolean}>`
 
 const icon = css`
   height: 40px;
+  width: auto;
 `
 
 const hiddenRadio = css`
@@ -69,6 +70,7 @@ export const PaymentMethodPicker = forwardRef<HTMLButtonElement, BuilderPaymentM
           name={name}
           value={value ? value : ''}
           onChange={event => onChange(event.target.value as string)}
+          sx={{flexWrap: 'nowrap'}}
           row>
           {paymentMethods?.map(method => (
             <FormControlLabel


### PR DESCRIPTION
When multiple payment providers are selected, the list would wrap to a new line. This style changes make sure that the list doesn't wrap on desktop displays.