### PR TITLE
fix(editor): external subscription counts in crowdfunding

### DIFF
--- a/apps/editor/src/app/locales/de.json
+++ b/apps/editor/src/app/locales/de.json
@@ -1693,6 +1693,7 @@
         "memberPlans": "Abo Pläne",
         "filter": "Einnahmen filtern",
         "additionalRevenue": "Externe Einnamen (z.B. via direkte Banküberweisung)",
+        "additionalSubscriptions": "Externe Abos (z.B. via direkte Banküberweisung)",
         "selectMemberPlans": "Abo Pläne wählen",
         "countSubscriptionsFrom": "Nur Abos einrechnen, die bezahlt wurden ab Datum",
         "countSubscriptionsUntil": "Nur Abos einrechnen, die bezahlt wurden bis Datum",
@@ -1708,6 +1709,7 @@
         "title": "Titel",
         "description": "Beschreibung",
         "amount": "Zielbetrag",
+        "amountSubscriptions": "Ziel Anzahl Abos",
         "remove": "Entfernen",
         "add": "Ziel hinzufügen"
       }

--- a/apps/editor/src/app/locales/en.json
+++ b/apps/editor/src/app/locales/en.json
@@ -1754,6 +1754,7 @@
         "memberPlans": "Subscription Plans",
         "filter": "Revenue Filter",
         "additionalRevenue": "External Revenues (e.g.. via direct bank transfer)",
+        "additionalSubscriptions": "External Subscriptions (e.g.. via direct bank transfer)",
         "selectMemberPlans": "Select Subscription Plans",
         "countSubscriptionsFrom": "Include only subscriptions paid from date",
         "countSubscriptionsUntil": "Include only subscriptions paid until date",
@@ -1769,6 +1770,7 @@
         "title": "Title",
         "description": "Description",
         "amount": "Target amount",
+        "amountSubscriptions": "Target subscription count",
         "remove": "Remove",
         "add": "Add Target"
       }

--- a/apps/editor/src/app/locales/fr.json
+++ b/apps/editor/src/app/locales/fr.json
@@ -1636,6 +1636,7 @@
         "memberPlans": "Plans d'abonnement",
         "filter": "Filtrer les revenus",
         "additionalRevenue": "Revenus externes (par ex. via virement bancaire direct)",
+        "additionalSubscriptions": "Abonnements externes (par ex. via virement bancaire direct)",
         "selectMemberPlans": "Choisir des plans d'abonnement",
         "countSubscriptionsFrom": "Inclure uniquement les abonnements payés à partir de la date",
         "countSubscriptionsUntil": "Inclure uniquement les abonnements payés jusqu'à la date",
@@ -1651,6 +1652,7 @@
         "title": "Titre",
         "description": "Description",
         "amount": "Montant cible",
+        "amountSubscriptions": "Nombre d'abonnements cible",
         "remove": "Supprimer",
         "add": "Ajouter un objectif"
       }

