### PR TITLE
fix(editor): preview btn overlay after saving

### DIFF
--- a/apps/editor/src/app/routes/articles/articleEditor.tsx
+++ b/apps/editor/src/app/routes/articles/articleEditor.tsx
@@ -446,7 +446,7 @@ function ArticleEditor() {
           header={t('articleEditor.overview.draftSaved')}
           duration={2000}
         />,
-        { placement: 'topEnd' }
+        { placement: 'bottomEnd' }
       );
       await refetch({ id: articleID });
     } else {
@@ -461,7 +461,7 @@ function ArticleEditor() {
           header={t('articleEditor.overview.draftCreated')}
           duration={2000}
         />,
-        { placement: 'topEnd' }
+        { placement: 'bottomEnd' }
       );
     }
   }
@@ -513,7 +513,7 @@ function ArticleEditor() {
           )}
           duration={2000}
         />,
-        { placement: 'topEnd' }
+        { placement: 'bottomEnd' }
       );
     }
     await refetch({ id: articleID });

--- a/apps/editor/src/app/routes/articles/articleEditor.tsx
+++ b/apps/editor/src/app/routes/articles/articleEditor.tsx
@@ -205,7 +205,11 @@ function ArticleEditor() {
   const isNotFound = articleData && !articleData.article;
   const isDisabled =
     isLoading || isCreating || isUpdating || isPublishing || isNotFound;
-  const canPreview = Boolean(articleData?.article?.draft);
+  const canPreview = Boolean(
+    articleData?.article?.draft ||
+      articleData?.article?.published ||
+      articleData?.article?.pending
+  );
 
   const [hasChanged, setChanged] = useState(false);
 

--- a/apps/editor/src/app/routes/pages/pageEditor.tsx
+++ b/apps/editor/src/app/routes/pages/pageEditor.tsx
@@ -151,7 +151,11 @@ function PageEditor() {
   const isNotFound = pageData && !pageData.page;
   const isDisabled =
     isLoading || isCreating || isUpdating || isPublishing || isNotFound;
-  const canPreview = Boolean(pageData?.page?.draft);
+  const canPreview = Boolean(
+    pageData?.page?.draft ||
+      pageData?.page?.published ||
+      pageData?.page?.pending
+  );
 
   const [hasChanged, setChanged] = useState(false);
   const unsavedChangesDialog = useUnsavedChangesDialog(hasChanged);

--- a/apps/editor/src/app/routes/pages/pageEditor.tsx
+++ b/apps/editor/src/app/routes/pages/pageEditor.tsx
@@ -309,7 +309,7 @@ function PageEditor() {
           header={t('pageEditor.overview.pageDraftSaved')}
           duration={2000}
         />,
-        { placement: 'topEnd' }
+        { placement: 'bottomEnd' }
       );
       await refetch({ id: pageID });
     } else {
@@ -325,7 +325,7 @@ function PageEditor() {
           header={t('pageEditor.overview.pageDraftCreated')}
           duration={2000}
         />,
-        { placement: 'topEnd' }
+        { placement: 'bottomEnd' }
       );
     }
   }
@@ -367,7 +367,7 @@ function PageEditor() {
         )}
         duration={2000}
       />,
-      { placement: 'topEnd' }
+      { placement: 'bottomEnd' }
     );
   }
 


### PR DESCRIPTION
- do not overlay the preview btn after saving article or page
- enable preview btn as long as article/page is draft, pending or published (not only in draft)