### PR TITLE
fix(image): default remote fetch MIME type

### DIFF
--- a/libs/image/api/src/lib/image-fetcher/image-fetcher.service.spec.ts
+++ b/libs/image/api/src/lib/image-fetcher/image-fetcher.service.spec.ts
@@ -1,0 +1,40 @@
+import { HttpService } from '@nestjs/axios';
+import { of } from 'rxjs';
+
+import { ImageFetcherService } from './image-fetcher.service';
+
+describe('ImageFetcherService', () => {
+  const buildService = (headers: Record<string, unknown>) => {
+    const get = jest.fn().mockReturnValue(
+      of({
+        data: new ArrayBuffer(8),
+        headers,
+      })
+    );
+
+    return {
+      get,
+      service: new ImageFetcherService({ get } as unknown as HttpService),
+    };
+  };
+
+  it('returns the response content type as upload MIME type', async () => {
+    const { service } = buildService({ 'content-type': 'image/png' });
+
+    await expect(
+      service.fetch('https://example.com/image.png')
+    ).resolves.toMatchObject({
+      mimetype: 'image/png',
+    });
+  });
+
+  it('falls back to an octet stream MIME type when the response content type is unusable', async () => {
+    const { service } = buildService({ 'content-type': 1234 });
+
+    await expect(
+      service.fetch('https://example.com/image')
+    ).resolves.toMatchObject({
+      mimetype: 'application/octet-stream',
+    });
+  });
+});

--- a/libs/image/api/src/lib/image-fetcher/image-fetcher.service.ts
+++ b/libs/image/api/src/lib/image-fetcher/image-fetcher.service.ts
@@ -3,6 +3,26 @@ import { firstValueFrom } from 'rxjs';
 import { ArrayBufferUpload } from '../media-adapter';
 import { Injectable } from '@nestjs/common';
 
+const DEFAULT_MIMETYPE = 'application/octet-stream';
+
+function normalizeContentType(contentType: unknown): string {
+  if (typeof contentType === 'string') {
+    const trimmedContentType = contentType.trim();
+    return trimmedContentType || DEFAULT_MIMETYPE;
+  }
+
+  if (Array.isArray(contentType)) {
+    const firstContentType = contentType.find(
+      (value): value is string =>
+        typeof value === 'string' && value.trim().length > 0
+    );
+
+    return firstContentType?.trim() ?? DEFAULT_MIMETYPE;
+  }
+
+  return DEFAULT_MIMETYPE;
+}
+
 @Injectable()
 export class ImageFetcherService {
   constructor(private httpService: HttpService) {}
@@ -18,9 +38,9 @@ export class ImageFetcherService {
           timeout: 30000,
         })
       );
-      const mimetype = headers['content-type'];
+      const mimetype = normalizeContentType(headers['content-type']);
 
-      const arrayBufferUpload = {
+      const arrayBufferUpload: ArrayBufferUpload = {
         filename,
         mimetype,
         arrayBuffer,


### PR DESCRIPTION
## Summary
- normalize the remote response `content-type` before handing fetched images to the media adapter
- keep valid string MIME types, support array-shaped header values, and fall back to `application/octet-stream` for missing or unusable values
- add a focused `ImageFetcherService` regression test for valid and invalid content-type headers

## Validation
- red/green: `npx jest --config libs/image/api/jest.config.ts --runInBand libs/image/api/src/lib/image-fetcher/image-fetcher.service.spec.ts` failed before the service change because numeric `content-type` was passed through as `mimetype`; the same command passes after the fix
- `npx eslint libs/image/api/src/lib/image-fetcher/image-fetcher.service.ts libs/image/api/src/lib/image-fetcher/image-fetcher.service.spec.ts`
- `npx prettier --check libs/image/api/src/lib/image-fetcher/image-fetcher.service.ts libs/image/api/src/lib/image-fetcher/image-fetcher.service.spec.ts`
- `git diff --check`
- `trufflehog git ... --since-commit $(git merge-base HEAD origin/master) --branch pr/image-fetcher-mimetype-fallback --results verified --fail --fail-on-scan-errors --no-update --concurrency=2` (0 verified, 0 unverified findings)

## Note
`libs/image/api` is intentionally listed in `.nxignore` because the current graph has an image/peer cycle, so I validated this slice with direct Jest and ESLint commands instead of `nx run image-api:*`.