### PR TITLE
fix(api): added insensitive mode to ArticleService and Pageservice

### DIFF
--- a/libs/article/api/src/lib/article.service.ts
+++ b/libs/article/api/src/lib/article.service.ts
@@ -26,7 +26,10 @@ export class ArticleService {
   async getArticleBySlug(slug: string) {
     return this.prisma.article.findFirst({
       where: {
-        slug
+        slug: {
+          equals: slug,
+          mode: 'insensitive'
+        }
       },
       orderBy: {
         publishedAt: 'asc' // there might be an unpublished article with the same slug

--- a/libs/page/api/src/lib/page.service.ts
+++ b/libs/page/api/src/lib/page.service.ts
@@ -19,7 +19,10 @@ export class PageService {
   async getPageBySlug(slug: string) {
     return this.prisma.page.findFirst({
       where: {
-        slug
+        slug: {
+          equals: slug,
+          mode: 'insensitive'
+        }
       },
       orderBy: {
         publishedAt: 'asc' // there might be an unpublished page with the same slug


### PR DESCRIPTION
Wenn jemand /A/Artikelname statt /a/artikelname aufruft, liefert die API inzwischen zwar dieselbe Seite, aber der Browser bleibt auf der Großschreibweise stehen. Für Google sieht das deshalb wie eine separate URL aus und sie behält den Leerinhalt im Index. SEO-seitig will man so etwas vermeiden und erzwingt daher meist, dass die Adresse selbst auf die „Kleinbuchstaben-Version“ umgeleitet wird – z. B. indem ein CDN wie Cloudflare alle Pfade lowercased oder indem du in Next.js eine Middleware einsetzt, die bei Großbuchstaben einen 301-Redirect auf die kleingeschriebene URL zurückgibt.