### PR TITLE
fix(hauptstadt): overlapping text during print

### DIFF
--- a/apps/hauptstadt/src/print-styles.tsx
+++ b/apps/hauptstadt/src/print-styles.tsx
@@ -3,8 +3,6 @@ import { ArticleWrapper } from '@wepublish/article/website';
 import { BannerWrapper } from '@wepublish/banner/website';
 import {
   ImageBlockCaption,
-  ImageBlockWrapper,
-  QuoteBlockWrapper,
   RichTextBlockWrapper,
   TeaserGridBlockWrapper,
 } from '@wepublish/block-content/website';
@@ -38,13 +36,6 @@ export const printStyles = (
         ${ArticleWrapper} {
           padding-left: 15%;
           padding-right: 15%;
-        }
-
-        ${ImageBlockWrapper},
-        ${QuoteBlockWrapper},
-        ul,
-        ol {
-          page-break-inside: avoid;
         }
 
         ${ImageBlockCaption} {


### PR DESCRIPTION
<img width="332" height="148" alt="image" src="https://github.com/user-attachments/assets/b697f699-f0fc-420f-b3da-204d396eb150" />
