### PR TITLE
fix(media): harden remote URL checks

### DIFF
--- a/apps/media/src/app/assertRemoteFileIsAccessible.spec.ts
+++ b/apps/media/src/app/assertRemoteFileIsAccessible.spec.ts
@@ -1,0 +1,103 @@
+import { promises as dns } from 'dns';
+import { assertRemoteFileIsAccessible } from './assertRemoteFileIsAccessible';
+
+describe('assertRemoteFileIsAccessible', () => {
+  const originalFetch = global.fetch;
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    process.env.NODE_ENV = originalNodeEnv;
+    jest.restoreAllMocks();
+  });
+
+  it('checks reachable HTTP(S) URLs without following redirects', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+    });
+    global.fetch = fetchMock;
+
+    await expect(
+      assertRemoteFileIsAccessible('https://media.example.com/image.jpg')
+    ).resolves.toBe(true);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://media.example.com/image.jpg',
+      {
+        method: 'HEAD',
+        redirect: 'manual',
+        signal: expect.any(AbortSignal),
+      }
+    );
+  });
+
+  it('rejects non-HTTP protocols before fetching', async () => {
+    const fetchMock = jest.fn();
+    global.fetch = fetchMock;
+
+    await expect(
+      assertRemoteFileIsAccessible('file:///etc/passwd')
+    ).rejects.toThrow('Remote object URL must use HTTP or HTTPS');
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects private network hosts in production before fetching', async () => {
+    process.env.NODE_ENV = 'production';
+    const fetchMock = jest.fn();
+    global.fetch = fetchMock;
+
+    await expect(
+      assertRemoteFileIsAccessible('http://127.0.0.1:9000/private.jpg')
+    ).rejects.toThrow('Remote object URL host is not allowed');
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects hosts that resolve to private network addresses in production before fetching', async () => {
+    process.env.NODE_ENV = 'production';
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+    });
+    global.fetch = fetchMock;
+    jest.spyOn(dns, 'lookup').mockResolvedValue([
+      {
+        address: '10.0.0.10',
+        family: 4,
+      },
+    ] as unknown as Awaited<ReturnType<typeof dns.lookup>>);
+
+    await expect(
+      assertRemoteFileIsAccessible('https://media.example.com/image.jpg')
+    ).rejects.toThrow('Remote object URL host is not allowed');
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('does not expose the full remote object URL in fetch errors', async () => {
+    const fetchMock = jest.fn().mockRejectedValue(new Error('network down'));
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+    global.fetch = fetchMock;
+
+    await expect(
+      assertRemoteFileIsAccessible(
+        'https://media.example.com/private/customer-file.jpg?token=secret'
+      )
+    ).rejects.toThrow('Failed to reach remote object');
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Fetch error while checking remote object',
+      expect.objectContaining({
+        origin: 'https://media.example.com',
+        message: 'network down',
+      })
+    );
+    expect(JSON.stringify(errorSpy.mock.calls)).not.toContain(
+      'customer-file.jpg'
+    );
+  });
+});

