### PR TITLE
fix(website): twitter changed data format from empty array to null when empty, hide when it throws errors

### DIFF
--- a/apps/editor/src/app/locales/de.json
+++ b/apps/editor/src/app/locales/de.json
@@ -1946,6 +1946,7 @@
         "containsAnyPlaceholder": "wert1, wert2, ...",
         "mf_user.firstName": "Vorname",
         "mf_user.name": "Nachname",
+        "mf_user.id": "Benutzer-ID",
         "mf_slug:contains": "Slug enthält",
         "mf_slug:contains_any": "Slug enthält eines von",
         "mf_slug:equals": "Slug ist gleich",

--- a/apps/editor/src/app/locales/en.json
+++ b/apps/editor/src/app/locales/en.json
@@ -2009,6 +2009,7 @@
         "containsAnyPlaceholder": "value1, value2, ...",
         "mf_user.firstName": "First name",
         "mf_user.name": "Last name",
+        "mf_user.id": "User ID",
         "mf_slug:contains": "Slug contains",
         "mf_slug:contains_any": "Slug contains any of",
         "mf_slug:equals": "Slug equals",

--- a/apps/editor/src/app/locales/fr.json
+++ b/apps/editor/src/app/locales/fr.json
@@ -1831,6 +1831,7 @@
         "containsAnyPlaceholder": "valeur1, valeur2, ...",
         "mf_user.firstName": "Prénom",
         "mf_user.name": "Nom",
+        "mf_user.id": "ID utilisateur",
         "mf_slug:contains": "Slug contient",
         "mf_slug:contains_any": "Slug contient l'un de",
         "mf_slug:equals": "Slug est égal à",

