### PR TITLE
fix(api): article and page lists should use preview mode

### DIFF
--- a/.github/workflows/on-demand-deploy-helm-website.yml
+++ b/.github/workflows/on-demand-deploy-helm-website.yml
@@ -59,11 +59,11 @@ jobs:
               NODE_ENV: production
             resources:
               requests:
-                memory: 100Mi
-                cpu: 50m
+                memory: null
+                cpu: null
               limits:
-                memory: 512Mi
-                cpu: 300m
+                memory: null
+                cpu: null
           EOF
           cat values.yaml
           export POD_NAME=review-${{ github.event.pull_request.number }}-${{ inputs.website_project }}-website

--- a/.github/workflows/on-demand-deploy-helm-website.yml
+++ b/.github/workflows/on-demand-deploy-helm-website.yml
@@ -57,6 +57,13 @@ jobs:
             image: ghcr.io/wepublish/website-${{ inputs.website_project }}:${{ github.sha }}
             env:
               NODE_ENV: production
+            resources:
+              requests:
+                memory: 100Mi
+                cpu: 50m
+              limits:
+                memory: 512Mi
+                cpu: 300m
           EOF
           cat values.yaml
           export POD_NAME=review-${{ github.event.pull_request.number }}-${{ inputs.website_project }}-website

--- a/.github/workflows/on-pr-review.yml
+++ b/.github/workflows/on-pr-review.yml
@@ -160,7 +160,7 @@ jobs:
             resources:
               requests:
                 memory: 100Mi
-                cpu: 200m
+                cpu: 50m
               limits:
                 memory: 256Mi
                 cpu: 300m
@@ -169,7 +169,7 @@ jobs:
             resources:
               requests:
                 memory: 192Mi
-                cpu: 100m
+                cpu: 50m
               limits:
                 memory: 384Mi
                 cpu: 200m

--- a/.github/workflows/on-pr-review.yml
+++ b/.github/workflows/on-pr-review.yml
@@ -86,9 +86,12 @@ jobs:
             rootUser: ${S3_ACCESS_KEY_ID}
             rootPassword: ${S3_SECRET_ACCESS_KEY}
           disableWebUI: true
+          console:
+            enabled: false
           defaultBuckets: wepublish-staff,wepublish-transformed
           persistence:
             enabled: false
+          resourcesPreset: "none"
           service:
             type: LoadBalancer
             port: 9000
@@ -159,20 +162,20 @@ jobs:
               OVERRIDE_ADMIN_PW: '123'
             resources:
               requests:
-                memory: 100Mi
-                cpu: 50m
+                memory: null
+                cpu: null
               limits:
-                memory: 256Mi
-                cpu: 300m
+                memory: null
+                cpu: null
           api:
             image: ghcr.io/wepublish/api:${{ github.sha }}
             resources:
               requests:
-                memory: 192Mi
-                cpu: 50m
+                memory: null
+                cpu: null
               limits:
-                memory: 384Mi
-                cpu: 200m
+                memory: null
+                cpu: null
             env:
               GOOGLE_APPLICATION_CREDENTIALS: /var/secrets/google/key.json
               DATABASE_URL: postgres://postgres:foo@review-${{ github.event.pull_request.number }}-database-postgresql.reviews.svc.cluster.local:5432/wepublish?schema=public
@@ -283,22 +286,22 @@ jobs:
               PEER_BY_DEFAULT: "true"
             resources:
               requests:
-                memory: 32Mi
-                cpu: 25m
+                memory: null
+                cpu: null
               limits:
-                memory: 64Mi
-                cpu: 100m
+                memory: null
+                cpu: null
           storybook:
             enabled: true
             image: ghcr.io/wepublish/storybook:${{ github.sha }}
             url: ${STORYBOOK_URL}
             resources:
               requests:
-                memory: 8Mi
-                cpu: 1m
+                memory: null
+                cpu: null
               limits:
-                memory: 16Mi
-                cpu: 20m
+                memory: null
+                cpu: null
           media:
             image: ghcr.io/wepublish/media:${{ github.sha }}
             env:
@@ -309,11 +312,11 @@ jobs:
               S3_PORT: '9000'
             resources:
               requests:
-                memory: 96Mi
-                cpu: 50m
+                memory: null
+                cpu: null
               limits:
-                memory: 192Mi
-                cpu: 200m
+                memory: null
+                cpu: null
           EOF
           export POD_NAME=review-${{ github.event.pull_request.number }}-app
           if [[ ! -z $(helm ls -a -n reviews |grep ${POD_NAME} |grep -v "deployed ") ]]; then helm uninstall -n reviews ${POD_NAME}; fi