--- a/libs/crowdfunding/api/src/lib/crowdfunding.resolver.spec.ts
+++ b/libs/crowdfunding/api/src/lib/crowdfunding.resolver.spec.ts
@@ -1,0 +1,75 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Crowdfunding, CrowdfundingGoalType } from '@prisma/client';
+import { CrowdfundingResolver } from './crowdfunding.resolver';
+import { CrowdfundingService } from './crowdfunding.service';
+import { CrowdfundingDataloaderService } from './crowdfunding-dataloader.service';
+import { CrowdfundingGoalDataloader } from './crowdfunding-goal.dataloader';
+import { CrowdfundingMemberPlanDataloader } from './crowdfunding-memberplan.dataloader';
+
+const mockCrowdfunding = (
+  override: Partial<Crowdfunding> = {}
+): Crowdfunding => ({
+  id: 'cf-1',
+  createdAt: new Date('2023-01-01'),
+  modifiedAt: new Date('2023-01-01'),
+  name: 'Test',
+  countSubscriptionsFrom: null,
+  countSubscriptionsUntil: null,
+  additionalRevenue: null,
+  goalType: CrowdfundingGoalType.Subscription,
+  ...override,
+});
+
+describe('CrowdfundingResolver', () => {
+  let resolver: CrowdfundingResolver;
+  let crowdfundingService: { getSubscriptions: jest.Mock };
+  let memberPlanDataloader: { load: jest.Mock };
+
+  beforeEach(async () => {
+    crowdfundingService = { getSubscriptions: jest.fn() };
+    memberPlanDataloader = { load: jest.fn().mockResolvedValue([]) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CrowdfundingResolver,
+        { provide: CrowdfundingService, useValue: crowdfundingService },
+        {
+          provide: CrowdfundingDataloaderService,
+          useValue: { load: jest.fn() },
+        },
+        {
+          provide: CrowdfundingMemberPlanDataloader,
+          useValue: memberPlanDataloader,
+        },
+        { provide: CrowdfundingGoalDataloader, useValue: { load: jest.fn() } },
+      ],
+    }).compile();
+
+    resolver = module.get(CrowdfundingResolver);
+  });
+
+  describe('subscriptions', () => {
+    it('adds the external subscriptions as whole subscriptions', async () => {
+      crowdfundingService.getSubscriptions.mockResolvedValue([{}, {}]);
+
+      // additionalRevenue holds the manually added subscription count for
+      // Subscription goals - 1 means exactly 1 extra subscription.
+      const subscriptions = await resolver.subscriptions(
+        mockCrowdfunding({ additionalRevenue: 1 })
+      );
+
+      // 2 counted subscriptions + 1 added manually = 3
+      expect(subscriptions).toBe(3);
+    });
+
+    it('counts only real subscriptions when no external ones are set', async () => {
+      crowdfundingService.getSubscriptions.mockResolvedValue([{}, {}, {}]);
+
+      const subscriptions = await resolver.subscriptions(
+        mockCrowdfunding({ additionalRevenue: null })
+      );
+
+      expect(subscriptions).toBe(3);
+    });
+  });
+});

