### PR TITLE
Fix intended route review feedback

### DIFF
--- a/apps/babanews/pages/login.tsx
+++ b/apps/babanews/pages/login.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 import { Typography } from '@mui/material';
 import {
-  IntendedRouteExpiryInSeconds,
   IntendedRouteStorageKey,
   LoginFormContainer,
+  usePersistIntendedRoute,
   useUser,
 } from '@wepublish/authentication/website';
 import { ContentWrapper } from '@wepublish/content/website';
@@ -13,8 +13,7 @@ import {
   SessionWithTokenWithoutUser,
 } from '@wepublish/website/api';
 import { useWebsiteBuilder } from '@wepublish/website/builder';
-import { deleteCookie, getCookie, setCookie } from 'cookies-next';
-import { add } from 'date-fns';
+import { deleteCookie, getCookie } from 'cookies-next';
 import { NextPageContext } from 'next';
 import { useRouter } from 'next/router';
 import { useEffect, useRef } from 'react';
@@ -39,16 +38,7 @@ export default function Login({ sessionToken }: LoginProps) {
     }
   }, [sessionToken, setToken]);
 
-  if (
-    router.query.intended &&
-    (router.query.intended as string).startsWith('/')
-  ) {
-    setCookie(IntendedRouteStorageKey, router.query.intended, {
-      expires: add(new Date(), {
-        seconds: IntendedRouteExpiryInSeconds,
-      }),
-    });
-  }
+  usePersistIntendedRoute(router.query.intended);
 
   if (hasUser && typeof window !== 'undefined') {
     const intendedRoute = getCookie(IntendedRouteStorageKey)?.toString();

--- a/apps/bajour/pages/login.tsx
+++ b/apps/bajour/pages/login.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 import { Typography } from '@mui/material';
 import {
-  IntendedRouteExpiryInSeconds,
   IntendedRouteStorageKey,
   LoginFormContainer,
+  usePersistIntendedRoute,
   useUser,
 } from '@wepublish/authentication/website';
 import { ContentWrapper } from '@wepublish/content/website';
@@ -17,8 +17,7 @@ import {
   SessionWithTokenWithoutUser,
 } from '@wepublish/website/api';
 import { useWebsiteBuilder } from '@wepublish/website/builder';
-import { deleteCookie, getCookie, setCookie } from 'cookies-next';
-import { add } from 'date-fns';
+import { deleteCookie, getCookie } from 'cookies-next';
 import { NextPageContext } from 'next';
 import { useRouter } from 'next/router';
 import { useEffect, useRef } from 'react';
@@ -45,16 +44,7 @@ export default function Login({ sessionToken }: LoginProps) {
     }
   }, [sessionToken, setToken]);
 
-  if (
-    router.query.intended &&
-    (router.query.intended as string).startsWith('/')
-  ) {
-    setCookie(IntendedRouteStorageKey, router.query.intended, {
-      expires: add(new Date(), {
-        seconds: IntendedRouteExpiryInSeconds,
-      }),
-    });
-  }
+  usePersistIntendedRoute(router.query.intended);
 
   if (hasUser && typeof window !== 'undefined') {
     const intendedRoute = getCookie(IntendedRouteStorageKey)?.toString();

--- a/apps/eenews/pages/login.tsx
+++ b/apps/eenews/pages/login.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 import { Typography } from '@mui/material';
 import {
-  IntendedRouteExpiryInSeconds,
   IntendedRouteStorageKey,
   LoginFormContainer,
+  usePersistIntendedRoute,
   useUser,
 } from '@wepublish/authentication/website';
 import { getApiUrl, handleJwtLogin } from '@wepublish/utils/website';
@@ -12,8 +12,7 @@ import {
   SessionWithTokenWithoutUser,
 } from '@wepublish/website/api';
 import { useWebsiteBuilder } from '@wepublish/website/builder';
-import { deleteCookie, getCookie, setCookie } from 'cookies-next';
-import { add } from 'date-fns';
+import { deleteCookie, getCookie } from 'cookies-next';
 import { NextPageContext } from 'next';
 import { useRouter } from 'next/router';
 import { useEffect, useRef } from 'react';
@@ -39,16 +38,7 @@ export default function Login({ sessionToken }: LoginProps) {
     }
   }, [sessionToken, setToken]);
 
