### PR TITLE
refactor(api): make all guids strings on a database level

### DIFF
--- a/libs/api/prisma/migrations/20250904071505_make_all_guids_in_the_database_strings/migration.sql
+++ b/libs/api/prisma/migrations/20250904071505_make_all_guids_in_the_database_strings/migration.sql
@@ -1,0 +1,176 @@
+/*
+  Warnings:
+
+  - The primary key for the `banner_actions` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The primary key for the `banners` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The primary key for the `block-content.styles` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The primary key for the `consents` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The primary key for the `crowdfunding_goals` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The primary key for the `crowdfundings` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The primary key for the `events` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The primary key for the `events.tagged-events` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The primary key for the `mail.log` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The primary key for the `mail_templates` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The primary key for the `periodic_jobs` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The primary key for the `subscription_communication_flows` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The primary key for the `subscriptions.intervals` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The primary key for the `user-consents` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The primary key for the `user_communication_flows` table will be changed. If it partially fails, the table could be left without primary key constraint.
+
+*/
+-- DropForeignKey
+ALTER TABLE "_BannerToPage" DROP CONSTRAINT "_BannerToPage_A_fkey";
+
+-- DropForeignKey
+ALTER TABLE "_CrowdfundingToMemberPlan" DROP CONSTRAINT "_CrowdfundingToMemberPlan_A_fkey";
+
+-- DropForeignKey
+ALTER TABLE "_PaymentMethodToSubscriptionFlow" DROP CONSTRAINT "_PaymentMethodToSubscriptionFlow_B_fkey";
+
+-- DropForeignKey
+ALTER TABLE "banner_actions" DROP CONSTRAINT "banner_actions_bannerId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "crowdfunding_goals" DROP CONSTRAINT "crowdfunding_goals_crowdfundingId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "events.tagged-events" DROP CONSTRAINT "events.tagged-events_eventId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "mail.log" DROP CONSTRAINT "mail.log_mailTemplateId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "subscriptions.intervals" DROP CONSTRAINT "subscriptions.intervals_mailTemplateId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "subscriptions.intervals" DROP CONSTRAINT "subscriptions.intervals_subscriptionFlowId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "user-consents" DROP CONSTRAINT "user-consents_consentId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "user_communication_flows" DROP CONSTRAINT "user_communication_flows_mailTemplateId_fkey";
+
+-- AlterTable
+ALTER TABLE "_BannerToPage" ALTER COLUMN "A" SET DATA TYPE TEXT;
+
+-- AlterTable
+ALTER TABLE "_CrowdfundingToMemberPlan" ALTER COLUMN "A" SET DATA TYPE TEXT;
+
+-- AlterTable
+ALTER TABLE "_PaymentMethodToSubscriptionFlow" ALTER COLUMN "B" SET DATA TYPE TEXT;
+
+-- AlterTable
+ALTER TABLE "banner_actions" DROP CONSTRAINT "banner_actions_pkey",
+ALTER COLUMN "id" SET DATA TYPE TEXT,
+ALTER COLUMN "bannerId" SET DATA TYPE TEXT,
+ADD CONSTRAINT "banner_actions_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "banners" DROP CONSTRAINT "banners_pkey",
+ALTER COLUMN "id" SET DATA TYPE TEXT,
+ADD CONSTRAINT "banners_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "block-content.styles" DROP CONSTRAINT "block-content.styles_pkey",
+ALTER COLUMN "id" SET DATA TYPE TEXT,
+ADD CONSTRAINT "block-content.styles_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "consents" DROP CONSTRAINT "consents_pkey",
+ALTER COLUMN "id" SET DATA TYPE TEXT,
+ADD CONSTRAINT "consents_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "crowdfunding_goals" DROP CONSTRAINT "crowdfunding_goals_pkey",
+ALTER COLUMN "id" SET DATA TYPE TEXT,
+ALTER COLUMN "crowdfundingId" SET DATA TYPE TEXT,
+ADD CONSTRAINT "crowdfunding_goals_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "crowdfundings" DROP CONSTRAINT "crowdfundings_pkey",
+ALTER COLUMN "id" SET DATA TYPE TEXT,
+ADD CONSTRAINT "crowdfundings_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "events" DROP CONSTRAINT "events_pkey",
+ALTER COLUMN "id" SET DATA TYPE TEXT,
+ADD CONSTRAINT "events_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "events.tagged-events" DROP CONSTRAINT "events.tagged-events_pkey",
+ALTER COLUMN "eventId" SET DATA TYPE TEXT,
+ADD CONSTRAINT "events.tagged-events_pkey" PRIMARY KEY ("eventId", "tagId");
+
+-- AlterTable
+ALTER TABLE "mail.log" DROP CONSTRAINT "mail.log_pkey",
+ALTER COLUMN "id" SET DATA TYPE TEXT,
+ALTER COLUMN "mailTemplateId" SET DATA TYPE TEXT,
+ADD CONSTRAINT "mail.log_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "mail_templates" DROP CONSTRAINT "mail_templates_pkey",
+ALTER COLUMN "id" SET DATA TYPE TEXT,
+ADD CONSTRAINT "mail_templates_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "periodic_jobs" DROP CONSTRAINT "periodic_jobs_pkey",
+ALTER COLUMN "id" SET DATA TYPE TEXT,
+ADD CONSTRAINT "periodic_jobs_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "subscription_communication_flows" DROP CONSTRAINT "subscription_communication_flows_pkey",
+ALTER COLUMN "id" SET DATA TYPE TEXT,
+ADD CONSTRAINT "subscription_communication_flows_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "subscriptions.intervals" DROP CONSTRAINT "subscriptions.intervals_pkey",
+ALTER COLUMN "id" SET DATA TYPE TEXT,
+ALTER COLUMN "mailTemplateId" SET DATA TYPE TEXT,
+ALTER COLUMN "subscriptionFlowId" SET DATA TYPE TEXT,
+ADD CONSTRAINT "subscriptions.intervals_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "user-consents" DROP CONSTRAINT "user-consents_pkey",
+ALTER COLUMN "id" SET DATA TYPE TEXT,
+ALTER COLUMN "consentId" SET DATA TYPE TEXT,
+ADD CONSTRAINT "user-consents_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "user_communication_flows" DROP CONSTRAINT "user_communication_flows_pkey",
+ALTER COLUMN "id" SET DATA TYPE TEXT,
+ALTER COLUMN "mailTemplateId" SET DATA TYPE TEXT,
+ADD CONSTRAINT "user_communication_flows_pkey" PRIMARY KEY ("id");
+
+-- AddForeignKey
+ALTER TABLE "mail.log" ADD CONSTRAINT "mail.log_mailTemplateId_fkey" FOREIGN KEY ("mailTemplateId") REFERENCES "mail_templates"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "events.tagged-events" ADD CONSTRAINT "events.tagged-events_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "events"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user-consents" ADD CONSTRAINT "user-consents_consentId_fkey" FOREIGN KEY ("consentId") REFERENCES "consents"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_communication_flows" ADD CONSTRAINT "user_communication_flows_mailTemplateId_fkey" FOREIGN KEY ("mailTemplateId") REFERENCES "mail_templates"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "subscriptions.intervals" ADD CONSTRAINT "subscriptions.intervals_mailTemplateId_fkey" FOREIGN KEY ("mailTemplateId") REFERENCES "mail_templates"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "subscriptions.intervals" ADD CONSTRAINT "subscriptions.intervals_subscriptionFlowId_fkey" FOREIGN KEY ("subscriptionFlowId") REFERENCES "subscription_communication_flows"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "banner_actions" ADD CONSTRAINT "banner_actions_bannerId_fkey" FOREIGN KEY ("bannerId") REFERENCES "banners"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "crowdfunding_goals" ADD CONSTRAINT "crowdfunding_goals_crowdfundingId_fkey" FOREIGN KEY ("crowdfundingId") REFERENCES "crowdfundings"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_PaymentMethodToSubscriptionFlow" ADD CONSTRAINT "_PaymentMethodToSubscriptionFlow_B_fkey" FOREIGN KEY ("B") REFERENCES "subscription_communication_flows"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_BannerToPage" ADD CONSTRAINT "_BannerToPage_A_fkey" FOREIGN KEY ("A") REFERENCES "banners"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_CrowdfundingToMemberPlan" ADD CONSTRAINT "_CrowdfundingToMemberPlan_A_fkey" FOREIGN KEY ("A") REFERENCES "crowdfundings"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/libs/api/prisma/schema.prisma
+++ b/libs/api/prisma/schema.prisma
@@ -511,7 +511,7 @@ enum MailLogState {
 }
 
 model MailLog {
-  id         String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  id         String   @id @default(dbgenerated("gen_random_uuid()"))
   createdAt  DateTime @default(now())
   modifiedAt DateTime @updatedAt
 
@@ -522,7 +522,7 @@ model MailLog {
   mailProviderID String
   mailIdentifier String
   mailTemplate   MailTemplate @relation(fields: [mailTemplateId], references: [id])
-  mailTemplateId String       @db.Uuid
+  mailTemplateId String
   mailData       String?
   subject        String?
 
@@ -1162,7 +1162,7 @@ enum EventStatus {
 }
 
 model Event {
-  id         String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  id         String   @id @default(dbgenerated("gen_random_uuid()"))
   createdAt  DateTime @default(now())
   modifiedAt DateTime @updatedAt
 
@@ -1188,7 +1188,7 @@ model Event {
 
 model TaggedEvents {
   event      Event    @relation(fields: [eventId], references: [id], onDelete: Cascade)
-  eventId    String   @db.Uuid
+  eventId    String
   tag        Tag      @relation(fields: [tagId], references: [id], onDelete: Cascade)
   tagId      String
   createdAt  DateTime @default(now())
@@ -1199,7 +1199,7 @@ model TaggedEvents {
 }
 
 model Consent {
-  id         String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  id         String   @id @default(dbgenerated("gen_random_uuid()"))
   createdAt  DateTime @default(now())
   modifiedAt DateTime @updatedAt
 
@@ -1212,12 +1212,12 @@ model Consent {
 }
 
 model UserConsent {
-  id         String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  id         String   @id @default(dbgenerated("gen_random_uuid()"))
   createdAt  DateTime @default(now())
   modifiedAt DateTime @updatedAt
 
   consent   Consent @relation(fields: [consentId], references: [id], onDelete: Cascade)
-  consentId String  @db.Uuid
+  consentId String
 
   user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId String
@@ -1236,14 +1236,14 @@ enum UserEvent {
 }
 
 model UserFlowMail {
-  id         String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  id         String   @id @default(dbgenerated("gen_random_uuid()"))
   createdAt  DateTime @default(now())
   modifiedAt DateTime @updatedAt
 
   event UserEvent @unique
 
   mailTemplate   MailTemplate? @relation(fields: [mailTemplateId], references: [id]) // user creates a new account
-  mailTemplateId String?       @db.Uuid
+  mailTemplateId String?
 
   @@map("user_communication_flows")
 }
@@ -1260,7 +1260,7 @@ enum SubscriptionEvent {
 }
 
 model SubscriptionFlow {
-  id         String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  id         String   @id @default(dbgenerated("gen_random_uuid()"))
   createdAt  DateTime @default(now())
   modifiedAt DateTime @updatedAt
 
@@ -1279,22 +1279,22 @@ model SubscriptionFlow {
 }
 
 model SubscriptionInterval {
-  id                 String            @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  id                 String            @id @default(dbgenerated("gen_random_uuid()"))
   createdAt          DateTime          @default(now())
   modifiedAt         DateTime          @updatedAt
   event              SubscriptionEvent
   daysAwayFromEnding Int?              @db.SmallInt
   mailTemplate       MailTemplate?     @relation(fields: [mailTemplateId], references: [id])
-  mailTemplateId     String?           @db.Uuid
+  mailTemplateId     String?
 
   subscriptionFlow   SubscriptionFlow @relation(fields: [subscriptionFlowId], references: [id], onDelete: Cascade)
-  subscriptionFlowId String           @db.Uuid
+  subscriptionFlowId String
 
   @@map("subscriptions.intervals")
 }
 
 model MailTemplate {
-  id         String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  id         String   @id @default(dbgenerated("gen_random_uuid()"))
   createdAt  DateTime @default(now())
   modifiedAt DateTime @updatedAt
 
@@ -1313,7 +1313,7 @@ model MailTemplate {
 }
 
 model PeriodicJob {
-  id         String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  id         String   @id @default(dbgenerated("gen_random_uuid()"))
   createdAt  DateTime @default(now())
   modifiedAt DateTime @updatedAt
 
@@ -1350,7 +1350,7 @@ enum BlockType {
 }
 
 model BlockStyle {
-  id         String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  id         String   @id @default(dbgenerated("gen_random_uuid()"))
   createdAt  DateTime @default(now())
   modifiedAt DateTime @updatedAt
 
@@ -1361,7 +1361,7 @@ model BlockStyle {
 }
 
 model Banner {
-  id         String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  id         String   @id @default(dbgenerated("gen_random_uuid()"))
   createdAt  DateTime @default(now())
   modifiedAt DateTime @updatedAt
 
@@ -1393,12 +1393,12 @@ enum LoginStatus {
 }
 
 model BannerAction {
-  id         String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  id         String   @id @default(dbgenerated("gen_random_uuid()"))
   createdAt  DateTime @default(now())
   modifiedAt DateTime @updatedAt
 
   banner   Banner @relation(fields: [bannerId], references: [id], onDelete: Cascade)
-  bannerId String @db.Uuid
+  bannerId String
 
   label String
   url   String
@@ -1416,7 +1416,7 @@ enum BannerActionRole {
 }
 
 model Crowdfunding {
-  id                      String             @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  id                      String             @id @default(dbgenerated("gen_random_uuid()"))
   createdAt               DateTime           @default(now())
   modifiedAt              DateTime           @updatedAt
   name                    String
@@ -1430,14 +1430,14 @@ model Crowdfunding {
 }
 
 model CrowdfundingGoal {
-  id             String       @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  id             String       @id @default(dbgenerated("gen_random_uuid()"))
   createdAt      DateTime     @default(now())
   modifiedAt     DateTime     @updatedAt
   title          String
   description    String?
   amount         Int
   Crowdfunding   Crowdfunding @relation(fields: [crowdfundingId], references: [id], onDelete: Cascade)
-  crowdfundingId String       @db.Uuid
+  crowdfundingId String
 
   @@map("crowdfunding_goals")
 }


### PR DESCRIPTION
As figured out by @dsheyp, when one tries to query an id that is not a guid/uuid, the database throws an error.
This is not desired in my opinion in applications like these as we map urls to ids, this keeps the ids being the same structure but with a more loose database type.
