### PR TITLE
feat(editor): regenerate GraphQL artifacts for the previously merged skipMail PR

### DIFF
--- a/apps/api-example/schema-v2.graphql
+++ b/apps/api-example/schema-v2.graphql
@@ -1634,7 +1634,15 @@ type Mutation {
   approveComment(id: String!): Comment!
 
   """Cancels a subscription."""
-  cancelSubscription(id: String!, reason: SubscriptionDeactivationReason!): PublicSubscription!
+  cancelSubscription(
+    id: String!
+    reason: SubscriptionDeactivationReason!
+
+    """
+    When true, suppress the subscription-deactivation mail. Useful for bulk migrations of already-cancelled subscriptions.
+    """
+    skipMail: Boolean
+  ): PublicSubscription!
 
   """
   This mutation allows to update the user's subscription by taking an input of type UserSubscription and throws an error if the user doesn't already have a subscription. Updating user subscriptions will set deactivation to null
@@ -1739,7 +1747,27 @@ type Mutation {
   createToken(name: String!): TokenWithSecret!
 
   """Creates a new user."""
-  createUser(active: Boolean!, address: UserAddressInput, birthday: DateTime, email: String!, emailVerifiedAt: DateTime, firstName: String, flair: String, name: String!, note: String, password: String, properties: [PropertyInput!]!, roleIDs: [String!]!, totpExempt: Boolean, userImageID: String): SensitiveDataUser!
+  createUser(
+    active: Boolean!
+    address: UserAddressInput
+    birthday: DateTime
+    email: String!
+    emailVerifiedAt: DateTime
+    firstName: String
+    flair: String
+    name: String!
+    note: String
+    password: String
+    properties: [PropertyInput!]!
+    roleIDs: [String!]!
+
+    """
+    When true, suppress the ACCOUNT_CREATION welcome email. Useful for bulk imports and scripted user creation.
+    """
+    skipMail: Boolean
+    totpExempt: Boolean
+    userImageID: String
+  ): SensitiveDataUser!
 
   "\n      Creates a new userConsent based on input.\n      Returns created userConsent.\n    "
   createUserConsent(consentId: String!, userId: String!, value: Boolean!): UserConsent!
@@ -1889,7 +1917,23 @@ type Mutation {
   importPeerArticle(articleId: String!, options: ImportArticleOptions! = {importAuthors: true, importContentImages: true, importTags: true}, peerId: String!): Article!
 
   """Imports a subscription."""
-  importSubscription(autoRenew: Boolean!, extendable: Boolean!, memberPlanID: String!, monthlyAmount: Int!, paidUntil: DateTime, paymentMethodID: String!, paymentPeriodicity: PaymentPeriodicity!, properties: [PropertyInput!]!, startsAt: DateTime!, userID: String!): PublicSubscription!
+  importSubscription(
+    autoRenew: Boolean!
+    extendable: Boolean!
+    memberPlanID: String!
+    monthlyAmount: Int!
+    paidUntil: DateTime
+    paymentMethodID: String!
+    paymentPeriodicity: PaymentPeriodicity!
+    properties: [PropertyInput!]!
+
+    """
+    When true, suppress any subscription / invoice mail dispatched as part of this import. Useful for bulk migrations.
+    """
+    skipMail: Boolean
+    startsAt: DateTime!
+    userID: String!
+  ): PublicSubscription!
 
   """Likes an article."""
   likeArticle(id: String!): Article!

--- a/libs/peering/api/src/lib/remote/graphql.ts
+++ b/libs/peering/api/src/lib/remote/graphql.ts
@@ -2074,6 +2074,7 @@ export type MutationApproveCommentArgs = {
 export type MutationCancelSubscriptionArgs = {
   id: Scalars['String'];
   reason: SubscriptionDeactivationReason;
+  skipMail?: InputMaybe<Scalars['Boolean']>;
 };
 
 
@@ -2393,6 +2394,7 @@ export type MutationCreateUserArgs = {
   password?: InputMaybe<Scalars['String']>;
   properties: Array<PropertyInput>;
   roleIDs: Array<Scalars['String']>;
+  skipMail?: InputMaybe<Scalars['Boolean']>;
   totpExempt?: InputMaybe<Scalars['Boolean']>;
   userImageID?: InputMaybe<Scalars['String']>;
 };
@@ -2665,6 +2667,7 @@ export type MutationImportSubscriptionArgs = {
   paymentMethodID: Scalars['String'];
   paymentPeriodicity: PaymentPeriodicity;
   properties: Array<PropertyInput>;
+  skipMail?: InputMaybe<Scalars['Boolean']>;
   startsAt: Scalars['DateTime'];
   userID: Scalars['String'];
 };

--- a/libs/testing/src/graphql/graphql-public.ts
+++ b/libs/testing/src/graphql/graphql-public.ts
@@ -2129,6 +2129,7 @@ export type MutationApproveCommentArgs = {
 export type MutationCancelSubscriptionArgs = {
   id: Scalars['String'];
   reason: SubscriptionDeactivationReason;
+  skipMail?: InputMaybe<Scalars['Boolean']>;
 };
 
 export type MutationCancelUserSubscriptionArgs = {
@@ -2414,6 +2415,7 @@ export type MutationCreateUserArgs = {
   password?: InputMaybe<Scalars['String']>;
   properties: Array<PropertyInput>;
   roleIDs: Array<Scalars['String']>;
+  skipMail?: InputMaybe<Scalars['Boolean']>;
   totpExempt?: InputMaybe<Scalars['Boolean']>;
   userImageID?: InputMaybe<Scalars['String']>;
 };
@@ -2639,6 +2641,7 @@ export type MutationImportSubscriptionArgs = {
   paymentMethodID: Scalars['String'];
   paymentPeriodicity: PaymentPeriodicity;
   properties: Array<PropertyInput>;
+  skipMail?: InputMaybe<Scalars['Boolean']>;
   startsAt: Scalars['DateTime'];
   userID: Scalars['String'];
 };

--- a/libs/website/api/src/lib/graphql.ts
+++ b/libs/website/api/src/lib/graphql.ts
@@ -2076,6 +2076,7 @@ export type MutationApproveCommentArgs = {
 export type MutationCancelSubscriptionArgs = {
   id: Scalars['String'];
   reason: SubscriptionDeactivationReason;
+  skipMail?: InputMaybe<Scalars['Boolean']>;
 };
 
 
@@ -2395,6 +2396,7 @@ export type MutationCreateUserArgs = {
   password?: InputMaybe<Scalars['String']>;
   properties: Array<PropertyInput>;
   roleIDs: Array<Scalars['String']>;
+  skipMail?: InputMaybe<Scalars['Boolean']>;
   totpExempt?: InputMaybe<Scalars['Boolean']>;
   userImageID?: InputMaybe<Scalars['String']>;
 };
@@ -2667,6 +2669,7 @@ export type MutationImportSubscriptionArgs = {
   paymentMethodID: Scalars['String'];
   paymentPeriodicity: PaymentPeriodicity;
   properties: Array<PropertyInput>;
+  skipMail?: InputMaybe<Scalars['Boolean']>;
   startsAt: Scalars['DateTime'];
   userID: Scalars['String'];
 };


### PR DESCRIPTION
codegen: adds what should have been comitted earlyer with https://github.com/wepublish/wepublish/pull/2675