### PR TITLE
fix(bajour): Make external votes work again

### DIFF
--- a/libs/ui/editor/src/lib/atoms/poll/pollExternalVotes.tsx
+++ b/libs/ui/editor/src/lib/atoms/poll/pollExternalVotes.tsx
@@ -57,22 +57,26 @@ export function ExternalVoteTable({
     if (!poll) {
       return
     }
-    const newPoll = {...poll} as FullPoll
-    const voteSource: PollExternalVoteSource | undefined = newPoll?.externalVoteSources?.find(
-      (tmpVoteSource: PollExternalVoteSource) => tmpVoteSource.source === externalVoteSource.source
-    )
-    if (!voteSource?.voteAmounts) {
-      return
-    }
-    const voteIndex = voteSource.voteAmounts?.findIndex(
-      (tmpVote: PollExternalVote) => tmpVote.answerId === answer.id
-    )
-    if (voteIndex < 0) {
-      return
-    }
-    voteSource.voteAmounts[voteIndex].amount =
-      typeof newAmount === 'string' ? parseInt(newAmount) : newAmount
-    onPollChange(newPoll)
+
+    const parsedAmount = typeof newAmount === 'string' ? parseInt(newAmount, 10) : newAmount
+
+    const updatedExternalVoteSources = (poll.externalVoteSources ?? []).map(src => {
+      if (src.source !== externalVoteSource.source) {
+        return src
+      }
+
+      return {
+        ...src,
+        voteAmounts: (src.voteAmounts ?? []).map(vote =>
+          vote.answerId === answer.id ? {...vote, amount: parsedAmount} : vote
+        )
+      }
+    })
+
+    onPollChange({
+      ...poll,
+      externalVoteSources: updatedExternalVoteSources
+    })
   }
 
   /**
@@ -177,8 +181,11 @@ export function AddSource({poll, setLoading, onPollChange}: AddSourceProps) {
     if (!source) {
       return
     }
-    const updatedPoll = {...poll}
-    updatedPoll.externalVoteSources?.push(source)
+
+    const updatedPoll: FullPoll = {
+      ...poll,
+      externalVoteSources: [...(poll.externalVoteSources ?? []), source]
+    }
     onPollChange(updatedPoll)
     setNewSource(undefined)
   }
@@ -221,7 +228,7 @@ export function DeleteModal({
 
   async function deletePoll() {
     const id = sourceToDelete?.id
-    if (!id) {
+    if (!id || !poll?.externalVoteSources) {
       return
     }
     const deletedSource = await deleteExternalVoteSource({
@@ -233,12 +240,13 @@ export function DeleteModal({
     if (!source || !poll?.externalVoteSources) {
       return
     }
-    const deleteIndex = poll.externalVoteSources.findIndex(tmpSource => tmpSource.id === source.id)
-    if (deleteIndex < 0) {
-      return
+
+    const updatedPoll: FullPoll = {
+      ...poll,
+      externalVoteSources: poll.externalVoteSources.filter(tmpSource => tmpSource.id !== source.id)
     }
-    poll.externalVoteSources?.splice(deleteIndex, 1)
-    onPollChange({...poll})
+
+    onPollChange(updatedPoll)
     closeModal()
   }
 

--- a/libs/ui/editor/src/lib/atoms/poll/pollStateIndication.tsx
+++ b/libs/ui/editor/src/lib/atoms/poll/pollStateIndication.tsx
@@ -11,7 +11,7 @@ const OpensIcon = styled(MdPlayCircleOutline)`
   color: green;
 `
 
-interface PollStateIndicationPorps {
+interface PollStateIndicationProps {
   closedAt: string | null | undefined
   opensAt: string
 }
@@ -19,7 +19,7 @@ interface PollStateIndicationPorps {
 export function PollStateIndication({
   closedAt: pollClosedAt,
   opensAt: pollOpensAt
-}: PollStateIndicationPorps) {
+}: PollStateIndicationProps) {
   const {t} = useTranslation()
   const now = new Date()
   const closedAt = pollClosedAt ? new Date(pollClosedAt) : undefined
@@ -28,7 +28,9 @@ export function PollStateIndication({
   if (closedAt && now.getTime() >= closedAt.getTime()) {
     return (
       <Whisper speaker={<Tooltip>{t('pollStateIndication.closed')}</Tooltip>}>
-        <ClosedIcon />
+        <span>
+          <ClosedIcon />
+        </span>
       </Whisper>
     )
   }
@@ -38,7 +40,9 @@ export function PollStateIndication({
   if (now.getTime() > opensAt.getTime()) {
     return (
       <Whisper speaker={<Tooltip>{t('pollStateIndication.open')}</Tooltip>}>
-        <OpensIcon />
+        <span>
+          <OpensIcon />
+        </span>
       </Whisper>
     )
   }
@@ -49,7 +53,9 @@ export function PollStateIndication({
       speaker={
         <Tooltip>{t('pollStateIndication.waiting', {date: new Date(pollOpensAt)})}</Tooltip>
       }>
-      <MdHourglassEmpty />
+      <span>
+        <MdHourglassEmpty />
+      </span>
     </Whisper>
   )
 }


### PR DESCRIPTION
Arrays returned by Apollo must not be modified. Instead, we need to create a new array.