### PR TITLE
fix(deployment): harden production deploy script

### DIFF
--- a/deployment/deploy_production.js
+++ b/deployment/deploy_production.js
@@ -1,80 +1,52 @@
-const {exec} = require('child_process');
+const { execFile } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const readline = require('readline');
-const chalk = require("chalk");
+const chalk = require('chalk');
 
-if (!process.argv[2]) {
-  console.error('Error: Project name is required.');
-  process.exit(1);
+const repositoryRoot = path.resolve(__dirname, '..');
+
+function validateProjectName(projectName) {
+  if (
+    typeof projectName !== 'string' ||
+    !/^[a-zA-Z0-9][a-zA-Z0-9_-]*$/.test(projectName)
+  ) {
+    throw new Error('Invalid project name.');
+  }
+
+  return projectName;
 }
 
-const projectName = process.argv[2];
-
-const rootPath = path.dirname(require.main.filename);
-const configPath = path.resolve(rootPath, '../apps', projectName, 'deployment.config.json');
-
-if (!fs.existsSync(configPath)) {
-  console.error(`Error: Given project < ${projectName} > does not exist or does not have a config <deployment.config.json>!`);
-  process.exit(1);
+function getDeploymentConfigPath(projectName) {
+  return path.resolve(
+    repositoryRoot,
+    'apps',
+    projectName,
+    'deployment.config.json'
+  );
 }
 
-const rl = readline.createInterface({
-  input: process.stdin,
-  output: process.stdout
-});
+function formatDeployTag(projectName, date = new Date()) {
+  const timestamp =
+    date.getFullYear().toString() +
+    (date.getMonth() + 1).toString().padStart(2, '0') +
+    date.getDate().toString().padStart(2, '0') +
+    date.getHours().toString().padStart(2, '0') +
+    date.getMinutes().toString().padStart(2, '0');
 
-function askConfirmation() {
-  return new Promise(async (resolve) => {
-    await execCommand(`git fetch --tags; true`,true)
-    const changelogCommand = `git log --color=always --graph --decorate --pretty=format:'%C(yellow)%h%C(reset) %s %C(cyan)%an%C(reset)' --abbrev-commit $(git tag -l 'deploy_${projectName}_*' --sort=version:refname | tail -n1 )..HEAD`
-    let changelog = await execCommand(changelogCommand)
-    changelog = changelog.replace(/#([0-9]+)/g, (text, number) => `\x1b]8;;https://github.com/wepublish/wepublish/pull/${number}\x1b\\${text}\x1b]8;;\x1b\\`)
-    const filterCommand = `echo "${changelog}" |egrep -i "core|website|editor|api|${projectName}"`
-    const changelogFiltered = await execCommand(filterCommand,false)
-    rl.write(`${chalk.underline("All changes you are about to deploy")}:\n\n${changelog}\n\n`)
-    rl.write(`${chalk.underline("Changes impacting customer you are about to deploy")}:\n\n${changelogFiltered}\n\n`)
-    rl.question(`Are you sure you want to deploy this commit to ${chalk.bold(projectName)} production? To confirm, write the project name: `, (answer) => {
-      rl.close();
-      resolve(answer);
-    });
-  });
+  return `deploy_${projectName}_${timestamp}`;
 }
 
-const date = new Date();
-const timestamp = date.getFullYear().toString() +
-  (date.getMonth() + 1).toString().padStart(2, '0') +
-  date.getDate().toString().padStart(2, '0') +
-  date.getHours().toString().padStart(2, '0') +
-  date.getMinutes().toString().padStart(2, '0');
-
-const tagName = `deploy_${projectName}_${timestamp}`;
-
-const commands = [
-  `git tag ${tagName}`,
-  `git push origin ${tagName}`
-];
-
-async function checkUncommittedChanges() {
+function execGit(args, rejectRCNonZero = true) {
   return new Promise((resolve, reject) => {
-    exec('git status --porcelain', (error, stdout, stderr) => {
+    execFile('git', args, { cwd: repositoryRoot }, (error, stdout, stderr) => {
       if (error) {
-        reject(`Error checking Git status: ${stderr}`);
-      } else {
-        resolve(stdout);
-      }
-    });
-  });
-}
-
-function execCommand(command, rejectRCNonZero=true) {
-  return new Promise((resolve, reject) => {
-    exec(command, (error, stdout, stderr) => {
-      if (error) {
-        if(rejectRCNonZero) {
-          reject(`Error executing command: ${command}\n${stderr}`);
+        if (rejectRCNonZero) {
+          reject(
+            `Error executing git ${args.join(' ')}\n${stderr || error.message}`
+          );
         } else {
-          resolve(stdout)
+          resolve(stdout);
         }
       } else {
         resolve(stdout);
@@ -83,26 +55,155 @@ function execCommand(command, rejectRCNonZero=true) {
   });
 }
 
-async function deploy() {
+async function checkUncommittedChanges() {
+  return execGit(['status', '--porcelain']);
+}
+
+async function getLastDeployTag(projectName) {
+  const tags = await execGit([
+    'tag',
+    '-l',
+    `deploy_${projectName}_*`,
+    '--sort=version:refname',
+  ]);
+
+  return tags.trim().split('\n').filter(Boolean).pop();
+}
+
+function filterCustomerChangelog(changelog, projectName) {
+  const keywords = [
+    'core',
+    'website',
+    'editor',
+    'api',
+    projectName.toLowerCase(),
+  ];
+
+  return changelog
+    .split(/\r?\n/)
+    .filter(line => {
+      const normalizedLine = line.toLowerCase();
+      return keywords.some(keyword => normalizedLine.includes(keyword));
+    })
+    .join('\n');
+}
+
+function linkPullRequests(changelog) {
+  return changelog.replace(
+    /#([0-9]+)/g,
+    (text, number) =>
+      `\x1b]8;;https://github.com/wepublish/wepublish/pull/${number}\x1b\\${text}\x1b]8;;\x1b\\`
+  );
+}
+
+async function askConfirmation(projectName) {
+  await execGit(['fetch', '--tags'], false);
+
+  const lastDeployTag = await getLastDeployTag(projectName);
+  const changelogArgs = [
+    'log',
+    '--color=always',
+    '--graph',
+    '--decorate',
+    '--pretty=format:%C(yellow)%h%C(reset) %s %C(cyan)%an%C(reset)',
+    '--abbrev-commit',
+    lastDeployTag ? `${lastDeployTag}..HEAD` : 'HEAD',
+  ];
+  const changelog = linkPullRequests(await execGit(changelogArgs));
+  const changelogFiltered = filterCustomerChangelog(changelog, projectName);
+
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  return new Promise(resolve => {
+    rl.write(
+      `${chalk.underline('All changes you are about to deploy')}:\n\n${changelog}\n\n`
+    );
+    rl.write(
+      `${chalk.underline(
+        'Changes impacting customer you are about to deploy'
+      )}:\n\n${changelogFiltered}\n\n`
+    );
+    rl.question(
+      `Are you sure you want to deploy this commit to ${chalk.bold(
+        projectName
+      )} production? To confirm, write the project name: `,
+      answer => {
+        rl.close();
+        resolve(answer);
+      }
+    );
+  });
+}
+
+async function deploy(projectName) {
+  const status = await checkUncommittedChanges();
+  if (status.trim() !== '') {
+    throw new Error(
+      'There are uncommitted changes in the repository. Please commit your changes before deploying.'
+    );
+  }
+
+  const confirmation = await askConfirmation(projectName);
+  if (confirmation !== projectName) {
+    throw new Error('Project name does not match. Deployment aborted.');
+  }
+
+  const tagName = formatDeployTag(projectName);
+  for (const args of [
+    ['tag', tagName],
+    ['push', 'origin', tagName],
+  ]) {
+    const result = await execGit(args);
+    console.log(result);
+  }
+
+  console.log(`Successfully deployed with tag: ${tagName}`);
+}
+
+async function main(argv = process.argv) {
+  const requestedProjectName = argv[2];
+
+  if (!requestedProjectName) {
+    console.error('Error: Project name is required.');
+    return 1;
+  }
+
+  let projectName;
   try {
-    const status = await checkUncommittedChanges();
-    if (status.trim() !== '') {
-      console.error('Error: There are uncommitted changes in the repository. Please commit your changes before deploying.');
-      process.exit(1);
-    }
-    const confirmation = await askConfirmation();
-    if (confirmation !== projectName) {
-      console.error('Error: Project name does not match. Deployment aborted.');
-      process.exit(1);
-    }
-    for (const command of commands) {
-      const result = await execCommand(command);
-      console.log(result);
-    }
-    console.log(`Successfully deployed with tag: ${tagName}`);
-  } catch (err) {
-    console.error('Error during deployment:', err);
+    projectName = validateProjectName(requestedProjectName);
+  } catch (error) {
+    console.error(`Error: ${error.message}`);
+    return 1;
+  }
+
+  const configPath = getDeploymentConfigPath(projectName);
+  if (!fs.existsSync(configPath)) {
+    console.error(
+      `Error: Given project < ${projectName} > does not exist or does not have a config <deployment.config.json>!`
+    );
+    return 1;
+  }
+
+  try {
+    await deploy(projectName);
+    return 0;
+  } catch (error) {
+    console.error('Error during deployment:', error);
+    return 1;
   }
 }
 
-deploy();
+if (require.main === module) {
+  main().then(exitCode => {
+    process.exit(exitCode);
+  });
+}
+
+module.exports = {
+  filterCustomerChangelog,
+  formatDeployTag,
+  validateProjectName,
+};

--- a/deployment/deploy_production.test.js
+++ b/deployment/deploy_production.test.js
@@ -1,0 +1,72 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+function loadDeployScript() {
+  const scriptPath = require.resolve('./deploy_production');
+  const originalArgv = process.argv;
+  const originalExit = process.exit;
+
+  delete require.cache[scriptPath];
+  process.argv = ['node', scriptPath];
+  process.exit = code => {
+    throw new Error(`unexpected process.exit(${code})`);
+  };
+
+  try {
+    return require('./deploy_production');
+  } finally {
+    process.argv = originalArgv;
+    process.exit = originalExit;
+    delete require.cache[scriptPath];
+  }
+}
+
+test('exports pure helpers without starting a deployment at import time', () => {
+  const deployScript = loadDeployScript();
+
+  assert.equal(typeof deployScript.validateProjectName, 'function');
+  assert.equal(typeof deployScript.filterCustomerChangelog, 'function');
+});
+
+test('validates project names before using them in git commands', () => {
+  const { validateProjectName } = loadDeployScript();
+
+  assert.equal(validateProjectName('bajour'), 'bajour');
+  assert.equal(
+    validateProjectName('winti_fluesterer-2026'),
+    'winti_fluesterer-2026'
+  );
+  assert.throws(() => validateProjectName('../bajour'), /Invalid project name/);
+  assert.throws(
+    () => validateProjectName('bajour;git push'),
+    /Invalid project name/
+  );
+});
+
+test('formats deploy tags with the project name and minute timestamp', () => {
+  const { formatDeployTag } = loadDeployScript();
+
+  assert.equal(
+    formatDeployTag('bajour', new Date(2026, 5, 12, 13, 45, 30)),
+    'deploy_bajour_202606121345'
+  );
+});
+
+test('filters customer changelog entries in JavaScript instead of shelling out to egrep', () => {
+  const { filterCustomerChangelog } = loadDeployScript();
+  const changelog = [
+    'abc123 update website navigation',
+    'def456 fix unrelated docs',
+    'fed321 improve bajour article page',
+    '987654 refactor editor settings',
+  ].join('\n');
+
+  assert.equal(
+    filterCustomerChangelog(changelog, 'bajour'),
+    [
+      'abc123 update website navigation',
+      'fed321 improve bajour article page',
+      '987654 refactor editor settings',
+    ].join('\n')
+  );
+});


### PR DESCRIPTION
## Summary
- replace shell-interpolated deployment git commands with `execFile("git", args)`
- validate project names before using them in paths, tag patterns, or git arguments
- filter deployment changelog entries in JavaScript instead of piping through shell `egrep`
- make the deploy script import-safe and add node:test coverage for helper behavior

## Validation
- `git diff --check`
- `node --test deployment/deploy_production.test.js`
- `node --check deployment/deploy_production.js`
- `npx prettier --check deployment/deploy_production.js deployment/deploy_production.test.js`
- `npx eslint deployment/deploy_production.js deployment/deploy_production.test.js` (files are ignored by current ESLint config; no source signal)
- `trufflehog git file:///home/void/ExternalRepos/wepublish --since-commit 8be726e397876aa158002bcad559fbe60919876c --branch pr/deploy-script-hardening --results verified --fail --fail-on-scan-errors --no-update --concurrency=2 --json` (0 verified, 0 unverified)

## Notes
This keeps the existing deployment flow intact: dirty-worktree guard, changelog preview, exact project-name confirmation, deploy tag creation, and tag push. The change is limited to command safety and testability.