--- a/apps/api-example/schema-v2.graphql
+++ b/apps/api-example/schema-v2.graphql
@@ -1056,8 +1056,6 @@ enum LoginStatus {
   ALL
   LOGGED_IN
   LOGGED_OUT
-  SUBSCRIBED
-  UNSUBSCRIBED
 }
 
 type MailProviderModel {

--- a/helm/charts/wepublish-website/Chart.yaml
+++ b/helm/charts/wepublish-website/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: WePublish website
 name: wepublish-website
-version: 1.2.0
+version: 1.2.1

--- a/helm/charts/wepublish-website/templates/website.yaml
+++ b/helm/charts/wepublish-website/templates/website.yaml
@@ -56,13 +56,28 @@ spec:
         - name: {{ include "helm.fullname" . }}
           image: {{ .Values.website.image }}
           imagePullPolicy: {{ .Values.deployment.imagePullPolicy }}
+          {{- $res := .Values.website.resources }}
+          {{- if or (and $res.requests (or $res.requests.cpu $res.requests.memory)) (and $res.limits (or $res.limits.cpu $res.limits.memory)) }}
           resources:
+            {{- if and $res.requests (or $res.requests.cpu $res.requests.memory) }}
             requests:
-              memory: {{ .Values.website.resources.requests.memory }}
-              cpu: {{ .Values.website.resources.requests.cpu }}
+              {{- if $res.requests.cpu }}
+              cpu: {{ $res.requests.cpu }}
+              {{- end }}
+              {{- if $res.requests.memory }}
+              memory: {{ $res.requests.memory }}
+              {{- end }}
+            {{- end }}
+            {{- if and $res.limits (or $res.limits.cpu $res.limits.memory) }}
             limits:
-              memory: {{ .Values.website.resources.limits.memory }}
-              cpu: {{ .Values.website.resources.limits.cpu }}
+              {{- if $res.limits.cpu }}
+              cpu: {{ $res.limits.cpu }}
+              {{- end }}
+              {{- if $res.limits.memory }}
+              memory: {{ $res.limits.memory }}
+              {{- end }}
+          {{- end }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 4000

--- a/helm/charts/wepublish/Chart.yaml
+++ b/helm/charts/wepublish/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: WePublish platform
 name: wepublish
-version: 5.2.0
+version: 5.2.1

--- a/helm/charts/wepublish/templates/api.yaml
+++ b/helm/charts/wepublish/templates/api.yaml
@@ -56,13 +56,28 @@ spec:
         - name: {{ include "helm.fullname" . }}
           image: {{ .Values.api.image }}
           imagePullPolicy: {{ .Values.deployment.imagePullPolicy }}
+          {{- $res := .Values.api.resources }}
+          {{- if or (and $res.requests (or $res.requests.cpu $res.requests.memory)) (and $res.limits (or $res.limits.cpu $res.limits.memory)) }}
           resources:
+            {{- if and $res.requests (or $res.requests.cpu $res.requests.memory) }}
             requests:
-              memory: {{ .Values.api.resources.requests.memory }}
-              cpu: {{ .Values.api.resources.requests.cpu }}
+              {{- if $res.requests.cpu }}
+              cpu: {{ $res.requests.cpu }}
+              {{- end }}
+              {{- if $res.requests.memory }}
+              memory: {{ $res.requests.memory }}
+              {{- end }}
+            {{- end }}
+            {{- if and $res.limits (or $res.limits.cpu $res.limits.memory) }}
             limits:
-              memory: {{ .Values.api.resources.limits.memory }}
-              cpu: {{ .Values.api.resources.limits.cpu }}
+              {{- if $res.limits.cpu }}
+              cpu: {{ $res.limits.cpu }}
+              {{- end }}
+              {{- if $res.limits.memory }}
+              memory: {{ $res.limits.memory }}
+              {{- end }}
+          {{- end }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 4000

--- a/helm/charts/wepublish/templates/editor.yaml
+++ b/helm/charts/wepublish/templates/editor.yaml
@@ -56,13 +56,28 @@ spec:
         - name: {{ include "helm.fullname" . }}
           image: {{ .Values.editor.image }}
           imagePullPolicy: {{ .Values.deployment.imagePullPolicy }}
+          {{- $res := .Values.editor.resources }}
+          {{- if or (and $res.requests (or $res.requests.cpu $res.requests.memory)) (and $res.limits (or $res.limits.cpu $res.limits.memory)) }}
           resources:
+            {{- if and $res.requests (or $res.requests.cpu $res.requests.memory) }}
             requests:
-              memory: {{ .Values.editor.resources.requests.memory }}
-              cpu: {{ .Values.editor.resources.requests.cpu }}
+              {{- if $res.requests.cpu }}
+              cpu: {{ $res.requests.cpu }}
+              {{- end }}
+              {{- if $res.requests.memory }}
+              memory: {{ $res.requests.memory }}
+              {{- end }}
+            {{- end }}
+            {{- if and $res.limits (or $res.limits.cpu $res.limits.memory) }}
             limits:
-              memory: {{ .Values.editor.resources.limits.memory }}
-              cpu: {{ .Values.editor.resources.limits.cpu }}
+              {{- if $res.limits.cpu }}
+              cpu: {{ $res.limits.cpu }}
+              {{- end }}
+              {{- if $res.limits.memory }}
+              memory: {{ $res.limits.memory }}
+              {{- end }}
+          {{- end }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 3000

--- a/helm/charts/wepublish/templates/media.yaml
+++ b/helm/charts/wepublish/templates/media.yaml
@@ -56,13 +56,28 @@ spec:
         - name: {{ include "helm.fullname" . }}
           image: {{ .Values.media.image }}
           imagePullPolicy: {{ .Values.deployment.imagePullPolicy }}
+          {{- $res := .Values.media.resources }}
+          {{- if or (and $res.requests (or $res.requests.cpu $res.requests.memory)) (and $res.limits (or $res.limits.cpu $res.limits.memory)) }}
           resources:
+            {{- if and $res.requests (or $res.requests.cpu $res.requests.memory) }}
             requests:
-              memory: {{ .Values.media.resources.requests.memory }}
-              cpu: {{ .Values.media.resources.requests.cpu }}
+              {{- if $res.requests.cpu }}
+              cpu: {{ $res.requests.cpu }}
+              {{- end }}
+              {{- if $res.requests.memory }}
+              memory: {{ $res.requests.memory }}
+              {{- end }}
+            {{- end }}
+            {{- if and $res.limits (or $res.limits.cpu $res.limits.memory) }}
             limits:
-              memory: {{ .Values.media.resources.limits.memory }}
-              cpu: {{ .Values.media.resources.limits.cpu }}
+              {{- if $res.limits.cpu }}
+              cpu: {{ $res.limits.cpu }}
+              {{- end }}
+              {{- if $res.limits.memory }}
+              memory: {{ $res.limits.memory }}
+              {{- end }}
+          {{- end }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 4100

--- a/helm/charts/wepublish/templates/migration.yaml
+++ b/helm/charts/wepublish/templates/migration.yaml
@@ -27,13 +27,28 @@ spec:
         - name: {{ include "helm.fullname" . }}
           image: {{ .Values.migration.image }}
           imagePullPolicy: {{ .Values.deployment.imagePullPolicy }}
+          {{- $res := .Values.migration.resources }}
+          {{- if or (and $res.requests (or $res.requests.cpu $res.requests.memory)) (and $res.limits (or $res.limits.cpu $res.limits.memory)) }}
           resources:
+            {{- if and $res.requests (or $res.requests.cpu $res.requests.memory) }}
             requests:
-              memory: {{ .Values.migration.resources.requests.memory }}
-              cpu: {{ .Values.migration.resources.requests.cpu }}
+              {{- if $res.requests.cpu }}
+              cpu: {{ $res.requests.cpu }}
+              {{- end }}
+              {{- if $res.requests.memory }}
+              memory: {{ $res.requests.memory }}
+              {{- end }}
+            {{- end }}
+            {{- if and $res.limits (or $res.limits.cpu $res.limits.memory) }}
             limits:
-              memory: {{ .Values.migration.resources.limits.memory }}
-              cpu: {{ .Values.migration.resources.limits.cpu }}
+              {{- if $res.limits.cpu }}
+              cpu: {{ $res.limits.cpu }}
+              {{- end }}
+              {{- if $res.limits.memory }}
+              memory: {{ $res.limits.memory }}
+              {{- end }}
+          {{- end }}
+          {{- end }}
           env:
             {{- if .Values.migration.dynamicEnv }}
             {{- range $key, $value := .Values.migration.dynamicEnv }}

--- a/helm/charts/wepublish/templates/storybook.yaml
+++ b/helm/charts/wepublish/templates/storybook.yaml
@@ -56,13 +56,28 @@ spec:
       containers:
         - name: {{ include "helm.fullname" . }}
           image: {{ .Values.storybook.image }}
+          {{- $res := .Values.storybook.resources }}
+          {{- if or (and $res.requests (or $res.requests.cpu $res.requests.memory)) (and $res.limits (or $res.limits.cpu $res.limits.memory)) }}
           resources:
+            {{- if and $res.requests (or $res.requests.cpu $res.requests.memory) }}
             requests:
-              memory: {{ .Values.storybook.resources.requests.memory }}
-              cpu: {{ .Values.storybook.resources.requests.cpu }}
+              {{- if $res.requests.cpu }}
+              cpu: {{ $res.requests.cpu }}
+              {{- end }}
+              {{- if $res.requests.memory }}
+              memory: {{ $res.requests.memory }}
+              {{- end }}
+            {{- end }}
+            {{- if and $res.limits (or $res.limits.cpu $res.limits.memory) }}
             limits:
-              memory: {{ .Values.storybook.resources.limits.memory }}
-              cpu: {{ .Values.storybook.resources.limits.cpu }}
+              {{- if $res.limits.cpu }}
+              cpu: {{ $res.limits.cpu }}
+              {{- end }}
+              {{- if $res.limits.memory }}
+              memory: {{ $res.limits.memory }}
+              {{- end }}
+          {{- end }}
+          {{- end }}
           imagePullPolicy: {{ .Values.storybook.imagePullPolicy }}
           ports:
             - name: http

--- a/libs/article/api/src/lib/article.resolver.ts
+++ b/libs/article/api/src/lib/article.resolver.ts
@@ -20,7 +20,7 @@ import {
   CanPublishArticle,
   CanGetArticle
 } from '@wepublish/permissions'
-import {hasPermission, Permissions, PreviewMode} from '@wepublish/permissions/api'
+import {Permissions, PreviewMode} from '@wepublish/permissions/api'
 import {CurrentUser, Public, UserSession} from '@wepublish/authentication/api'
 import {TrackingPixelService} from '@wepublish/tracking-pixel/api'
 import {SettingDataloaderService, SettingName} from '@wepublish/settings/api'
@@ -69,8 +69,8 @@ export class ArticleResolver {
   @Query(() => PaginatedArticles, {
     description: `Returns a paginated list of articles based on the filters given.`
   })
-  public articles(@Args() args: ArticleListArgs, @CurrentUser() user: UserSession | undefined) {
-    if (!hasPermission(CanGetArticle, user?.roles ?? [])) {
+  public articles(@Args() args: ArticleListArgs, @PreviewMode() isPreview: boolean) {
+    if (!isPreview) {
       args.filter = {
         ...args.filter,
         draft: undefined,
@@ -153,15 +153,11 @@ export class ArticleResolver {
   }
 
   @ResolveField(() => ArticleRevision)
-  async latest(
-    @Parent() parent: PArticle,
-    @CurrentUser() user: UserSession | undefined,
-    @PreviewMode() isPreview: boolean
-  ) {
+  async latest(@Parent() parent: PArticle, @PreviewMode() isPreview: boolean) {
     const {id: articleId} = parent
     const {draft, pending, published} = await this.articleRevisionsDataloader.load(articleId)
 
-    if (!isPreview || !hasPermission(CanGetArticle, user?.roles ?? [])) {
+    if (!isPreview) {
       if (published) {
         return published
       }

--- a/libs/page/api/src/lib/page.resolver.ts
+++ b/libs/page/api/src/lib/page.resolver.ts
@@ -16,7 +16,7 @@ import {Page as PPage} from '@prisma/client'
 import {BadRequestException} from '@nestjs/common'
 import {CurrentUser, Public, UserSession} from '@wepublish/authentication/api'
 import {CanCreatePage, CanDeletePage, CanGetPage, CanPublishPage} from '@wepublish/permissions'
-import {hasPermission, Permissions, PreviewMode} from '@wepublish/permissions/api'
+import {Permissions, PreviewMode} from '@wepublish/permissions/api'
 
 @Resolver(() => Page)
 export class PageResolver {
@@ -48,8 +48,8 @@ export class PageResolver {
   @Query(() => PaginatedPages, {
     description: `Returns a paginated list of pages based on the filters given.`
   })
-  public pages(@Args() args: PageListArgs, @CurrentUser() user: UserSession | undefined) {
-    if (!hasPermission(CanGetPage, user?.roles ?? [])) {
+  public pages(@Args() args: PageListArgs, @PreviewMode() isPreview: boolean) {
+    if (!isPreview) {
       args.filter = {
         ...args.filter,
         draft: undefined,
@@ -110,15 +110,11 @@ export class PageResolver {
   }
 
   @ResolveField(() => PageRevision)
-  async latest(
-    @Parent() parent: PPage,
-    @CurrentUser() user: UserSession | undefined,
-    @PreviewMode() isPreview: boolean
-  ) {
+  async latest(@Parent() parent: PPage, @PreviewMode() isPreview: boolean) {
     const {id: pageId} = parent
     const {draft, pending, published} = await this.pageRevisionsDataloader.load(pageId)
 
-    if (!isPreview || !hasPermission(CanGetPage, user?.roles ?? [])) {
+    if (!isPreview) {
       return published
     }
 


### PR DESCRIPTION
Also unless preview mode is enabled even with  `CanGetArticles` & `CanGetPages`  permissions no previews are shown on `latest` but still accessible via `draft`  or `pending`.

This fixes article list on the website and makes the preview more intentional.