--- a/apps/editor/src/app/routes/integrations/mailchimpSyncIntegrationForm.tsx
+++ b/apps/editor/src/app/routes/integrations/mailchimpSyncIntegrationForm.tsx
@@ -258,6 +258,7 @@ function InterestExpressionEditor({
 type MergeFieldType =
   | 'user.firstName'
   | 'user.name'
+  | 'user.id'
   | 'slug:contains'
   | 'slug:contains_any'
   | 'slug:equals'
@@ -270,6 +271,7 @@ type MergeFieldType =
 const MERGE_FIELD_TYPES: MergeFieldType[] = [
   'user.firstName',
   'user.name',
+  'user.id',
   'slug:contains',
   'slug:contains_any',
   'slug:equals',
@@ -286,6 +288,7 @@ function parseMergeFieldExpression(expr: string): {
 } {
   if (expr === 'user.firstName') return { type: 'user.firstName', args: [] };
   if (expr === 'user.name') return { type: 'user.name', args: [] };
+  if (expr === 'user.id') return { type: 'user.id', args: [] };
   if (expr === 'active_abo') return { type: 'active_abo', args: [] };
 
   const slugMatch = /^slug:(contains_any|contains|equals):(.*)$/.exec(expr);
@@ -318,6 +321,7 @@ function buildMergeFieldExpression(
   switch (type) {
     case 'user.firstName':
     case 'user.name':
+    case 'user.id':
     case 'active_abo':
       return type;
     case 'slug:contains':

--- a/libs/block-content/website/src/lib/twitter/twitter-tweet-block.tsx
+++ b/libs/block-content/website/src/lib/twitter/twitter-tweet-block.tsx
@@ -4,7 +4,23 @@ import {
   TwitterTweetBlock as TwitterTweetBlockType,
 } from '@wepublish/website/api';
 import { BuilderTwitterTweetBlockProps } from '@wepublish/website/builder';
+import { Component, PropsWithChildren } from 'react';
 import { Tweet } from 'react-tweet';
+
+class TweetErrorBoundary extends Component<
+  PropsWithChildren,
+  { hasError: boolean }
+> {
+  state = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  render() {
+    return this.state.hasError ? null : this.props.children;
+  }
+}
 
 export const isTwitterTweetBlock = (
   block: Pick<BlockContent, '__typename'>
@@ -26,7 +42,9 @@ export function TwitterTweetBlock({
       className={className}
       data-theme="dark"
     >
-      <Tweet id={tweetID} />
+      <TweetErrorBoundary>
+        <Tweet id={tweetID} />
+      </TweetErrorBoundary>
     </TwitterTweetBlockWrapper>
   );
 }

--- a/libs/membership/api/src/lib/mailchimp-sync/mailchimp-sync.service.ts
+++ b/libs/membership/api/src/lib/mailchimp-sync/mailchimp-sync.service.ts
@@ -771,9 +771,9 @@ export class MailchimpSyncService {
    *
    * Single expression formats:
    * - "user.firstName" / "user.name" / "user.id" - direct user field access
-   * - "slug:contains:value" - "1" if current subscription plan slug contains value, else "0"
-   * - "slug:contains_any:val1,val2" - "1" if current slug contains any of the values
-   * - "slug:equals:value" - "1" if current subscription plan slug equals value
+   * - "slug:contains:value" / "slug:contains_any:v1,v2" / "slug:equals:value"
+   *     "1" if current subscription plan slug matches, "-1" if only past
+   *     subscriptions match, "" if no matching sub ever.
    * - "active_abo" - "1" if active, "-1" if past subscriptions, "" if none
    * - "active_abo_with_payment:method_slug:days" - like active_abo but also returns "1"
    *     if last subscription has given payment method and paidUntil within N days
@@ -816,23 +816,20 @@ export class MailchimpSyncService {
       case 'slug': {
         const op = parts[1];
         const value = parts.slice(2).join(':');
-        if (op === 'contains') {
-          return data.currentSubscription?.memberPlan.slug.includes(value) ?
-              '1'
-            : '';
-        }
-        if (op === 'contains_any') {
-          const values = value.split(',');
-          return (
-              values.some(v =>
-                data.currentSubscription?.memberPlan.slug.includes(v.trim())
-              )
-            ) ?
-              '1'
-            : '';
-        }
-        if (op === 'equals') {
-          return data.currentSubscription?.memberPlan.slug === value ? '1' : '';
+
+        const matches = (slug: string | undefined): boolean => {
+          if (!slug) return false;
+          if (op === 'equals') return slug === value;
+          if (op === 'contains') return slug.includes(value);
+          if (op === 'contains_any') {
+            return value.split(',').some(v => slug.includes(v.trim()));
+          }
+          return false;
+        };
+
+        if (matches(data.currentSubscription?.memberPlan.slug)) return '1';
+        if (data.subscriptions.some(s => matches(s.memberPlan.slug))) {
+          return '-1';
         }
         return '';
       }

--- a/libs/membership/api/src/lib/mailchimp-sync/mailchimp-sync.service.ts
+++ b/libs/membership/api/src/lib/mailchimp-sync/mailchimp-sync.service.ts
@@ -237,6 +237,13 @@ export class MailchimpSyncService {
       }
     }
 
+    // Build a mapping from numeric Mailchimp keys (e.g. MMERGE6) to the
+    // configured friendly tag names (e.g. VERBILLIGTABO) so that contacts
+    // fetched from Mailchimp can be normalised before comparison.
+    const mergeFieldAliasMap = await this.buildMergeFieldAliasMap(
+      config.mailchimp_listId
+    );
+
     let mailchimpContactMap: Map<string, any>;
     if (useTargetedContactFetch) {
       const candidateEmails: string[] = [];
@@ -257,6 +264,20 @@ export class MailchimpSyncService {
       mailchimpContactMap = new Map(
         mailchimpContacts.map(m => [m.email_address?.toLowerCase(), m])
       );
+    }
+
+    // Normalise merge field keys in all fetched contacts so that numeric
+    // aliases (MMERGE6) are remapped to their friendly tag (VERBILLIGTABO)
+    // before any comparison takes place.
+    if (mergeFieldAliasMap.size > 0) {
+      for (const contact of mailchimpContactMap.values()) {
+        if (contact.merge_fields) {
+          contact.merge_fields = this.normalizeMergeFields(
+            contact.merge_fields,
+            mergeFieldAliasMap
+          );
+        }
+      }
     }
 
     let updatedCount = 0;
@@ -997,6 +1018,39 @@ export class MailchimpSyncService {
       if (!this.valuesEquivalent(existing[key], desired[key])) return false;
     }
     return true;
+  }
+
+  private async buildMergeFieldAliasMap(
+    listId: string
+  ): Promise<Map<string, string>> {
+    // Maps the Mailchimp API tag (e.g. "MMERGE6") to the field's display name
+    // (e.g. "VERBILLIGTABO") for fields where the tag is the default numeric
+    // form but the sync config uses the human-readable label instead.
+    const aliasMap = new Map<string, string>();
+    try {
+      const response = (await mailchimp.lists.getListMergeFields(listId, {
+        count: 100,
+      })) as any;
+      for (const field of response.merge_fields ?? []) {
+        if (field.tag && field.name && field.tag !== field.name) {
+          aliasMap.set(field.tag, field.name);
+        }
+      }
+    } catch {
+      // Proceed without normalisation if the API call fails
+    }
+    return aliasMap;
+  }
+
+  private normalizeMergeFields(
+    mergeFields: Record<string, any>,
+    aliasMap: Map<string, string>
+  ): Record<string, any> {
+    const normalized: Record<string, any> = {};
+    for (const [key, value] of Object.entries(mergeFields)) {
+      normalized[aliasMap.get(key) ?? key] = value;
+    }
+    return normalized;
   }
 
   private valuesEquivalent(a: any, b: any): boolean {

--- a/libs/membership/api/src/lib/mailchimp-sync/mailchimp-sync.service.ts
+++ b/libs/membership/api/src/lib/mailchimp-sync/mailchimp-sync.service.ts
@@ -763,9 +763,9 @@ export class MailchimpSyncService {
     if (expression.includes('|')) {
       for (const subExpr of expression.split('|')) {
         const result = this.evaluateSingleMergeField(subExpr.trim(), data);
-        if (result !== '' && result !== '0') return result;
+        if (result !== '') return result;
       }
-      return '0';
+      return '';
     }
 
     return this.evaluateSingleMergeField(expression, data);
@@ -791,7 +791,7 @@ export class MailchimpSyncService {
         if (op === 'contains') {
           return data.currentSubscription?.memberPlan.slug.includes(value) ?
               '1'
-            : '0';
+            : '';
         }
         if (op === 'contains_any') {
           const values = value.split(',');
@@ -801,14 +801,12 @@ export class MailchimpSyncService {
               )
             ) ?
               '1'
-            : '0';
+            : '';
         }
         if (op === 'equals') {
-          return data.currentSubscription?.memberPlan.slug === value ?
-              '1'
-            : '0';
+          return data.currentSubscription?.memberPlan.slug === value ? '1' : '';
         }
-        return '0';
+        return '';
       }
 
       case 'active_abo': {

--- a/libs/membership/api/src/lib/mailchimp-sync/mailchimp-sync.service.ts
+++ b/libs/membership/api/src/lib/mailchimp-sync/mailchimp-sync.service.ts
@@ -318,9 +318,13 @@ export class MailchimpSyncService {
         }
       }
 
-      // Default interest groups are always enabled for every contact.
-      for (const groupId of defaultInterestGroupIds) {
-        interests[groupId] = true;
+      // Default interest groups are only applied when first creating the
+      // contact. For existing contacts we preserve whatever Mailchimp has so
+      // manual unsubscribes aren't clobbered on every sync.
+      if (!existingContact) {
+        for (const groupId of defaultInterestGroupIds) {
+          interests[groupId] = true;
+        }
       }
 
       // For each mapped interest group: only flip to true when a genuinely

--- a/libs/membership/api/src/lib/mailchimp-sync/mailchimp-sync.service.ts
+++ b/libs/membership/api/src/lib/mailchimp-sync/mailchimp-sync.service.ts
@@ -237,9 +237,10 @@ export class MailchimpSyncService {
       }
     }
 
-    // Build a mapping from numeric Mailchimp keys (e.g. MMERGE6) to the
-    // configured friendly tag names (e.g. VERBILLIGTABO) so that contacts
-    // fetched from Mailchimp can be normalised before comparison.
+    // Build a mapping from merge field display names (e.g. "Vorname") to
+    // the Mailchimp tag (e.g. "MMERGE1") so that contacts fetched from
+    // Mailchimp whose merge_fields are keyed by name get normalised to the
+    // tag-keyed form expected by the sync config before comparison.
     const mergeFieldAliasMap = await this.buildMergeFieldAliasMap(
       config.mailchimp_listId
     );
@@ -266,9 +267,9 @@ export class MailchimpSyncService {
       );
     }
 
-    // Normalise merge field keys in all fetched contacts so that numeric
-    // aliases (MMERGE6) are remapped to their friendly tag (VERBILLIGTABO)
-    // before any comparison takes place.
+    // Normalise merge field keys in all fetched contacts: any key that
+    // matches a known display name is remapped to its tag so the
+    // comparison against the config's tag-keyed mergeFields works.
     if (mergeFieldAliasMap.size > 0) {
       for (const contact of mailchimpContactMap.values()) {
         if (contact.merge_fields) {
@@ -1020,9 +1021,10 @@ export class MailchimpSyncService {
   private async buildMergeFieldAliasMap(
     listId: string
   ): Promise<Map<string, string>> {
-    // Maps the Mailchimp API tag (e.g. "MMERGE6") to the field's display name
-    // (e.g. "VERBILLIGTABO") for fields where the tag is the default numeric
-    // form but the sync config uses the human-readable label instead.
+    // Maps the field's display name (e.g. "Vorname") to the Mailchimp API
+    // tag (e.g. "MMERGE1"). Used to normalise contact merge_fields whose
+    // keys arrive as names instead of tags so they line up with the
+    // tag-keyed config mappings before comparison.
     const aliasMap = new Map<string, string>();
     try {
       const response = (await mailchimp.lists.getListMergeFields(listId, {
@@ -1030,7 +1032,7 @@ export class MailchimpSyncService {
       })) as any;
       for (const field of response.merge_fields ?? []) {
         if (field.tag && field.name && field.tag !== field.name) {
-          aliasMap.set(field.tag, field.name);
+          aliasMap.set(field.name, field.tag);
         }
       }
     } catch {

--- a/libs/membership/api/src/lib/mailchimp-sync/mailchimp-sync.service.ts
+++ b/libs/membership/api/src/lib/mailchimp-sync/mailchimp-sync.service.ts
@@ -745,7 +745,7 @@ export class MailchimpSyncService {
    * E.g. "slug:contains:firmen-abo|slug:contains:gonner"
    *
    * Single expression formats:
-   * - "user.firstName" / "user.name" - direct user field access
+   * - "user.firstName" / "user.name" / "user.id" - direct user field access
    * - "slug:contains:value" - "1" if current subscription plan slug contains value, else "0"
    * - "slug:contains_any:val1,val2" - "1" if current slug contains any of the values
    * - "slug:equals:value" - "1" if current subscription plan slug equals value
@@ -784,6 +784,9 @@ export class MailchimpSyncService {
 
       case 'user.name':
         return (data.user.name || 'Unbekannt').trim();
+
+      case 'user.id':
+        return data.user.id;
 
       case 'slug': {
         const op = parts[1];

--- a/package-lock.json
+++ b/package-lock.json
@@ -130,7 +130,7 @@
         "react-router-dom": "^6.3.0",
         "react-sortable-hoc": "^1.11.0",
         "react-turnstile": "^1.1.4",
-        "react-tweet": "^3.2.1",
+        "react-tweet": "^3.3.0",
         "recharts": "^2.5.0",
         "reflect-metadata": "^0.1.13",
         "regenerator-runtime": "0.13.7",
@@ -43334,17 +43334,18 @@
       }
     },
     "node_modules/react-tweet": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/react-tweet/-/react-tweet-3.2.1.tgz",
-      "integrity": "sha512-dktP3RMuwRB4pnSDocKpSsW5Hq1IXRW6fONkHhxT5EBIXsKZzdQuI70qtub1XN2dtZdkJWWxfBm/Q+kN+vRYFA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/react-tweet/-/react-tweet-3.3.0.tgz",
+      "integrity": "sha512-gSIG2169ZK7UH6rBzuU+j1xnQbH3IlOTLEkuGrRiJJTMgETik+h+26yHyyVKrLkzwrOaYPk4K3OtEKycqKgNLw==",
+      "license": "MIT",
       "dependencies": {
         "@swc/helpers": "^0.5.3",
         "clsx": "^2.0.0",
         "swr": "^2.2.4"
       },
       "peerDependencies": {
-        "react": ">= 18.0.0",
-        "react-dom": ">= 18.0.0"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-tweet/node_modules/clsx": {

--- a/package.json
+++ b/package.json
@@ -330,7 +330,7 @@
     "react-router-dom": "^6.3.0",
     "react-sortable-hoc": "^1.11.0",
     "react-turnstile": "^1.1.4",
-    "react-tweet": "^3.2.1",
+    "react-tweet": "^3.3.0",
     "recharts": "^2.5.0",
     "reflect-metadata": "^0.1.13",
     "regenerator-runtime": "0.13.7",


### PR DESCRIPTION
- fix(mailchimp): Return empty for non-existing subscription
- Add userid
- Default only on creation
- Normalize merge field names
- Add 3 state merge field
- Turn mapping arround
- fix(website): twitter changed data format from empty array to null when empty, hide when it throws errors