-  if (
-    router.query.intended &&
-    (router.query.intended as string).startsWith('/')
-  ) {
-    setCookie(IntendedRouteStorageKey, router.query.intended, {
-      expires: add(new Date(), {
-        seconds: IntendedRouteExpiryInSeconds,
-      }),
-    });
-  }
+  usePersistIntendedRoute(router.query.intended);
 
   if (hasUser && typeof window !== 'undefined') {
     const intendedRoute = getCookie(IntendedRouteStorageKey)?.toString();

--- a/apps/fazetten/pages/login.tsx
+++ b/apps/fazetten/pages/login.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 import { Typography } from '@mui/material';
 import {
-  IntendedRouteExpiryInSeconds,
   IntendedRouteStorageKey,
   LoginFormContainer,
+  usePersistIntendedRoute,
   useUser,
 } from '@wepublish/authentication/website';
 import { getApiUrl, handleJwtLogin } from '@wepublish/utils/website';
@@ -12,8 +12,7 @@ import {
   SessionWithTokenWithoutUser,
 } from '@wepublish/website/api';
 import { useWebsiteBuilder } from '@wepublish/website/builder';
-import { deleteCookie, getCookie, setCookie } from 'cookies-next';
-import { add } from 'date-fns';
+import { deleteCookie, getCookie } from 'cookies-next';
 import { NextPageContext } from 'next';
 import { useRouter } from 'next/router';
 import { useEffect, useRef } from 'react';
@@ -39,16 +38,7 @@ export default function Login({ sessionToken }: LoginProps) {
     }
   }, [sessionToken, setToken]);
 
-  if (
-    router.query.intended &&
-    (router.query.intended as string).startsWith('/')
-  ) {
-    setCookie(IntendedRouteStorageKey, router.query.intended, {
-      expires: add(new Date(), {
-        seconds: IntendedRouteExpiryInSeconds,
-      }),
-    });
-  }
+  usePersistIntendedRoute(router.query.intended);
 
   if (hasUser && typeof window !== 'undefined') {
     const intendedRoute = getCookie(IntendedRouteStorageKey)?.toString();

--- a/apps/flimmer/pages/login.tsx
+++ b/apps/flimmer/pages/login.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 import { Typography } from '@mui/material';
 import {
-  IntendedRouteExpiryInSeconds,
   IntendedRouteStorageKey,
   LoginFormContainer,
+  usePersistIntendedRoute,
   useUser,
 } from '@wepublish/authentication/website';
 import { getApiUrl, handleJwtLogin } from '@wepublish/utils/website';
@@ -12,8 +12,7 @@ import {
   SessionWithTokenWithoutUser,
 } from '@wepublish/website/api';
 import { useWebsiteBuilder } from '@wepublish/website/builder';
-import { deleteCookie, getCookie, setCookie } from 'cookies-next';
-import { add } from 'date-fns';
+import { deleteCookie, getCookie } from 'cookies-next';
 import { NextPageContext } from 'next';
 import { useRouter } from 'next/router';
 import { useEffect, useRef } from 'react';
@@ -39,16 +38,7 @@ export default function Login({ sessionToken }: LoginProps) {
     }
   }, [sessionToken, setToken]);
 
-  if (
-    router.query.intended &&
-    (router.query.intended as string).startsWith('/')
-  ) {
-    setCookie(IntendedRouteStorageKey, router.query.intended, {
-      expires: add(new Date(), {
-        seconds: IntendedRouteExpiryInSeconds,
-      }),
-    });
-  }
+  usePersistIntendedRoute(router.query.intended);
 
   if (hasUser && typeof window !== 'undefined') {
     const intendedRoute = getCookie(IntendedRouteStorageKey)?.toString();

--- a/apps/ganzgraz/pages/login.tsx
+++ b/apps/ganzgraz/pages/login.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 import { Typography } from '@mui/material';
 import {
-  IntendedRouteExpiryInSeconds,
   IntendedRouteStorageKey,
   LoginFormContainer,
+  usePersistIntendedRoute,
   useUser,
 } from '@wepublish/authentication/website';
 import { getApiUrl, handleJwtLogin } from '@wepublish/utils/website';
@@ -12,8 +12,7 @@ import {
   SessionWithTokenWithoutUser,
 } from '@wepublish/website/api';
 import { useWebsiteBuilder } from '@wepublish/website/builder';
-import { deleteCookie, getCookie, setCookie } from 'cookies-next';
-import { add } from 'date-fns';
+import { deleteCookie, getCookie } from 'cookies-next';
 import { NextPageContext } from 'next';
 import { useRouter } from 'next/router';
 import { useEffect, useRef } from 'react';
@@ -39,16 +38,7 @@ export default function Login({ sessionToken }: LoginProps) {
     }
   }, [sessionToken, setToken]);
 
