### PR TITLE
fix(website): mailchimp campaign sorting

### DIFF
--- a/apps/cultur/pages/index.tsx
+++ b/apps/cultur/pages/index.tsx
@@ -43,7 +43,7 @@ export const getStaticProps: GetStaticProps = async () => {
   const [mailchimpResponse] = await Promise.all([
     mailchimp.campaigns.list({
       count: 4,
-      sortField: 'send_time',
+      sortField: 'create_time',
       status: 'sent',
       sortDir: 'DESC',
       folderId: '496b1eb537',

--- a/apps/tsri/pages/index.tsx
+++ b/apps/tsri/pages/index.tsx
@@ -43,7 +43,7 @@ export const getStaticProps: GetStaticProps = async () => {
   const [mailchimpResponse] = await Promise.all([
     mailchimp.campaigns.list({
       count: 4,
-      sortField: 'send_time',
+      sortField: 'create_time',
       status: 'sent',
       sortDir: 'DESC',
       folderId: '90c02813e1',


### PR DESCRIPTION
Move from send_time to create_time due to a bug on mailchimp API
