### PR TITLE
fix(api): bounded cache in admin api

### DIFF
--- a/apps/api-example/src/nestapp/app.module.ts
+++ b/apps/api-example/src/nestapp/app.module.ts
@@ -95,6 +95,7 @@ import {UserSubscriptionModule} from '@wepublish/user-subscription/api'
           sortSchema: true,
           path: 'v1',
           cache: 'bounded',
+          persistedQueries: false,
           introspection: configFile.general.apolloIntrospection,
           playground: configFile.general.apolloPlayground,
           allowBatchedHttpRequests: true,

--- a/libs/api/src/lib/server.ts
+++ b/libs/api/src/lib/server.ts
@@ -43,7 +43,8 @@ export class WepublishServer {
           : ApolloServerPluginLandingPageDisabled()
       ],
       introspection: true,
-      context: ({req}) => contextFromRequest(req, this.opts)
+      context: ({req}) => contextFromRequest(req, this.opts),
+      cache: 'bounded'
     })
 
     if (process.env['NODE_ENV'] !== 'production') {

--- a/libs/api/src/lib/server.ts
+++ b/libs/api/src/lib/server.ts
@@ -44,7 +44,8 @@ export class WepublishServer {
       ],
       introspection: true,
       context: ({req}) => contextFromRequest(req, this.opts),
-      cache: 'bounded'
+      cache: 'bounded',
+      persistedQueries: false
     })
 
     if (process.env['NODE_ENV'] !== 'production') {


### PR DESCRIPTION
<img width="1972" height="138" alt="image" src="https://github.com/user-attachments/assets/a557569a-3a5f-4e3b-a265-c8228dfa705c" />
<img width="1264" height="162" alt="image" src="https://github.com/user-attachments/assets/13a12fbe-5e12-4aa7-9e65-d268f3a9b243" />


https://www.apollographql.com/docs/apollo-server/v3/performance/cache-backends#ensuring-a-bounded-cache
https://www.apollographql.com/docs/kotlin/advanced/persisted-queries

we don't use the persisted query feature so turned that off.