-  if (
-    router.query.intended &&
-    (router.query.intended as string).startsWith('/')
-  ) {
-    setCookie(IntendedRouteStorageKey, router.query.intended, {
-      expires: add(new Date(), {
-        seconds: IntendedRouteExpiryInSeconds,
-      }),
-    });
-  }
+  usePersistIntendedRoute(router.query.intended);
 
   if (hasUser && typeof window !== 'undefined') {
     const intendedRoute = getCookie(IntendedRouteStorageKey)?.toString();

--- a/apps/gruppetto/pages/login.tsx
+++ b/apps/gruppetto/pages/login.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 import { Typography } from '@mui/material';
 import {
-  IntendedRouteExpiryInSeconds,
   IntendedRouteStorageKey,
   LoginFormContainer,
+  usePersistIntendedRoute,
   useUser,
 } from '@wepublish/authentication/website';
 import { getApiUrl, handleJwtLogin } from '@wepublish/utils/website';
@@ -12,8 +12,7 @@ import {
   SessionWithTokenWithoutUser,
 } from '@wepublish/website/api';
 import { useWebsiteBuilder } from '@wepublish/website/builder';
-import { deleteCookie, getCookie, setCookie } from 'cookies-next';
-import { add } from 'date-fns';
+import { deleteCookie, getCookie } from 'cookies-next';
 import { NextPageContext } from 'next';
 import { useRouter } from 'next/router';
 import { useEffect, useRef } from 'react';
@@ -39,16 +38,7 @@ export default function Login({ sessionToken }: LoginProps) {
     }
   }, [sessionToken, setToken]);
 
-  if (
-    router.query.intended &&
-    (router.query.intended as string).startsWith('/')
-  ) {
-    setCookie(IntendedRouteStorageKey, router.query.intended, {
-      expires: add(new Date(), {
-        seconds: IntendedRouteExpiryInSeconds,
-      }),
-    });
-  }
+  usePersistIntendedRoute(router.query.intended);
 
   if (hasUser && typeof window !== 'undefined') {
     const intendedRoute = getCookie(IntendedRouteStorageKey)?.toString();

--- a/apps/hauptstadt/pages/login.tsx
+++ b/apps/hauptstadt/pages/login.tsx
@@ -1,7 +1,7 @@
 import {
-  IntendedRouteExpiryInSeconds,
   IntendedRouteStorageKey,
   LoginFormContainer,
+  usePersistIntendedRoute,
   useUser,
 } from '@wepublish/authentication/website';
 import { PageContainer } from '@wepublish/page/website';
@@ -12,8 +12,7 @@ import {
   SessionWithTokenWithoutUser,
 } from '@wepublish/website/api';
 import { getApiClient } from '@wepublish/website/api';
-import { deleteCookie, getCookie, setCookie } from 'cookies-next';
-import { add } from 'date-fns';
+import { deleteCookie, getCookie } from 'cookies-next';
 import { NextPageContext } from 'next';
 import { useRouter } from 'next/router';
 import { useEffect, useRef } from 'react';
@@ -33,16 +32,7 @@ export default function Login({ sessionToken }: LoginProps) {
     }
   }, [sessionToken, setToken]);
 
