### PR TITLE
fix(onlinereports): sanitize middleware log fields

### DIFF
--- a/apps/onlinereports/middleware.spec.ts
+++ b/apps/onlinereports/middleware.spec.ts
@@ -1,0 +1,20 @@
+async function loadMiddleware() {
+  Object.assign(globalThis, {
+    Headers: class Headers {},
+    Request: class Request {},
+    Response: class Response {},
+  });
+
+  return await import('./middleware');
+}
+
+describe('sanitizeLogField', () => {
+  it('removes control characters and bounds logged path fragments', async () => {
+    const { sanitizeLogField } = await loadMiddleware();
+
+    expect(sanitizeLogField('/archive\nWARN injected\r\t\u0000tail')).toBe(
+      '/archive WARN injected  ?tail'
+    );
+    expect(sanitizeLogField('a'.repeat(260))).toHaveLength(200);
+  });
+});

--- a/apps/onlinereports/middleware.ts
+++ b/apps/onlinereports/middleware.ts
@@ -18,6 +18,32 @@ function normalizePath(pathname: string): string {
   return '/' + stack.join('/');
 }
 
+export function sanitizeLogField(value: string): string {
+  const sanitized = Array.from(value)
+    .map(character => {
+      if (character === '\n' || character === '\r' || character === '\t') {
+        return ' ';
+      }
+
+      const code = character.charCodeAt(0);
+      return code < 32 || code === 127 ? '?' : character;
+    })
+    .join('');
+
+  return sanitized.slice(0, 200);
+}
+
+function sanitizeLogError(error: unknown) {
+  if (error instanceof Error) {
+    return {
+      name: sanitizeLogField(error.name),
+      message: sanitizeLogField(error.message),
+    };
+  }
+
+  return { name: 'UnknownError' };
+}
+
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
@@ -26,9 +52,10 @@ export async function middleware(request: NextRequest) {
 
   // Reject if normalization changed the path (means suspicious input)
   if (normalizedPath !== pathname) {
-    console.warn(
-      `Path normalization changed path: ${pathname} -> ${normalizedPath}`
-    );
+    console.warn('Path normalization changed path', {
+      pathname: sanitizeLogField(pathname),
+      normalizedPath: sanitizeLogField(normalizedPath),
+    });
     return NextResponse.next();
   }
 
@@ -41,7 +68,9 @@ export async function middleware(request: NextRequest) {
   // Validate pathname to prevent SSRF attacks
   const pathValidation = /^\/[a-zA-Z0-9\-_/.+ :]+\.html$/;
   if (!pathValidation.test(decodedPathname)) {
-    console.warn(`Invalid pathname pattern: ${pathname}`);
+    console.warn('Invalid pathname pattern', {
+      pathname: sanitizeLogField(pathname),
+    });
     return NextResponse.next();
   }
 
@@ -72,7 +101,11 @@ export async function middleware(request: NextRequest) {
       return NextResponse.redirect(externalUrl, 302);
     }
   } catch (error) {
-    console.warn(`Error checking ${externalUrl} :`, error);
+    console.warn('Error checking archive URL', {
+      origin: externalHostname,
+      pathname: sanitizeLogField(pathname),
+      error: sanitizeLogError(error),
+    });
   }
 
   return NextResponse.next();


### PR DESCRIPTION
## Summary
- sanitize path fragments before writing them to onlinereports middleware warnings
- switch warning payloads to structured objects so raw request input and thrown errors are not interpolated into log strings
- add a focused middleware utility test for control-character replacement and log length bounding

## Validation
- `git diff --check`
- `npx prettier --check apps/onlinereports/middleware.ts apps/onlinereports/middleware.spec.ts`
- `npx nx run onlinereports:test --runInBand --skip-nx-cache`
- `npx nx run onlinereports:lint --skip-nx-cache` (passes with existing warnings outside touched middleware files)
- `trufflehog git ... --since-commit $(git merge-base HEAD origin/master) --branch pr/onlinereports-log-sanitization --results verified --fail --fail-on-scan-errors --no-update --concurrency=2` (0 verified, 0 unverified findings)

## Note
I also attempted `npx nx run onlinereports:build --skip-nx-cache`; the local build reached static page generation, then failed because this checkout had no API running at `127.0.0.1:4000` for prerender data fetching. I am not counting that as a green validation result.