### PR TITLE
feat(token): roleIDs on createToken + updateToken mutation

### DIFF
--- a/libs/peering/api/src/lib/token.model.ts
+++ b/libs/peering/api/src/lib/token.model.ts
@@ -20,6 +20,12 @@ export abstract class BaseToken {
 
   @Field()
   name!: string;
+
+  @Field(() => [String], {
+    description:
+      'Role IDs whose permissions this token carries (used for service/peer tokens).',
+  })
+  roleIDs!: string[];
 }
 
 @ObjectType({
@@ -40,7 +46,15 @@ export class CreateTokenInput extends PickType(
   TokenWithSecret,
   ['name'] as const,
   ArgsType
-) {}
+) {
+  @Field(() => [String], {
+    nullable: true,
+    defaultValue: [],
+    description:
+      'Role IDs whose permissions the token should carry. Defaults to none.',
+  })
+  roleIDs?: string[];
+}
 
 @ArgsType()
 export class UpdateTokenInput extends PartialType(CreateTokenInput, ArgsType) {

--- a/libs/peering/api/src/lib/token.resolver.ts
+++ b/libs/peering/api/src/lib/token.resolver.ts
@@ -1,5 +1,10 @@
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { CreateTokenInput, Token, TokenWithSecret } from './token.model';
+import {
+  CreateTokenInput,
+  Token,
+  TokenWithSecret,
+  UpdateTokenInput,
+} from './token.model';
 import { TokenService } from './token.service';
 import { Permissions } from '@wepublish/permissions/api';
 import {
@@ -26,6 +31,14 @@ export class TokenResolver {
   })
   async createToken(@Args() input: CreateTokenInput) {
     return this.service.createToken(input);
+  }
+
+  @Permissions(CanCreateToken)
+  @Mutation(() => Token, {
+    description: 'Updates a token (its name and/or role IDs).',
+  })
+  async updateToken(@Args() input: UpdateTokenInput) {
+    return this.service.updateToken(input);
   }
 
   @Permissions(CanDeleteToken)

--- a/libs/peering/api/src/lib/token.service.ts
+++ b/libs/peering/api/src/lib/token.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaClient } from '@prisma/client';
-import { CreateTokenInput } from './token.model';
+import { CreateTokenInput, UpdateTokenInput } from './token.model';
 import * as crypto from 'crypto';
 
 export function generateToken() {
@@ -17,7 +17,18 @@ export class TokenService {
 
   async createToken(input: CreateTokenInput) {
     return this.prisma.token.create({
-      data: { ...input, token: generateToken() },
+      data: {
+        name: input.name,
+        roleIDs: input.roleIDs ?? [],
+        token: generateToken(),
+      },
+    });
+  }
+
+  async updateToken({ id, ...data }: UpdateTokenInput) {
+    return this.prisma.token.update({
+      where: { id },
+      data,
     });
   }
 


### PR DESCRIPTION
## Problem

Tokens carry permissions through their `roleIDs` (`getPeerSession` builds the session's roles from `tokens.roleIDs`), but **the API gives no supported way to set them**:

- `CreateTokenInput = PickType(TokenWithSecret, ['name'])` — only `name`.
- `TokenService.createToken` never writes `roleIDs` → defaults to `[]`.
- No `updateToken` mutation; no editor UI.

So every token minted via the API has **zero permissions** and fails every `@Permissions`-gated query. The only way to make a token usable today is a direct DB write (`UPDATE tokens SET role_ids=…`).

> ⚠️ **Draft — for review, do not merge yet.**

## Change

- `CreateTokenInput` accepts optional **`roleIDs`** (default `[]`).
- New **`updateToken`** mutation (name and/or roleIDs), gated by `CanCreateToken`.
- Expose **`roleIDs`** on the `Token` type.

Files: `libs/peering/api/src/lib/token.{model,service,resolver}.ts`.

## Why

Lets an admin mint a **scoped read-only service token** (e.g. `CanGetPaymentMethods`, `CanGetSubscriptions`, `CanGetSettings`) through supported means instead of a DB write. Needed by the read-only CMS diagnostics MCP (wepublish/labs#43), which authenticates as a peer/service token.

## Security note

`roleIDs` can reference any role (incl. admin). Same trust level as `createToken` already requires (`CanCreateToken` is admin-level); it does not widen who can create tokens. Prefer a dedicated **read-only** role for service tokens over `admin`.

## Before merge (reviewer)

- Run `npm run generate-api` to refresh `apps/api-example/schema-v2.graphql` + typed hooks (code-first; snapshot not regenerated here).
- Run the test suite.
- **Follow-up:** editor token UI role-picker (`apps/editor/src/app/routes/tokens/tokenList.tsx`, `libs/ui/editor/src/lib/panel/tokenGeneratePanel.tsx`, `libs/editor/api/src/lib/schemas/token.graphql`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)