-  if (
-    router.query.intended &&
-    (router.query.intended as string).startsWith('/')
-  ) {
-    setCookie(IntendedRouteStorageKey, router.query.intended, {
-      expires: add(new Date(), {
-        seconds: IntendedRouteExpiryInSeconds,
-      }),
-    });
-  }
+  usePersistIntendedRoute(router.query.intended);
 
   if (hasUser && typeof window !== 'undefined') {
     const intendedRoute = getCookie(IntendedRouteStorageKey)?.toString();

--- a/apps/mannschaft/pages/login.tsx
+++ b/apps/mannschaft/pages/login.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 import { Typography } from '@mui/material';
 import {
-  IntendedRouteExpiryInSeconds,
   IntendedRouteStorageKey,
   LoginFormContainer,
+  usePersistIntendedRoute,
   useUser,
 } from '@wepublish/authentication/website';
 import { getApiUrl, handleJwtLogin } from '@wepublish/utils/website';
@@ -12,8 +12,7 @@ import {
   SessionWithTokenWithoutUser,
 } from '@wepublish/website/api';
 import { useWebsiteBuilder } from '@wepublish/website/builder';
-import { deleteCookie, getCookie, setCookie } from 'cookies-next';
-import { add } from 'date-fns';
+import { deleteCookie, getCookie } from 'cookies-next';
 import { NextPageContext } from 'next';
 import { useRouter } from 'next/router';
 import { useEffect, useRef } from 'react';
@@ -42,16 +41,7 @@ export default function Login({ sessionToken }: LoginProps) {
     }
   }, [sessionToken, setToken]);
 
-  if (
-    router.query.intended &&
-    (router.query.intended as string).startsWith('/')
-  ) {
-    setCookie(IntendedRouteStorageKey, router.query.intended, {
-      expires: add(new Date(), {
-        seconds: IntendedRouteExpiryInSeconds,
-      }),
-    });
-  }
+  usePersistIntendedRoute(router.query.intended);
 
   if (hasUser && typeof window !== 'undefined') {
     const intendedRoute = getCookie(IntendedRouteStorageKey)?.toString();

--- a/apps/mediamakerscamp/pages/login.tsx
+++ b/apps/mediamakerscamp/pages/login.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 import { Typography } from '@mui/material';
 import {
-  IntendedRouteExpiryInSeconds,
   IntendedRouteStorageKey,
   LoginFormContainer,
+  usePersistIntendedRoute,
   useUser,
 } from '@wepublish/authentication/website';
 import { getApiUrl, handleJwtLogin } from '@wepublish/utils/website';
@@ -12,8 +12,7 @@ import {
   SessionWithTokenWithoutUser,
 } from '@wepublish/website/api';
 import { useWebsiteBuilder } from '@wepublish/website/builder';
-import { deleteCookie, getCookie, setCookie } from 'cookies-next';
-import { add } from 'date-fns';
+import { deleteCookie, getCookie } from 'cookies-next';
 import { NextPageContext } from 'next';
 import { useRouter } from 'next/router';
 import { useEffect, useRef } from 'react';
@@ -39,16 +38,7 @@ export default function Login({ sessionToken }: LoginProps) {
     }
   }, [sessionToken, setToken]);
 
