### PR TITLE
refactor(onlinereports): apply custom content-wrapper styles only to article-wrapper

### DIFF
--- a/apps/onlinereports/pages/_app.tsx
+++ b/apps/onlinereports/pages/_app.tsx
@@ -53,7 +53,6 @@ import {
   TitleBlockTitle,
   TitleBlockWrapper
 } from '@wepublish/block-content/website'
-import {ContentWrapperStyled} from '@wepublish/content/website'
 import styled from '@emotion/styled'
 import {
   authLink,
@@ -122,7 +121,7 @@ const MainContent = styled('main')`
 
   row-gap: ${({theme}) => theme.spacing(7.5)};
 
-  ${ContentWrapperStyled} {
+  [class*='ContentWrapperStyled'][class*='ArticleWrapper'] {
     ${({theme}) => theme.breakpoints.down('md')} {
       row-gap: ${({theme}) => theme.spacing(5)};
     }


### PR DESCRIPTION
I'm using css as I could not get it working with Emotion `${ArticleWrapper}`. Works as intended, adding styles into ContentWrapperStyled only on article page.