### PR TITLE
ux(editor): while editing teasers in teaser-overview (to) keep them visually in correct position outside of to

### DIFF
--- a/libs/ui/editor/src/lib/atoms/teaserOverview/useWorkingBlocks.ts
+++ b/libs/ui/editor/src/lib/atoms/teaserOverview/useWorkingBlocks.ts
@@ -175,12 +175,10 @@ function applyWorkingToBlocks(
 ): BlockValue[] {
   let next = base;
   for (const b of working) {
-    const realTeasers = b.teasers.filter(
-      w => w.type === 'real' && w.teaser !== null
-    );
     for (let i = 0; i < b.originalCount; i++) {
       const address = b.addressTemplates[i];
-      const teaser = realTeasers[i]?.teaser ?? null;
+      const slot = b.teasers[i];
+      const teaser = slot?.type === 'real' ? slot.teaser : null;
       next = setTeaserAt(next, address, teaser);
     }
   }


### PR DESCRIPTION
* when a teaser is moved to scratch make sure in teaser components outside of teaser-overview the empty slot shows in correct position while editing