-  if (
-    router.query.intended &&
-    (router.query.intended as string).startsWith('/')
-  ) {
-    setCookie(IntendedRouteStorageKey, router.query.intended, {
-      expires: add(new Date(), {
-        seconds: IntendedRouteExpiryInSeconds,
-      }),
-    });
-  }
+  usePersistIntendedRoute(router.query.intended);
 
   if (hasUser && typeof window !== 'undefined') {
     const intendedRoute = getCookie(IntendedRouteStorageKey)?.toString();

--- a/apps/munotgloeggli/pages/login.tsx
+++ b/apps/munotgloeggli/pages/login.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 import { Typography } from '@mui/material';
 import {
-  IntendedRouteExpiryInSeconds,
   IntendedRouteStorageKey,
   LoginFormContainer,
+  usePersistIntendedRoute,
   useUser,
 } from '@wepublish/authentication/website';
 import {
@@ -14,8 +14,7 @@ import {
 import { SessionWithTokenWithoutUser } from '@wepublish/website/api';
 import { getApiClient } from '@wepublish/website/api';
 import { useWebsiteBuilder } from '@wepublish/website/builder';
-import { deleteCookie, getCookie, setCookie } from 'cookies-next';
-import { add } from 'date-fns';
+import { deleteCookie, getCookie } from 'cookies-next';
 import { NextPageContext } from 'next';
 import { useRouter } from 'next/router';
 import { useEffect, useRef } from 'react';
@@ -41,16 +40,7 @@ export default function Login({ sessionToken }: LoginProps) {
     }
   }, [sessionToken, setToken]);
 
-  if (
-    router.query.intended &&
-    (router.query.intended as string).startsWith('/')
-  ) {
-    setCookie(IntendedRouteStorageKey, router.query.intended, {
-      expires: add(new Date(), {
-        seconds: IntendedRouteExpiryInSeconds,
-      }),
-    });
-  }
+  usePersistIntendedRoute(router.query.intended);
 
   if (hasUser && typeof window !== 'undefined') {
     const intendedRoute = getCookie(IntendedRouteStorageKey)?.toString();

--- a/apps/onlinereports/pages/login.tsx
+++ b/apps/onlinereports/pages/login.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 import { Typography } from '@mui/material';
 import {
-  IntendedRouteExpiryInSeconds,
   IntendedRouteStorageKey,
   LoginFormContainer,
+  usePersistIntendedRoute,
   useUser,
 } from '@wepublish/authentication/website';
 import { getApiUrl, handleJwtLogin } from '@wepublish/utils/website';
@@ -12,8 +12,7 @@ import {
   SessionWithTokenWithoutUser,
 } from '@wepublish/website/api';
 import { useWebsiteBuilder } from '@wepublish/website/builder';
-import { deleteCookie, getCookie, setCookie } from 'cookies-next';
-import { add } from 'date-fns';
+import { deleteCookie, getCookie } from 'cookies-next';
 import { NextPageContext } from 'next';
 import { useRouter } from 'next/router';
 import { useEffect, useRef } from 'react';
@@ -39,16 +38,7 @@ export default function Login({ sessionToken }: LoginProps) {
     }
   }, [sessionToken, setToken]);
 
-  if (
-    router.query.intended &&
-    (router.query.intended as string).startsWith('/')
-  ) {
-    setCookie(IntendedRouteStorageKey, router.query.intended, {
-      expires: add(new Date(), {
-        seconds: IntendedRouteExpiryInSeconds,
-      }),
-    });
-  }
+  usePersistIntendedRoute(router.query.intended);
 
   if (hasUser && typeof window !== 'undefined') {
     const intendedRoute = getCookie(IntendedRouteStorageKey)?.toString();

--- a/apps/reflekt/pages/login.tsx
+++ b/apps/reflekt/pages/login.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 import { Typography } from '@mui/material';
 import {
-  IntendedRouteExpiryInSeconds,
   IntendedRouteStorageKey,
   LoginFormContainer,
+  usePersistIntendedRoute,
   useUser,
 } from '@wepublish/authentication/website';
 import { getApiUrl, handleJwtLogin } from '@wepublish/utils/website';
@@ -12,8 +12,7 @@ import {
   SessionWithTokenWithoutUser,
 } from '@wepublish/website/api';
 import { useWebsiteBuilder } from '@wepublish/website/builder';
-import { deleteCookie, getCookie, setCookie } from 'cookies-next';
-import { add } from 'date-fns';
+import { deleteCookie, getCookie } from 'cookies-next';
 import { NextPageContext } from 'next';
 import { useRouter } from 'next/router';
 import { useEffect, useRef } from 'react';
@@ -39,16 +38,7 @@ export default function Login({ sessionToken }: LoginProps) {
     }
   }, [sessionToken, setToken]);
 
