### PR TITLE
fix(editor): harden link URL validation

### DIFF
--- a/apps/editor/src/app/utility.spec.ts
+++ b/apps/editor/src/app/utility.spec.ts
@@ -1,0 +1,27 @@
+import { validateURL } from './utility';
+
+const scriptScheme = 'javascript';
+
+describe('validateURL', () => {
+  it.each([
+    'example.com/news',
+    'example.com:8080/news',
+    'https://example.com/news?topic=local#lead',
+    'http://192.168.1.1:8080/path',
+  ])('accepts %s', url => {
+    expect(validateURL(url)).toBe(true);
+  });
+
+  it.each([
+    '',
+    'ftp://example.com/file',
+    `${scriptScheme}://example.com/%0Aalert(1)`,
+    `${scriptScheme}:alert(1)`,
+    'http://999.999.999.999',
+    'https://example.com/e vil',
+    'https://user:pass@example.com',
+    '-bad.example.com',
+  ])('rejects %s', url => {
+    expect(validateURL(url)).toBe(false);
+  });
+});

--- a/apps/editor/src/app/utility.ts
+++ b/apps/editor/src/app/utility.ts
@@ -153,20 +153,109 @@ export enum StateColor {
   none = 'white',
 }
 
+const ALLOWED_URL_PROTOCOLS = new Set(['http:', 'https:']);
+
 export function validateURL(url: string) {
-  if (url) {
-    const pattern = new RegExp(
-      '^(https?:\\/\\/)?' + // protocol
-        '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' + // domain name
-        '((\\d{1,3}\\.){3}\\d{1,3}))' + // OR ip (v4) address
-        '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // port and path
-        '(\\?[;&a-z\\d%_.~+=-]*)?' + // query string
-        '(\\#[-a-z\\d_]*)?$',
-      'i'
-    );
-    return pattern.test(url);
+  const input = url.trim();
+
+  if (!input || hasWhitespace(input)) {
+    return false;
   }
-  return false;
+
+  try {
+    const parsed = new URL(
+      hasExplicitScheme(input) ? input : `https://${input}`
+    );
+
+    return (
+      ALLOWED_URL_PROTOCOLS.has(parsed.protocol) &&
+      !parsed.username &&
+      !parsed.password &&
+      isValidUrlHostname(parsed.hostname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function hasExplicitScheme(value: string) {
+  return /^[a-z][a-z0-9+.-]*:\/\//i.test(value);
+}
+
+function hasWhitespace(value: string) {
+  return Array.from(value).some(character => character.trim() === '');
+}
+
+function isValidUrlHostname(hostname: string) {
+  const normalized = hostname.endsWith('.') ? hostname.slice(0, -1) : hostname;
+
+  if (!normalized || normalized.length > 253) {
+    return false;
+  }
+
+  if (isValidIPv4Address(normalized)) {
+    return true;
+  }
+
+  const labels = normalized.toLowerCase().split('.');
+  const topLevelDomain = labels[labels.length - 1];
+
+  return (
+    labels.length > 1 &&
+    topLevelDomain.length >= 2 &&
+    Array.from(topLevelDomain).every(character =>
+      isAsciiLetter(character.charCodeAt(0))
+    ) &&
+    labels.every(isValidDnsLabel)
+  );
+}
+
+function isValidIPv4Address(hostname: string) {
+  const parts = hostname.split('.');
+
+  return (
+    parts.length === 4 &&
+    parts.every(part => {
+      if (!part || part.length > 3) {
+        return false;
+      }
+
+      if (
+        !Array.from(part).every(character =>
+          isAsciiDigit(character.charCodeAt(0))
+        )
+      ) {
+        return false;
+      }
+
+      const value = Number(part);
+      return Number.isInteger(value) && value >= 0 && value <= 255;
+    })
+  );
+}
+
+function isValidDnsLabel(label: string) {
+  if (
+    !label ||
+    label.length > 63 ||
+    label.startsWith('-') ||
+    label.endsWith('-')
+  ) {
+    return false;
+  }
+
+  return Array.from(label).every(character => {
+    const code = character.charCodeAt(0);
+    return isAsciiLetter(code) || isAsciiDigit(code) || character === '-';
+  });
+}
+
+function isAsciiLetter(code: number) {
+  return (code >= 65 && code <= 90) || (code >= 97 && code <= 122);
+}
+
+function isAsciiDigit(code: number) {
+  return code >= 48 && code <= 57;
 }
 
 export function flattenDOMTokenList(list: DOMTokenList) {

--- a/libs/ui/editor/src/lib/blocks/richTextBlock/toolbar/linkMenu.tsx
+++ b/libs/ui/editor/src/lib/blocks/richTextBlock/toolbar/linkMenu.tsx
@@ -22,6 +22,7 @@ import {
 import { useSlate } from 'slate-react';
 
 import { SubMenuContext } from '../../../atoms/toolbar';
+import { validateURL as isValidLinkUrl } from '../../../utility';
 import { WepublishEditor } from '../editor/wepublishEditor';
 
 const { Group, Control, ControlLabel, HelpText } = Form;
@@ -59,7 +60,10 @@ export function LinkMenu() {
 
   const [isValidURL, setIsValidURL] = useState(false);
   const [isValidMail, setIsValidMail] = useState(false);
-  const isDisabled = !url || !title;
+  const isDisabled =
+    !url ||
+    !title ||
+    (prefix === prefixType.mailto ? !isValidMail : !isValidURL);
 
   const { t } = useTranslation();
 
@@ -206,19 +210,7 @@ async function validateMail(mail: string) {
 }
 
 async function validateURL(url: string) {
-  if (url) {
-    const pattern = new RegExp(
-      '^(https?:\\/\\/)?' + // protocol
-        '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' + // domain name
-        '((\\d{1,3}\\.){3}\\d{1,3}))' + // OR ip (v4) address
-        '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // port and path
-        '(\\?[;&a-z\\d%_.~+=-]*)?' + // query string
-        '(\\#[-a-z\\d_]*)?$',
-      'i'
-    );
-    return pattern.test(url);
-  }
-  return false;
+  return isValidLinkUrl(url);
 }
 
 export function RemoveLinkFormatButton() {

--- a/libs/ui/editor/src/lib/utility.spec.ts
+++ b/libs/ui/editor/src/lib/utility.spec.ts
@@ -1,0 +1,27 @@
+import { validateURL } from './utility';
+
+const scriptScheme = 'javascript';
+
+describe('validateURL', () => {
+  it.each([
+    'example.com/news',
+    'example.com:8080/news',
+    'https://example.com/news?topic=local#lead',
+    'http://192.168.1.1:8080/path',
+  ])('accepts %s', url => {
+    expect(validateURL(url)).toBe(true);
+  });
+
+  it.each([
+    '',
+    'ftp://example.com/file',
+    `${scriptScheme}://example.com/%0Aalert(1)`,
+    `${scriptScheme}:alert(1)`,
+    'http://999.999.999.999',
+    'https://example.com/e vil',
+    'https://user:pass@example.com',
+    '-bad.example.com',
+  ])('rejects %s', url => {
+    expect(validateURL(url)).toBe(false);
+  });
+});

--- a/libs/ui/editor/src/lib/utility.ts
+++ b/libs/ui/editor/src/lib/utility.ts
@@ -154,20 +154,109 @@ export enum StateColor {
   none = 'white',
 }
 
+const ALLOWED_URL_PROTOCOLS = new Set(['http:', 'https:']);
+
 export function validateURL(url: string) {
-  if (url) {
-    const pattern = new RegExp(
-      '^(https?:\\/\\/)?' + // protocol
-        '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' + // domain name
-        '((\\d{1,3}\\.){3}\\d{1,3}))' + // OR ip (v4) address
-        '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // port and path
-        '(\\?[;&a-z\\d%_.~+=-]*)?' + // query string
-        '(\\#[-a-z\\d_]*)?$',
-      'i'
-    );
-    return pattern.test(url);
+  const input = url.trim();
+
+  if (!input || hasWhitespace(input)) {
+    return false;
   }
-  return false;
+
+  try {
+    const parsed = new URL(
+      hasExplicitScheme(input) ? input : `https://${input}`
+    );
+
+    return (
+      ALLOWED_URL_PROTOCOLS.has(parsed.protocol) &&
+      !parsed.username &&
+      !parsed.password &&
+      isValidUrlHostname(parsed.hostname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function hasExplicitScheme(value: string) {
+  return /^[a-z][a-z0-9+.-]*:\/\//i.test(value);
+}
+
+function hasWhitespace(value: string) {
+  return Array.from(value).some(character => character.trim() === '');
+}
+
+function isValidUrlHostname(hostname: string) {
+  const normalized = hostname.endsWith('.') ? hostname.slice(0, -1) : hostname;
+
+  if (!normalized || normalized.length > 253) {
+    return false;
+  }
+
+  if (isValidIPv4Address(normalized)) {
+    return true;
+  }
+
+  const labels = normalized.toLowerCase().split('.');
+  const topLevelDomain = labels[labels.length - 1];
+
+  return (
+    labels.length > 1 &&
+    topLevelDomain.length >= 2 &&
+    Array.from(topLevelDomain).every(character =>
+      isAsciiLetter(character.charCodeAt(0))
+    ) &&
+    labels.every(isValidDnsLabel)
+  );
+}
+
+function isValidIPv4Address(hostname: string) {
+  const parts = hostname.split('.');
+
+  return (
+    parts.length === 4 &&
+    parts.every(part => {
+      if (!part || part.length > 3) {
+        return false;
+      }
+
+      if (
+        !Array.from(part).every(character =>
+          isAsciiDigit(character.charCodeAt(0))
+        )
+      ) {
+        return false;
+      }
+
+      const value = Number(part);
+      return Number.isInteger(value) && value >= 0 && value <= 255;
+    })
+  );
+}
+
+function isValidDnsLabel(label: string) {
+  if (
+    !label ||
+    label.length > 63 ||
+    label.startsWith('-') ||
+    label.endsWith('-')
+  ) {
+    return false;
+  }
+
+  return Array.from(label).every(character => {
+    const code = character.charCodeAt(0);
+    return isAsciiLetter(code) || isAsciiDigit(code) || character === '-';
+  });
+}
+
+function isAsciiLetter(code: number) {
+  return (code >= 65 && code <= 90) || (code >= 97 && code <= 122);
+}
+
+function isAsciiDigit(code: number) {
+  return code >= 48 && code <= 57;
 }
 
 export function flattenDOMTokenList(list: DOMTokenList) {


### PR DESCRIPTION
## Summary
- replace regex-only editor URL validation with URL-parser-based validation for HTTP(S) links
- reject non-HTTP schemes, embedded credentials, whitespace, invalid IPv4 addresses, and invalid DNS labels
- keep common editor inputs working, including scheme-less domains and `host:port/path` URLs
- reuse the shared UI editor URL validator in the rich-text link menu and disable insertion while the current URL/mail target is invalid

## Validation
- `git diff --check`
- `npx nx run editor:test --runInBand --skip-nx-cache`
- `npx nx run ui-editor:test --runInBand --skip-nx-cache`
- `npx nx run editor:lint --skip-nx-cache` (passes with existing warnings)
- `npx nx run ui-editor:lint --skip-nx-cache` (passes with existing warnings)
- `npx nx run editor:browser --skip-nx-cache`
- `npx prettier --check apps/editor/src/app/utility.ts apps/editor/src/app/utility.spec.ts libs/ui/editor/src/lib/utility.ts libs/ui/editor/src/lib/utility.spec.ts libs/ui/editor/src/lib/blocks/richTextBlock/toolbar/linkMenu.tsx`
- `trufflehog git file:///home/void/ExternalRepos/wepublish --since-commit 8be726e397876aa158002bcad559fbe60919876c --branch pr/editor-url-validation --results verified --fail --fail-on-scan-errors --no-update --concurrency=2 --json` (0 verified, 0 unverified)

## Notes
This PR intentionally avoids dependency changes and SSR rate-limiting work. It is limited to editor/frontend URL validation and rich-text link insertion behavior.