### PR TITLE
fix(api): remove committed dev JWT keys

### DIFF
--- a/.env
+++ b/.env
@@ -8,9 +8,11 @@ API_URL=http://localhost:4000
 #API_URL_INTERNAL=
 WEP_ONE_URL=https://one-admin.wepublish.cloud
 
-# Api (Ed25519 key pair - newlines escaped as \n)
-JWT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIJWbdZ23hpurtFiEpnulSfJ1U4TwbkiDWmbGZSDVx3nR\n-----END PRIVATE KEY-----"
-JWT_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA93mjXbSful1W9nAVHuYHdRfgKEF+pvkwm4/5P27J4RA=\n-----END PUBLIC KEY-----"
+# Api
+# Omit both JWT keys in local development to use a process-local Ed25519 pair.
+# Production must provide JWT_PRIVATE_KEY and JWT_PUBLIC_KEY via secrets.
+JWT_PRIVATE_KEY=
+JWT_PUBLIC_KEY=
 
 SEND_LOGIN_JWT_EXPIRES_MIN=10080
 RESET_PASSWORD_JWT_EXPIRES_MIN=1440

--- a/apps/api-example/prisma/seed.ts
+++ b/apps/api-example/prisma/seed.ts
@@ -36,6 +36,7 @@ import {
 } from '@wepublish/block-content/api';
 import { TrackingPixel } from '@wepublish/tracking-pixel/api';
 import { hash as argon2Hash } from '@node-rs/argon2';