-  if (
-    router.query.intended &&
-    (router.query.intended as string).startsWith('/')
-  ) {
-    setCookie(IntendedRouteStorageKey, router.query.intended, {
-      expires: add(new Date(), {
-        seconds: IntendedRouteExpiryInSeconds,
-      }),
-    });
-  }
+  usePersistIntendedRoute(router.query.intended);
 
   if (hasUser && typeof window !== 'undefined') {
     const intendedRoute = getCookie(IntendedRouteStorageKey)?.toString();

--- a/apps/tsri/pages/login.tsx
+++ b/apps/tsri/pages/login.tsx
@@ -1,17 +1,16 @@
 import styled from '@emotion/styled';
 import { Typography } from '@mui/material';
 import {
-  IntendedRouteExpiryInSeconds,
   IntendedRouteStorageKey,
   LoginFormContainer,
+  usePersistIntendedRoute,
   useUser,
 } from '@wepublish/authentication/website';
 import { getApiUrl, handleJwtLogin } from '@wepublish/utils/website';
 import { SessionWithTokenWithoutUser } from '@wepublish/website/api';
 import { getApiClient } from '@wepublish/website/api';
 import { useWebsiteBuilder } from '@wepublish/website/builder';
-import { deleteCookie, getCookie, setCookie } from 'cookies-next';
-import { add } from 'date-fns';
+import { deleteCookie, getCookie } from 'cookies-next';
 import { NextPageContext } from 'next';
 import { useRouter } from 'next/router';
 import { useEffect, useRef } from 'react';
@@ -38,16 +37,7 @@ export default function Login({ sessionToken }: LoginProps) {
     }
   }, [sessionToken, setToken]);
 
-  if (
-    router.query.intended &&
-    (router.query.intended as string).startsWith('/')
-  ) {
-    setCookie(IntendedRouteStorageKey, router.query.intended, {
-      expires: add(new Date(), {
-        seconds: IntendedRouteExpiryInSeconds,
-      }),
-    });
-  }
+  usePersistIntendedRoute(router.query.intended);
 
   if (hasUser && typeof window !== 'undefined') {
     const intendedRoute = getCookie(IntendedRouteStorageKey)?.toString();

--- a/apps/website-example/pages/login.tsx
+++ b/apps/website-example/pages/login.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 import { Typography } from '@mui/material';
 import {
-  IntendedRouteExpiryInSeconds,
   IntendedRouteStorageKey,
   LoginFormContainer,
+  usePersistIntendedRoute,
   useUser,
 } from '@wepublish/authentication/website';
 import { getApiUrl, handleJwtLogin } from '@wepublish/utils/website';
@@ -12,8 +12,7 @@ import {
   SessionWithTokenWithoutUser,
 } from '@wepublish/website/api';
 import { useWebsiteBuilder } from '@wepublish/website/builder';
-import { deleteCookie, getCookie, setCookie } from 'cookies-next';
-import { add } from 'date-fns';
+import { deleteCookie, getCookie } from 'cookies-next';
 import { NextPageContext } from 'next';
 import { useRouter } from 'next/router';
 import { useEffect, useRef } from 'react';
@@ -39,16 +38,7 @@ export default function Login({ sessionToken }: LoginProps) {
     }
   }, [sessionToken, setToken]);
 
-  if (
-    router.query.intended &&
-    (router.query.intended as string).startsWith('/')
-  ) {
-    setCookie(IntendedRouteStorageKey, router.query.intended, {
-      expires: add(new Date(), {
-        seconds: IntendedRouteExpiryInSeconds,
-      }),
-    });
-  }
+  usePersistIntendedRoute(router.query.intended);
 
   if (hasUser && typeof window !== 'undefined') {
     const intendedRoute = getCookie(IntendedRouteStorageKey)?.toString();

--- a/apps/wnti/pages/login.tsx
+++ b/apps/wnti/pages/login.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 import { Typography } from '@mui/material';
 import {
-  IntendedRouteExpiryInSeconds,
   IntendedRouteStorageKey,
   LoginFormContainer,
+  usePersistIntendedRoute,
   useUser,
 } from '@wepublish/authentication/website';
 import { getApiUrl, handleJwtLogin } from '@wepublish/utils/website';
@@ -12,8 +12,7 @@ import {
   SessionWithTokenWithoutUser,
 } from '@wepublish/website/api';
 import { useWebsiteBuilder } from '@wepublish/website/builder';
-import { deleteCookie, getCookie, setCookie } from 'cookies-next';
-import { add } from 'date-fns';
+import { deleteCookie, getCookie } from 'cookies-next';
 import { NextPageContext } from 'next';
 import { useRouter } from 'next/router';
 import { useEffect, useRef } from 'react';
@@ -39,16 +38,7 @@ export default function Login({ sessionToken }: LoginProps) {
     }
   }, [sessionToken, setToken]);
 