--- a/libs/crowdfunding/api/src/lib/crowdfunding.service.spec.ts
+++ b/libs/crowdfunding/api/src/lib/crowdfunding.service.spec.ts
@@ -1,0 +1,146 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  Crowdfunding,
+  CrowdfundingGoal,
+  CrowdfundingGoalType,
+  PaymentPeriodicity,
+  PrismaClient,
+} from '@prisma/client';
+import { CrowdfundingService } from './crowdfunding.service';
+import { CrowdfundingDataloaderService } from './crowdfunding-dataloader.service';
+
+const mockCrowdfunding = (
+  override: Partial<Crowdfunding> = {}
+): Crowdfunding => ({
+  id: 'cf-1',
+  createdAt: new Date('2023-01-01'),
+  modifiedAt: new Date('2023-01-01'),
+  name: 'Test',
+  countSubscriptionsFrom: null,
+  countSubscriptionsUntil: null,
+  additionalRevenue: null,
+  goalType: CrowdfundingGoalType.Revenue,
+  ...override,
+});
+
+const mockGoal = (override: Partial<CrowdfundingGoal> = {}): CrowdfundingGoal =>
+  ({
+    id: 'goal-1',
+    createdAt: new Date('2023-01-01'),
+    modifiedAt: new Date('2023-01-01'),
+    title: 'Goal',
+    description: null,
+    amount: 100,
+    crowdfundingId: 'cf-1',
+    ...override,
+  }) as CrowdfundingGoal;
+
+describe('CrowdfundingService', () => {
+  let service: CrowdfundingService;
+  let prismaMock: {
+    subscription: { findMany: jest.Mock };
+    crowdfunding: { [key: string]: jest.Mock };
+  };
+
+  beforeEach(async () => {
+    prismaMock = {
+      subscription: { findMany: jest.fn() },
+      crowdfunding: {
+        findMany: jest.fn(),
+        create: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CrowdfundingService,
+        { provide: PrismaClient, useValue: prismaMock },
+        {
+          provide: CrowdfundingDataloaderService,
+          useValue: { prime: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    service = module.get(CrowdfundingService);
+  });
+
+  describe('getActiveGoalWithProgress', () => {
+    it('uses the subscription count for a Subscription goal', () => {
+      const goals = [mockGoal({ id: 'a', amount: 100 })];
+
+      const activeGoal = service.getActiveGoalWithProgress({
+        goalType: CrowdfundingGoalType.Subscription,
+        goals,
+        revenue: 999999,
+        subscriptions: 50,
+      });
+
+      // progress is based on subscriptions (50/100), not revenue
+      expect(activeGoal?.progress).toBe(50);
+    });
+
+    it('uses the revenue for a Revenue goal', () => {
+      const goals = [mockGoal({ id: 'a', amount: 100 })];
+
+      const activeGoal = service.getActiveGoalWithProgress({
+        goalType: CrowdfundingGoalType.Revenue,
+        goals,
+        revenue: 25,
+        subscriptions: 999,
+      });
+
+      expect(activeGoal?.progress).toBe(25);
+    });
+
+    it('returns the first goal when no progress has been made', () => {
+      const goals = [
+        mockGoal({ id: 'b', amount: 200 }),
+        mockGoal({ id: 'a', amount: 100 }),
+      ];
+
+      const activeGoal = service.getActiveGoalWithProgress({
+        goalType: CrowdfundingGoalType.Subscription,
+        goals,
+        revenue: 0,
+        subscriptions: 0,
+      });
+
+      expect(activeGoal?.id).toBe('a');
+    });
+  });
+
+  describe('getRevenue', () => {
+    it('sums up monthly revenue and adds the external revenue', async () => {
+      prismaMock.subscription.findMany.mockResolvedValue([
+        {
+          monthlyAmount: 1000,
+          paymentPeriodicity: PaymentPeriodicity.yearly,
+        },
+      ]);
+
+      const revenue = await service.getRevenue(
+        mockCrowdfunding({ additionalRevenue: 500 }),
+        ['mp-1']
+      );
+
+      // 1000 * 12 (yearly) + 500 external = 12500
+      expect(revenue).toBe(12500);
+    });
+  });
+
+  describe('calcMonthFactor', () => {
+    it.each([
+      [PaymentPeriodicity.monthly, 1],
+      [PaymentPeriodicity.quarterly, 3],
+      [PaymentPeriodicity.biannual, 6],
+      [PaymentPeriodicity.yearly, 12],
+      [PaymentPeriodicity.biennial, 24],
+      [PaymentPeriodicity.lifetime, 1200],
+    ])('maps %s to a factor of %i', (periodicity, factor) => {
+      expect(service.calcMonthFactor(periodicity)).toBe(factor);
+    });
+  });
+});

--- a/libs/crowdfunding/editor/jest.config.ts
+++ b/libs/crowdfunding/editor/jest.config.ts
@@ -2,17 +2,11 @@
 export default {
   displayName: 'crowdfunding-editor',
   preset: '../../../jest.preset.js',
-  globals: {},
-  testEnvironment: 'node',
   transform: {
-    '^.+\\.[tj]s$': [
-      'ts-jest',
-      {
-        tsconfig: '<rootDir>/tsconfig.spec.json',
-      },
-    ],
+    '^(?!.*\\.(js|jsx|ts|tsx|css|json)$)': '@nx/react/plugins/jest',
+    '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nx/react/babel'] }],
   },
-  moduleFileExtensions: ['ts', 'js', 'html'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../../coverage/libs/crowdfunding/editor',
   maxWorkers: 1,
 };

--- a/libs/crowdfunding/editor/src/lib/crowdfunding-form.spec.tsx
+++ b/libs/crowdfunding/editor/src/lib/crowdfunding-form.spec.tsx
@@ -1,0 +1,77 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { MockedProvider } from '@apollo/client/testing';
+import { Form } from 'rsuite';
+import { CrowdfundingGoalType } from '@wepublish/editor/api';
+import { CrowdfundingForm } from './crowdfunding-form';
+
+const renderForm = (goalType: CrowdfundingGoalType) =>
+  render(
+    <MockedProvider
+      mocks={[]}
+      addTypename={false}
+    >
+      <Form>
+        <CrowdfundingForm
+          crowdfunding={{
+            name: 'Test',
+            goalType,
+            additionalRevenue: 0,
+            goals: [{ title: 'Goal', description: '', amount: 0 }],
+          }}
+          onChange={jest.fn()}
+          onAddGoal={jest.fn()}
+          onRemoveGoal={jest.fn()}
+        />
+      </Form>
+    </MockedProvider>
+  );
+
+describe('CrowdfundingForm', () => {
+  describe('Subscription goal type', () => {
+    it('labels the goal amount column as the subscription count target', () => {
+      renderForm(CrowdfundingGoalType.Subscription);
+
+      expect(
+        screen.getByText('crowdfunding.goalsForm.amountSubscriptions')
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText('crowdfunding.goalsForm.amount')
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders the external revenue field as a plain number input (no CHF)', () => {
+      const { container } = renderForm(CrowdfundingGoalType.Subscription);
+
+      expect(
+        screen.getByText('crowdfunding.form.additionalSubscriptions')
+      ).toBeInTheDocument();
+
+      const input = container.querySelector('input[name="additionalRevenue"]');
+      expect(input).toHaveAttribute('type', 'number');
+      expect(screen.queryByText('CHF')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Revenue goal type', () => {
+    it('labels the goal amount column as the target amount', () => {
+      renderForm(CrowdfundingGoalType.Revenue);
+
+      expect(
+        screen.getByText('crowdfunding.goalsForm.amount')
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText('crowdfunding.goalsForm.amountSubscriptions')
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders the external revenue field as a CHF currency input', () => {
+      renderForm(CrowdfundingGoalType.Revenue);
+
+      expect(
+        screen.getByText('crowdfunding.form.additionalRevenue')
+      ).toBeInTheDocument();
+      expect(screen.getByText('CHF')).toBeInTheDocument();
+    });
+  });
+});

--- a/libs/crowdfunding/editor/src/lib/crowdfunding-form.tsx
+++ b/libs/crowdfunding/editor/src/lib/crowdfunding-form.tsx
@@ -42,6 +42,10 @@ export const CrowdfundingForm = (props: CrowdfundingFormProps) => {
 
   const memberPlans = memberPlanData?.memberPlans?.nodes ?? [];
 
+  const goalType =
+    props.crowdfunding.goalType ?? CrowdfundingGoalType.Subscription;
+  const isSubscriptionGoal = goalType === CrowdfundingGoalType.Subscription;
+
   return (
     <CrowdfundingFormWrapper>
       <Panel
@@ -64,17 +68,32 @@ export const CrowdfundingForm = (props: CrowdfundingFormProps) => {
 
         <Form.Group controlId="additionalRevenue">
           <Form.ControlLabel>
-            {t('crowdfunding.form.additionalRevenue')}
+            {isSubscriptionGoal ?
+              t('crowdfunding.form.additionalSubscriptions')
+            : t('crowdfunding.form.additionalRevenue')}
           </Form.ControlLabel>
 
-          <CurrencyInput
-            name="additionalRevenue"
-            currency={'CHF'}
-            centAmount={props.crowdfunding.additionalRevenue || 0}
-            onChange={(additionalRevenue: number) =>
-              props.onChange({ ...props.crowdfunding, additionalRevenue })
-            }
-          />
+          {isSubscriptionGoal ?
+            <Form.Control
+              name="additionalRevenue"
+              type="number"
+              value={props.crowdfunding.additionalRevenue || 0}
+              onChange={value =>
+                props.onChange({
+                  ...props.crowdfunding,
+                  additionalRevenue: +(value || 0),
+                })
+              }
+            />
+          : <CurrencyInput
+              name="additionalRevenue"
+              currency={'CHF'}
+              centAmount={props.crowdfunding.additionalRevenue || 0}
+              onChange={(additionalRevenue: number) =>
+                props.onChange({ ...props.crowdfunding, additionalRevenue })
+              }
+            />
+          }
         </Form.Group>
       </Panel>
 
@@ -185,9 +204,7 @@ export const CrowdfundingForm = (props: CrowdfundingFormProps) => {
           </Form.Group>
 
           <CrowdfundingGoalList
-            goalType={
-              props.crowdfunding.goalType ?? CrowdfundingGoalType.Subscription
-            }
+            goalType={goalType}
             goals={props.crowdfunding.goals || []}
             onAdd={goal =>
               props.onChange({

--- a/libs/crowdfunding/editor/src/lib/crowdfunding-goal-list.tsx
+++ b/libs/crowdfunding/editor/src/lib/crowdfunding-goal-list.tsx
@@ -39,7 +39,11 @@ export const CrowdfundingGoalList = ({
         <Row>
           <Col xs={5}>{t('crowdfunding.goalsForm.title')}</Col>
           <Col xs={5}>{t('crowdfunding.goalsForm.description')}</Col>
-          <Col xs={5}>{t('crowdfunding.goalsForm.amount')}</Col>
+          <Col xs={5}>
+            {goalType === CrowdfundingGoalType.Subscription ?
+              t('crowdfunding.goalsForm.amountSubscriptions')
+            : t('crowdfunding.goalsForm.amount')}
+          </Col>
           <Col xs={4}>{t('crowdfunding.goalsForm.remove')}</Col>
         </Row>
         {goals.map((goal, index) => (

--- a/libs/ui/editor/src/lib/atoms/crowdfunding/crowdfundingProgressBar.spec.tsx
+++ b/libs/ui/editor/src/lib/atoms/crowdfunding/crowdfundingProgressBar.spec.tsx
@@ -1,0 +1,28 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import {
+  CrowdfundingGoalType,
+  FullCrowdfundingFragment,
+} from '@wepublish/editor/api';
+import { CrowdfundingProgressBar } from './crowdfundingProgressBar';
+
+describe('CrowdfundingProgressBar', () => {
+  it('rounds the progress percentage to a whole number', () => {
+    render(
+      <CrowdfundingProgressBar
+        crowdfunding={
+          {
+            goalType: CrowdfundingGoalType.Subscription,
+            subscriptions: 5,
+            activeGoal: {
+              progress: 100 / 6, // 16.6666...
+            },
+          } as Partial<FullCrowdfundingFragment>
+        }
+      />
+    );
+
+    expect(screen.getByText('17%')).toBeInTheDocument();
+    expect(screen.queryByText(/16\.6/)).not.toBeInTheDocument();
+  });
+});

--- a/libs/ui/editor/src/lib/atoms/crowdfunding/crowdfundingProgressBar.tsx
+++ b/libs/ui/editor/src/lib/atoms/crowdfunding/crowdfundingProgressBar.tsx
@@ -18,7 +18,7 @@ export function CrowdfundingProgressBar({
   crowdfunding: Partial<FullCrowdfundingFragment>;
 }) {
   const { t } = useTranslation();
-  const progress = crowdfunding.activeGoal?.progress || 0;
+  const progress = Math.round(crowdfunding.activeGoal?.progress || 0);
 
   return (
     <>


### PR DESCRIPTION
- Fix crowdfunding subscription goals & progress rounding
- Subscription goals now use count-based inputs: target field labelled "Ziel Anzahl Abos" and "Externe Einnamen" is a plain number field "Externe Abos".
- Fixed manual entry: 1 now adds 1 subscription (was 0.01).
- Rounded the editor progress bar (17% instead of 16.6666…%).
- Translations for de/en/fr; website rendering unchanged.
- Tests added for the service, resolver, form, and progress bar.

<img width="1618" height="748" alt="image" src="https://github.com/user-attachments/assets/231a1a4e-16bd-487e-b0e5-8f65f5625efd" />