--- a/apps/media/src/app/assertRemoteFileIsAccessible.ts
+++ b/apps/media/src/app/assertRemoteFileIsAccessible.ts
@@ -1,21 +1,127 @@
+import { promises as dns } from 'dns';
+import { isIP } from 'net';
+
+const REMOTE_FILE_TIMEOUT_MS = 10_000;
+
+const isPrivateIPv4 = (hostname: string): boolean => {
+  const [first = '', second = ''] = hostname.split('.');
+  const firstOctet = Number(first);
+  const secondOctet = Number(second);
+
+  return (
+    firstOctet === 0 ||
+    firstOctet === 10 ||
+    (firstOctet === 100 && secondOctet >= 64 && secondOctet <= 127) ||
+    firstOctet === 127 ||
+    (firstOctet === 169 && secondOctet === 254) ||
+    (firstOctet === 172 && secondOctet >= 16 && secondOctet <= 31) ||
+    (firstOctet === 192 && (secondOctet === 0 || secondOctet === 168)) ||
+    (firstOctet === 198 && (secondOctet === 18 || secondOctet === 19)) ||
+    firstOctet >= 224
+  );
+};
+
+const stripIPv6Brackets = (hostname: string) =>
+  hostname.startsWith('[') && hostname.endsWith(']') ?
+    hostname.slice(1, -1)
+  : hostname;
+
+const isPrivateHost = (hostname: string): boolean => {
+  const normalized = stripIPv6Brackets(hostname.toLowerCase());
+
+  if (normalized === 'localhost') {
+    return true;
+  }
+
+  if (normalized.startsWith('::ffff:')) {
+    const mappedIPv4 = normalized.slice('::ffff:'.length);
+    return isIP(mappedIPv4) === 4 && isPrivateIPv4(mappedIPv4);
+  }
+
+  const ipVersion = isIP(normalized);
+
+  if (ipVersion === 4) {
+    return isPrivateIPv4(normalized);
+  }
+
+  if (ipVersion === 6) {
+    return (
+      normalized === '::' ||
+      normalized === '::1' ||
+      normalized.startsWith('fc') ||
+      normalized.startsWith('fd') ||
+      normalized.startsWith('fe80:')
+    );
+  }
+
+  return false;
+};
+
+const parseRemoteObjectUrl = (rawUrl: string): URL => {
+  const url = new URL(rawUrl);
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error('Remote object URL must use HTTP or HTTPS');
+  }
+
+  if (process.env.NODE_ENV === 'production' && isPrivateHost(url.hostname)) {
+    throw new Error('Remote object URL host is not allowed');
+  }
+
+  return url;
+};
+
+const assertRemoteObjectHostAllowed = async (url: URL): Promise<void> => {
+  if (
+    process.env.NODE_ENV !== 'production' ||
+    isIP(stripIPv6Brackets(url.hostname))
+  ) {
+    return;
+  }
+
+  const resolvedAddresses = await dns.lookup(url.hostname, {
+    all: true,
+    verbatim: true,
+  });
+
+  if (resolvedAddresses.some(({ address }) => isPrivateHost(address))) {
+    throw new Error('Remote object URL host is not allowed');
+  }
+};
+
 export async function assertRemoteFileIsAccessible(
   url: string
 ): Promise<boolean> {
+  const remoteUrl = parseRemoteObjectUrl(url);
+  await assertRemoteObjectHostAllowed(remoteUrl);
+
   try {
-    const res = await fetch(url, {
+    // codeql[js/request-forgery] remoteUrl is protocol-validated and production checks reject private literal and resolved hosts before fetching.
+    const res = await fetch(remoteUrl.toString(), {
       method: 'HEAD',
-      signal: AbortSignal.timeout(10_000),
+      redirect: 'manual',
+      signal: AbortSignal.timeout(REMOTE_FILE_TIMEOUT_MS),
     });
+
     if (!res.ok) {
-      console.error(
-        `HTTP error: ${res.status} ${res.statusText} for URL: ${url}`
-      );
-      throw new Error(`Remote image is unreachable: ${url}`);
+      console.error('HTTP error while checking remote object', {
+        status: res.status,
+        statusText: res.statusText,
+        origin: remoteUrl.origin,
+      });
+      throw new Error('Remote image is unreachable');
     }
   } catch (err) {
-    console.error('Fetch error while checking object:', err);
-    throw new Error(`Failed to reach remote object: ${url}`);
+    console.error('Fetch error while checking remote object', {
+      origin: remoteUrl.origin,
+      message: err instanceof Error ? err.message : 'Unknown fetch error',
+    });
+    throw new Error('Failed to reach remote object');
   }
-  console.info(`Initial check for valid image url successful: ${url}`);
+
+  console.info('Initial check for remote object URL succeeded', {
+    origin: remoteUrl.origin,
+  });
+
   return true;
 }

--- a/apps/media/src/bootstrap.spec.ts
+++ b/apps/media/src/bootstrap.spec.ts
@@ -1,0 +1,19 @@
+import { getMediaHelmetOptions } from './bootstrap';
+
+describe('getMediaHelmetOptions', () => {
+  it('enables a restrictive CSP while allowing media responses to be embedded cross-origin', () => {
+    expect(getMediaHelmetOptions()).toEqual(
+      expect.objectContaining({
+        contentSecurityPolicy: expect.objectContaining({
+          directives: expect.objectContaining({
+            defaultSrc: ["'none'"],
+            frameAncestors: ["'none'"],
+            objectSrc: ["'none'"],
+            scriptSrc: ["'none'"],
+          }),
+        }),
+        crossOriginResourcePolicy: false,
+      })
+    );
+  });
+});

--- a/apps/media/src/bootstrap.ts
+++ b/apps/media/src/bootstrap.ts
@@ -9,6 +9,22 @@ import { Logger, NestApplicationOptions } from '@nestjs/common';
 sharp.cache({ memory: 50, items: 20 });
 sharp.concurrency(2);
 
+export function getMediaHelmetOptions() {
+  return {
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'none'"],
+        baseUri: ["'none'"],
+        formAction: ["'none'"],
+        frameAncestors: ["'none'"],
+        objectSrc: ["'none'"],
+        scriptSrc: ["'none'"],
+      },
+    },
+    crossOriginResourcePolicy: false,
+  };
+}
+
 export async function bootstrap(logger?: NestApplicationOptions['logger']) {
   const app = await NestFactory.create(AppModule, {
     logger,
@@ -18,12 +34,7 @@ export async function bootstrap(logger?: NestApplicationOptions['logger']) {
     origin: true,
     credentials: true,
   });
-  app.use(
-    helmet({
-      contentSecurityPolicy: false,
-      crossOriginResourcePolicy: false,
-    })
-  );
+  app.use(helmet(getMediaHelmetOptions()));
 
   const port = process.env.PORT || 4100;
   await app.listen(port);


### PR DESCRIPTION
## Summary
- validate media remote-object checks before `fetch`: HTTP(S) only, production private literal hosts blocked, production DNS resolutions to private ranges blocked
- disable automatic redirect following for the HEAD reachability check
- stop logging full object URLs, keeping only origin plus status/error context
- replace disabled media CSP with a restrictive media-safe Helmet policy while preserving cross-origin embedding of media responses

## Validation
- `git diff --check`
- `npx nx run media:test --runInBand --skip-nx-cache`
- `npx nx run media:lint --skip-nx-cache` (passes with existing controller warnings only)
- `npx nx run media:build --skip-nx-cache`
- `trufflehog git file:///home/void/ExternalRepos/wepublish --since-commit 8be726e397876aa158002bcad559fbe60919876c --branch pr/media-remote-url-hardening --results verified --fail --fail-on-scan-errors --no-update --concurrency=2 --json` (0 verified, 0 unverified)

## Notes
This is intentionally limited to the media service security hardening. It does not include dependency bumps or broader package-lock changes from the previous broad branch.