-  if (
-    router.query.intended &&
-    (router.query.intended as string).startsWith('/')
-  ) {
-    setCookie(IntendedRouteStorageKey, router.query.intended, {
-      expires: add(new Date(), {
-        seconds: IntendedRouteExpiryInSeconds,
-      }),
-    });
-  }
+  usePersistIntendedRoute(router.query.intended);
 
   if (hasUser && typeof window !== 'undefined') {
     const intendedRoute = getCookie(IntendedRouteStorageKey)?.toString();

--- a/libs/authentication/website/src/lib/auth.constants.ts
+++ b/libs/authentication/website/src/lib/auth.constants.ts
@@ -1,2 +1,2 @@
 export const IntendedRouteStorageKey = 'auth.intended';
-export const IntendedRouteExpiryInSeconds = 5 * 60;
+export const IntendedRouteExpiryInSeconds = 30 * 60;

--- a/libs/authentication/website/src/lib/use-set-intended-auth.spec.tsx
+++ b/libs/authentication/website/src/lib/use-set-intended-auth.spec.tsx
@@ -1,0 +1,72 @@
+import { renderHook } from '@testing-library/react';
+import {
+  IntendedRouteExpiryInSeconds,
+  IntendedRouteStorageKey,
+} from './auth.constants';
+import {
+  createIntendedRouteCookieOptions,
+  isValidIntendedRoute,
+  setIntendedRouteCookie,
+  usePersistIntendedRoute,
+} from './use-set-intended-auth';
+
+const clearIntendedRouteCookie = () => {
+  document.cookie = `${IntendedRouteStorageKey}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`;
+};
+
+const getIntendedRouteCookie = () => {
+  const value = document.cookie
+    .split('; ')
+    .find(cookie => cookie.startsWith(`${IntendedRouteStorageKey}=`))
+    ?.split('=')
+    .slice(1)
+    .join('=');
+
+  return value ? decodeURIComponent(value) : undefined;
+};
+
+describe('intended auth route', () => {
+  beforeEach(() => {
+    clearIntendedRouteCookie();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    clearIntendedRouteCookie();
+  });
+
+  it('keeps the intended route long enough for the email login flow', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-06-16T12:00:00.000Z'));
+
+    expect(createIntendedRouteCookieOptions()).toEqual({
+      expires: new Date('2026-06-16T12:30:00.000Z'),
+    });
+    expect(IntendedRouteExpiryInSeconds).toBe(30 * 60);
+  });
+
+  it('accepts only a string path from the query value', () => {
+    expect(isValidIntendedRoute('/mitmachen')).toBe(true);
+    expect(isValidIntendedRoute('/mitmachen?mail=user@example.com')).toBe(true);
+    expect(isValidIntendedRoute('https://example.com/mitmachen')).toBe(false);
+    expect(isValidIntendedRoute(['/mitmachen'])).toBe(false);
+    expect(isValidIntendedRoute(undefined)).toBe(false);
+  });
+
+  it('persists the intended query route from an effect', () => {
+    renderHook(() => usePersistIntendedRoute('/mitmachen'));
+
+    expect(getIntendedRouteCookie()).toBe('/mitmachen');
+  });
+
+  it('ignores invalid query route values', () => {
+    renderHook(() => usePersistIntendedRoute(['https://example.com']));
+
+    expect(getIntendedRouteCookie()).toBeUndefined();
+  });
+
+  it('sets the intended route cookie directly', () => {
+    setIntendedRouteCookie('/mitmachen?mail=user@example.com');
+
+    expect(getIntendedRouteCookie()).toBe('/mitmachen?mail=user@example.com');
+  });
+});

