### PR TITLE
fix(editor): Warning: React does not recognize the isExpanded prop on…

### DIFF
--- a/apps/editor/src/app/base.tsx
+++ b/apps/editor/src/app/base.tsx
@@ -121,7 +121,9 @@ const IconButton = styled(RIconButton)`
   }
 `;
 
-const FloatingButton = styled(RIconButton)`
+const FloatingButton = styled(RIconButton, {
+  shouldForwardProp: prop => prop !== 'isExpanded',
+})<{ isExpanded: boolean }>`
   display: block;
   padding: 6px;
   position: absolute;
@@ -168,7 +170,6 @@ export function Base({ children }: BaseProps) {
     <Wrapper>
       <Container>
         <Sidebar
-          isExpanded={isExpanded}
           collapsible
           width={isExpanded ? 260 : 56}
         >


### PR DESCRIPTION
… a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase isexpanded instead. If you accidentally passed it from a parent component, remove it from the DOM element.