+import { resolveJwtKeyPair } from '../src/nestapp/dev-jwt-keypair';
 
 async function hashPassword(password: string) {
   return await argon2Hash(password);
@@ -82,10 +83,9 @@ function getText(min = 1, max = 10) {
 async function seedImages(prisma: PrismaClient) {
   const internalUrl = process.env.MEDIA_SERVER_INTERNAL_URL;
 
-  const jwtPrivateKey = (process.env.JWT_PRIVATE_KEY ?? '').replace(
-    /\\n/g,
-    '\n'
-  );
+  const { privateKey: jwtPrivateKey } = resolveJwtKeyPair({
+    get: key => process.env[key],
+  });
 
   const mediaAdapter = new NovaMediaAdapter(
     new URL(process.env.MEDIA_SERVER_URL),

--- a/apps/api-example/src/nestapp/app.module.ts
+++ b/apps/api-example/src/nestapp/app.module.ts
@@ -108,6 +108,7 @@ import {
   KvTtlCacheModule,
   KvTtlCacheService,
 } from '@wepublish/kv-ttl-cache/api';
+import { resolveJwtKeyPair } from './dev-jwt-keypair';
 
 @Global()
 @Module({
@@ -201,10 +202,7 @@ import {
           throw new Error('A MailProvider must be configured.');
         }
 
-        const jwtPrivateKey = (config.get('JWT_PRIVATE_KEY') || '').replace(
-          /\\n/g,
-          '\n'
-        );
+        const { privateKey: jwtPrivateKey } = resolveJwtKeyPair(config);
         const hostURL = config.get('HOST_URL') || 'http://localhost:4000';
         const websiteURL = config.get('WEBSITE_URL') || 'http://localhost:3000';
 
@@ -420,25 +418,10 @@ import {
             configFile.general.sessionTTLDays
           : 7;
         const sessionTTL = MS_PER_DAY * sessionTTLDays;
-        const jwtPrivateKey = (config.get('JWT_PRIVATE_KEY') || '').replace(
-          /\\n/g,
-          '\n'
-        );
-        const jwtPublicKey = (config.get('JWT_PUBLIC_KEY') || '').replace(
-          /\\n/g,
-          '\n'
-        );
+        const { privateKey: jwtPrivateKey, publicKey: jwtPublicKey } =
+          resolveJwtKeyPair(config);
         const hostURL = config.getOrThrow('HOST_URL');
         const websiteURL = config.getOrThrow('WEBSITE_URL');
-
-        if (
-          process.env.NODE_ENV === 'production' &&
-          (!jwtPrivateKey || !jwtPublicKey)
-        ) {
-          console.error(
-            'WARNING: JWT_PRIVATE_KEY or JWT_PUBLIC_KEY not set in production environment!'
-          );
-        }
 
         return {
           sessionTTL,
@@ -558,9 +541,7 @@ import {
           config.getOrThrow('CONFIG_FILE_PATH')
         );
         const internalUrl = config.get('MEDIA_SERVER_INTERNAL_URL');
-        const jwtPrivateKey = config
-          .getOrThrow<string>('JWT_PRIVATE_KEY')
-          .replace(/\\n/g, '\n');
+        const { privateKey: jwtPrivateKey } = resolveJwtKeyPair(config);
 
         return new NovaMediaAdapter(
           config.getOrThrow('MEDIA_SERVER_URL'),

--- a/apps/api-example/src/nestapp/dev-jwt-keypair.spec.ts
+++ b/apps/api-example/src/nestapp/dev-jwt-keypair.spec.ts
@@ -1,0 +1,67 @@
+import { generateKeyPairSync } from 'crypto';
+import { importPKCS8, importSPKI } from 'jose';
+import { resolveJwtKeyPair } from './dev-jwt-keypair';
+
+const createPemPair = () => {
+  const { privateKey, publicKey } = generateKeyPairSync('ed25519');
+
+  return {
+    privateKey: privateKey.export({ format: 'pem', type: 'pkcs8' }).toString(),
+    publicKey: publicKey.export({ format: 'pem', type: 'spki' }).toString(),
+  };
+};
+
+const configFrom = (values: Record<string, string | undefined>) => ({
+  get: (key: string) => values[key],
+});
+
+describe('resolveJwtKeyPair', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it('returns configured keys with escaped newlines restored', async () => {
+    const pair = createPemPair();
+    const resolved = resolveJwtKeyPair(
+      configFrom({
+        JWT_PRIVATE_KEY: pair.privateKey.replace(/\n/g, '\\n'),
+        JWT_PUBLIC_KEY: pair.publicKey.replace(/\n/g, '\\n'),
+      })
+    );
+
+    expect(resolved).toEqual(pair);
+    await expect(
+      importPKCS8(resolved.privateKey, 'EdDSA')
+    ).resolves.toBeTruthy();
+    await expect(importSPKI(resolved.publicKey, 'EdDSA')).resolves.toBeTruthy();
+  });
+
+  it('generates an importable development key pair when both keys are omitted', async () => {
+    process.env.NODE_ENV = 'development';
+
+    const first = resolveJwtKeyPair(configFrom({}));
+    const second = resolveJwtKeyPair(configFrom({}));
+
+    expect(second).toEqual(first);
+    await expect(importPKCS8(first.privateKey, 'EdDSA')).resolves.toBeTruthy();
+    await expect(importSPKI(first.publicKey, 'EdDSA')).resolves.toBeTruthy();
+  });
+
+  it('rejects partial JWT key configuration', () => {
+    const pair = createPemPair();
+
+    expect(() =>
+      resolveJwtKeyPair(configFrom({ JWT_PRIVATE_KEY: pair.privateKey }))
+    ).toThrow('JWT_PRIVATE_KEY and JWT_PUBLIC_KEY must be configured together');
+  });
+
+  it('requires explicit JWT keys in production', () => {
+    process.env.NODE_ENV = 'production';
+
+    expect(() => resolveJwtKeyPair(configFrom({}))).toThrow(
+      'JWT_PRIVATE_KEY and JWT_PUBLIC_KEY must be configured in production'
+    );
+  });
+});

--- a/apps/api-example/src/nestapp/dev-jwt-keypair.ts
+++ b/apps/api-example/src/nestapp/dev-jwt-keypair.ts
@@ -1,0 +1,56 @@
+import { generateKeyPairSync } from 'crypto';
+
+export interface JwtKeyPairConfig {
+  get(key: string): string | undefined;
+}
+
+export interface JwtKeyPair {
+  privateKey: string;
+  publicKey: string;
+}
+
+let developmentJwtKeyPair: JwtKeyPair | undefined;
+
+const readPem = (value: string | undefined): string =>
+  (value ?? '').replace(/\\n/g, '\n');
+
+const createDevelopmentJwtKeyPair = (): JwtKeyPair => {
+  const { privateKey, publicKey } = generateKeyPairSync('ed25519');
+
+  return {
+    privateKey: privateKey.export({ format: 'pem', type: 'pkcs8' }).toString(),
+    publicKey: publicKey.export({ format: 'pem', type: 'spki' }).toString(),
+  };
+};
+
+/**
+ * Resolves the Ed25519 JWT key pair used by the API and media service.
+ *
+ * Production requires explicit keys from secret-managed environment variables.
+ * Development may omit both keys; in that case a process-local key pair is
+ * generated so local Docker and test runs do not require committed PEM files.
+ */
+export const resolveJwtKeyPair = (config: JwtKeyPairConfig): JwtKeyPair => {
+  const privateKey = readPem(config.get('JWT_PRIVATE_KEY'));
+  const publicKey = readPem(config.get('JWT_PUBLIC_KEY'));
+
+  if (privateKey && publicKey) {
+    return { privateKey, publicKey };
+  }
+
+  if (privateKey || publicKey) {
+    throw new Error(
+      'JWT_PRIVATE_KEY and JWT_PUBLIC_KEY must be configured together'
+    );
+  }
+
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error(
+      'JWT_PRIVATE_KEY and JWT_PUBLIC_KEY must be configured in production'
+    );
+  }
+
+  developmentJwtKeyPair ??= createDevelopmentJwtKeyPair();
+
+  return developmentJwtKeyPair;
+};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,8 +28,6 @@ services:
       MEDIA_SERVER_URL: http://localhost:4100
       MEDIA_SERVER_INTERNAL_URL: http://media:4100
       WEBSITE_URL: http://localhost:4200
-      JWT_PRIVATE_KEY: "-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIJWbdZ23hpurtFiEpnulSfJ1U4TwbkiDWmbGZSDVx3nR\n-----END PRIVATE KEY-----"
-      JWT_PUBLIC_KEY: "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA93mjXbSful1W9nAVHuYHdRfgKEF+pvkwm4/5P27J4RA=\n-----END PUBLIC KEY-----"
     env_file: .env
     volumes:
       - ./apps/api-example/src/default.yaml:/config.yaml


### PR DESCRIPTION
## Summary
- remove the tracked local Ed25519 JWT private/public key pair from `.env` and `docker-compose.yml`
- add a shared JWT key resolver for the API example that keeps production strict while generating a process-local Ed25519 pair for local development/test when both env vars are omitted
- use the resolver in mail login JWTs, sessions, media adapter wiring, and API example seeding

## Validation
- `npm ci`
- `git diff --check`
- `npx nx run api-example:test --runInBand --skip-nx-cache`
- `npx nx run api-example:lint --skip-nx-cache` (passes with existing warnings)
- `npx nx run api-example:build --skip-nx-cache`
- `trufflehog git file:///home/void/ExternalRepos/wepublish --since-commit 8be726e397876aa158002bcad559fbe60919876c --branch pr/dev-jwt-key-fallback --results verified --fail --fail-on-scan-errors --no-update --concurrency=2 --json` (0 verified, 0 unverified)
- `trivy fs --scanners secret --skip-dirs node_modules --skip-dirs dist --skip-dirs .git --skip-dirs .nx --severity HIGH,CRITICAL --exit-code 1 .`

## Notes
This is intentionally narrow: it only removes committed development JWT key material and preserves local developer ergonomics without relaxing production requirements.