--- a/libs/authentication/website/src/lib/use-set-intended-auth.tsx
+++ b/libs/authentication/website/src/lib/use-set-intended-auth.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import {
   IntendedRouteExpiryInSeconds,
   IntendedRouteStorageKey,
@@ -7,12 +7,36 @@ import { add } from 'date-fns';
 // we only use the client side implementation which isn't next specific
 import { setCookie } from 'cookies-next';
 
+export const isValidIntendedRoute = (
+  intendedRoute: unknown
+): intendedRoute is string => {
+  return typeof intendedRoute === 'string' && intendedRoute.startsWith('/');
+};
+
+export const createIntendedRouteCookieOptions = () => ({
+  expires: add(new Date(), {
+    seconds: IntendedRouteExpiryInSeconds,
+  }),
+});
+
+export const setIntendedRouteCookie = (intendedRoute: string) => {
+  setCookie(
+    IntendedRouteStorageKey,
+    intendedRoute,
+    createIntendedRouteCookieOptions()
+  );
+};
+
+export const usePersistIntendedRoute = (intendedRoute: unknown) => {
+  useEffect(() => {
+    if (isValidIntendedRoute(intendedRoute)) {
+      setIntendedRouteCookie(intendedRoute);
+    }
+  }, [intendedRoute]);
+};
+
 export const useSetIntendedRoute = () => {
   return useCallback(() => {
-    setCookie(IntendedRouteStorageKey, window.location.pathname, {
-      expires: add(new Date(), {
-        seconds: IntendedRouteExpiryInSeconds,
-      }),
-    });
+    setIntendedRouteCookie(window.location.pathname);
   }, []);
 };

--- a/libs/errors/website/src/lib/api-alert.spec.tsx
+++ b/libs/errors/website/src/lib/api-alert.spec.tsx
@@ -1,0 +1,15 @@
+import { createLoginLink } from './api-alert';
+
+describe('createLoginLink', () => {
+  it('adds the intended route query with the correct spelling', () => {
+    expect(createLoginLink('/mitmachen', '')).toBe(
+      '/login?intended=%2Fmitmachen'
+    );
+  });
+
+  it('keeps the full current route encoded as one intended route value', () => {
+    expect(createLoginLink('/mitmachen', '?mail=user@example.com')).toBe(
+      '/login?intended=%2Fmitmachen%3Fmail%3Duser%40example.com'
+    );
+  });
+});

--- a/libs/errors/website/src/lib/api-alert.tsx
+++ b/libs/errors/website/src/lib/api-alert.tsx
@@ -8,6 +8,14 @@ enum ErrorMessage {
   EmailAlreadyInUse = 'Email already in use',
 }
 
+export const createLoginLink = (pathname: string, search: string) => {
+  const query = new URLSearchParams({
+    intended: `${pathname}${search}`,
+  });
+
+  return `/login?${query.toString()}`;
+};
+
 export function translateApolloErrorMessage(
   errorMessage: string
 ): string | undefined {
@@ -26,7 +34,7 @@ export function ApiAlert({ error, ...props }: BuilderApiAlertProps) {
 
   const loginLink =
     typeof window !== 'undefined' ?
-      `/login?inteded=${window.location.pathname}${window.location.search}`
+      createLoginLink(window.location.pathname, window.location.search)
     : `/login`;
 
   return (


### PR DESCRIPTION
This is a focused follow-up to #2819 and targets the feature branch, not `master`.

It addresses the current review comments by:

- moving the `intended` query cookie write out of render and into an auth hook effect
- centralizing intended-route validation and cookie persistence in `@wepublish/authentication/website`
- correcting `inteded` to `intended` in the duplicate-account login link and encoding the current route as one query value
- extending the intended-route cookie lifetime to 30 minutes so the email-login round trip has enough time
- adding focused tests for intended-route persistence and login-link construction

Local validation run with `NODE_OPTIONS=--max-old-space-size=6144` and `NX_DAEMON=false`:

- `npx nx test authentication-website --runInBand --skip-nx-cache`
- `npx nx test errors-website --runInBand --skip-nx-cache`
- `npx nx run-many -t lint --projects=babanews,bajour,eenews,fazetten,flimmer,ganzgraz,gruppetto,hauptstadt,mannschaft,mediamakerscamp,munotgloeggli,onlinereports,reflekt,tsri,website-example,wnti,authentication-website,errors-website --parallel=1 --skip-nx-cache`
- `bash ./tools/typecheck-websites.sh`

Notes:

- Lint completed successfully; it printed existing warnings in unrelated files, but no lint errors and no warnings in the edited login/auth/error files.
- The first full `authentication-website` test run hit a transient registration story timeout; the failing story passed in isolation, and the full target passed on rerun.