### PR TITLE
fix(onlinereports): OR-96 fix vertical margins and line-heights in mobile view (ads, titles, pre-titles)

### DIFF
--- a/apps/onlinereports/pages/_app.tsx
+++ b/apps/onlinereports/pages/_app.tsx
@@ -25,6 +25,8 @@ import {OnlineReportsAuthorChip} from '../src/components/author-chip'
 import {OnlineReportsArticleAuthors} from '../src/components/online-reports-article-authors'
 import {OnlineReportsArticleList} from '../src/components/online-reports-article-list'
 import {OnlineReportsTeaserListBlock} from '../src/onlinereports-teaser-list-block'
+import {OnlineReportsTeaserGridFlexBlock} from '../src/onlinereports-teaser-grid-flex-blocks'
+import {OnlineReportsTeaserGridBlock} from '../src/onlinereports-teaser-grid-block'
 import {Advertisement} from '../src/components/advertisement'
 import {Structure} from '../src/structure'
 import {OnlineReportsQuoteBlock} from '../src/components/quote-block'
@@ -100,7 +102,11 @@ const MainContainer = styled('div')`
 const MainContent = styled('main')`
   display: flex;
   flex-direction: column;
-  row-gap: ${({theme}) => theme.spacing(7.5)};
+  row-gap: ${({theme}) => theme.spacing(4)};
+
+  ${theme.breakpoints.up('sm')} {
+    row-gap: ${({theme}) => theme.spacing(7.5)};
+  }
 
   ${theme.breakpoints.down('lg')} {
     padding-left: ${({theme}) => theme.spacing(2.5)};
@@ -182,6 +188,8 @@ function CustomApp({Component, pageProps, emotionCache}: CustomAppProps) {
               Teaser: OnlineReportsTeaser,
               Renderer: OnlineReportsBlockRenderer,
               TeaserList: OnlineReportsTeaserListBlock,
+              TeaserGridFlex: OnlineReportsTeaserGridFlexBlock,
+              TeaserGrid: OnlineReportsTeaserGridBlock,
               Quote: OnlineReportsQuoteBlock,
               Subscribe: Mitmachen,
               Title: OnlineReportsTitle

--- a/apps/onlinereports/pages/a/tag/[tag].tsx
+++ b/apps/onlinereports/pages/a/tag/[tag].tsx
@@ -33,7 +33,10 @@ const TagArticleListWrapper = styled('div')`
   display: flex;
   flex-direction: column;
   gap: ${({theme}) => theme.spacing(2.5)};
-  margin-top: ${({theme}) => theme.spacing(4)};
+
+  ${({theme}) => theme.breakpoints.up('sm')} {
+    margin-top: ${({theme}) => theme.spacing(4)};
+  }
 `
 
 export default function ArticleListByTag({tagId}: ArticleListByTagProps) {

--- a/apps/onlinereports/src/block-styles/news.tsx
+++ b/apps/onlinereports/src/block-styles/news.tsx
@@ -69,7 +69,12 @@ const Filler = styled(Box)``
 const NewsTeaserListWrapper = styled(Box)`
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: ${({theme}) => theme.spacing(2.5)};
+  row-gap: ${({theme}) => theme.spacing(3)};
+
+  ${({theme}) => theme.breakpoints.up('sm')} {
+    row-gap: ${({theme}) => theme.spacing(2.5)};
+    column-gap: ${({theme}) => theme.spacing(2.5)};
+  }
 
   ${BlueBox} {
     grid-column: span 3;

--- a/apps/onlinereports/src/components/article.tsx
+++ b/apps/onlinereports/src/components/article.tsx
@@ -26,15 +26,11 @@ export const ArticleWrapper = styled(OnlineReportsContentWrapper)`
 
 export const ArticlePreTitle = styled('div')`
   margin-top: ${({theme}) => theme.spacing(4)};
-  margin-bottom: -${({theme}) => theme.spacing(5)};
-
-  ${({theme}) => theme.breakpoints.up('md')} {
-    margin-bottom: -${({theme}) => theme.spacing(3.5)};
-  }
-
+  margin-bottom: -${({theme}) => theme.spacing(3)};
   color: ${({theme}) => theme.palette.primary.main};
   grid-row-start: 1;
   font-weight: 500;
+  line-height: 1.2;
 `
 
 export const ArticleTopMeta = styled('aside')`

--- a/apps/onlinereports/src/components/content-wrapper.tsx
+++ b/apps/onlinereports/src/components/content-wrapper.tsx
@@ -18,7 +18,17 @@ export const OnlineReportsContentWrapperStyled = styled(ContentWrapperStyled)<{
   fullWidth?: boolean
 }>`
   display: grid;
-  gap: ${({theme}) => theme.spacing(7)};
+  row-gap: ${({theme}) => theme.spacing(4)};
+  & > * {
+    max-width: calc(100vw - ${({theme}) => theme.spacing(5)});
+  }
+
+  ${({theme}) => theme.breakpoints.up('sm')} {
+    gap: ${({theme}) => theme.spacing(7)};
+    & > * {
+      max-width: unset;
+    }
+  }
 
   ${({theme, fullWidth}) =>
     !fullWidth &&

--- a/apps/onlinereports/src/custom-teasers/news.tsx
+++ b/apps/onlinereports/src/custom-teasers/news.tsx
@@ -44,7 +44,9 @@ export const NewsTeaser = styled(NewsTeaserUnstyled)`
   }
 
   > span {
+    display: inline-block;
     font-weight: 500;
+    line-height: 1.2;
   }
 
   h4 {

--- a/apps/onlinereports/src/onlinereports-base-teaser.tsx
+++ b/apps/onlinereports/src/onlinereports-base-teaser.tsx
@@ -96,7 +96,7 @@ export const OnlineReportsBaseTeaserStyled = styled(Teaser)`
     'lead'
     'tags'
     'authors';
-  grid-template-rows: min-content 12px min-content min-content min-content min-content;
+  grid-template-rows: repeat(6, min-content);
 
   .MuiChip-root {
     color: inherit;
@@ -108,6 +108,14 @@ export const OnlineReportsBaseTeaserStyled = styled(Teaser)`
   }
 
   ${TeaserImageWrapper} {
+    &:empty {
+      display: none;
+
+      ${({theme}) => theme.breakpoints.up('sm')} {
+        display: unset;
+      }
+    }
+
     img {
       aspect-ratio: 4/3;
       max-height: unset;
@@ -120,7 +128,7 @@ export const OnlineReportsBaseTeaserStyled = styled(Teaser)`
 
   ${TeaserPreTitleWrapper} {
     margin-bottom: 0;
-    padding: 0;
+    padding: ${({theme}) => theme.spacing(0.5)} 0 0 0;
     height: unset;
     color: ${({theme}) => theme.palette.primary.main};
     background-color: transparent;
@@ -141,6 +149,10 @@ export const OnlineReportsBaseTeaserStyled = styled(Teaser)`
     font-size: ${({theme}) => theme.typography.h3.fontSize};
     font-weight: ${({theme}) => theme.typography.h3.fontWeight};
     color: ${({theme}) => theme.typography.h3.color};
+    margin-bottom: ${({theme}) => theme.spacing(0.25)};
+    ${({theme}) => theme.breakpoints.up('sm')} {
+      margin-bottom: ${({theme}) => theme.spacing(1)};
+    }
   }
 
   ${TeaserLead} {

--- a/apps/onlinereports/src/onlinereports-teaser-grid-block.tsx
+++ b/apps/onlinereports/src/onlinereports-teaser-grid-block.tsx
@@ -1,0 +1,45 @@
+import styled from '@emotion/styled'
+import {
+  alignmentForTeaserBlock,
+  isFilledTeaser,
+  isTeaserGridBlock,
+  TeaserGridBlockWrapper
+} from '@wepublish/block-content/website'
+import {BuilderTeaserGridBlockProps, useWebsiteBuilder} from '@wepublish/website/builder'
+
+export const OnlineReportsTeaserGridBlockWrapper = styled(TeaserGridBlockWrapper)`
+  row-gap: ${({theme}) => theme.spacing(3)};
+
+  ${({theme}) => theme.breakpoints.up('sm')} {
+    row-gap: ${({theme}) => theme.spacing(5)};
+  }
+`
+
+export const OnlineReportsTeaserGridBlock = ({
+  numColumns,
+  teasers,
+  blockStyle,
+  className
+}: BuilderTeaserGridBlockProps) => {
+  const {
+    blocks: {Teaser}
+  } = useWebsiteBuilder()
+
+  const filledTeasers = teasers.filter(isFilledTeaser)
+
+  return (
+    <OnlineReportsTeaserGridBlockWrapper className={className} numColumns={numColumns}>
+      {filledTeasers.map((teaser, index) => (
+        <Teaser
+          key={index}
+          teaser={teaser}
+          numColumns={numColumns}
+          alignment={alignmentForTeaserBlock(index, numColumns)}
+          blockStyle={blockStyle}
+        />
+      ))}
+    </OnlineReportsTeaserGridBlockWrapper>
+  )
+}
+
+export {alignmentForTeaserBlock, isFilledTeaser, isTeaserGridBlock}

--- a/apps/onlinereports/src/onlinereports-teaser-grid-flex-blocks.tsx
+++ b/apps/onlinereports/src/onlinereports-teaser-grid-flex-blocks.tsx
@@ -1,0 +1,42 @@
+import styled from '@emotion/styled'
+import {
+  fixFlexTeasers,
+  isTeaserGridFlexBlock,
+  omitEmptyFlexTeasers,
+  TeaserGridFlexBlockWrapper
+} from '@wepublish/block-content/website'
+import {BuilderTeaserGridFlexBlockProps, useWebsiteBuilder} from '@wepublish/website/builder'
+import {useMemo} from 'react'
+
+export const OnlineReportsTeaserGridFlexBlockWrapper = styled(TeaserGridFlexBlockWrapper)`
+  row-gap: ${({theme}) => theme.spacing(3)};
+
+  ${({theme}) => theme.breakpoints.up('sm')} {
+    row-gap: ${({theme}) => theme.spacing(5)};
+  }
+`
+
+export const OnlineReportsTeaserGridFlexBlock = ({
+  flexTeasers,
+  blockStyle,
+  className
+}: BuilderTeaserGridFlexBlockProps) => {
+  const {
+    blocks: {Teaser}
+  } = useWebsiteBuilder()
+
+  const sortedTeasers = useMemo(
+    () => (flexTeasers ? fixFlexTeasers(flexTeasers) : []),
+    [flexTeasers]
+  )
+
+  return (
+    <OnlineReportsTeaserGridFlexBlockWrapper className={className}>
+      {sortedTeasers.map((teaser, index) => (
+        <Teaser key={index} {...teaser} blockStyle={blockStyle} />
+      ))}
+    </OnlineReportsTeaserGridFlexBlockWrapper>
+  )
+}
+
+export {fixFlexTeasers, isTeaserGridFlexBlock, omitEmptyFlexTeasers}


### PR DESCRIPTION
… also addresses horizontal overflow on super small devices < 300px width