### PR TITLE
fix(bajour): Fix search slider search

### DIFF
--- a/apps/bajour/src/components/search-slider/search-slider.tsx
+++ b/apps/bajour/src/components/search-slider/search-slider.tsx
@@ -392,7 +392,7 @@ export function SearchSlider({
       async (query: string, slider: KeenSliderInstance) => {
         await fetchMore({
           variables: {
-            cursor: null,
+            cursorId: null,
             order: SortOrder.Descending,
             filter: {
               body: query,


### PR DESCRIPTION
While the article count was returned correctly from the API, the actual article list was empty. This happened because the website included the `cursorId` variable in the query to only show articles after the currently selected one. Because the currently selected article was not in the result set, no articles were returned. `cursorId` was still being included in the search query even though it was not present in the `searchArticles` function. This happens because Apollos `fetchMore` automatically merges the new variables with the original query's variables. Setting the variable explicitely to `undefined` skips it.