### PR TITLE
improve(deployment-dashboard): render in separate repo

### DIFF
--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -1,74 +1,52 @@
 name: Deploy overview dashboard
 
 on:
-  # Rebuild the moment a production deploy is tagged. This is also when the
-  # deploy commit is still the tip of its source branch, so the branch label
-  # gets captured and persisted before later work moves the branch on.
-  #
-  # NOTE: for a tag push, GitHub runs this workflow as it exists in the *tagged
-  # commit*, so a deploy only self-triggers once its commit contains this file
-  # (immediately for deploys off `development`; for `master`/feature branches
-  # once they pick up the merge). The dashboard always reads the latest run per
-  # project, so a missed trigger is corrected by the next deploy that fires.
   push:
     tags:
       - 'deploy_*'
-  # Manual trigger (runs from the default branch).
   workflow_dispatch:
 
-# The page is generated into docs/deploy/ and committed to `development`, where
-# the repo's legacy GitHub Pages site serves it at <pages-url>/deploy/.
 permissions:
-  contents: write
-  actions: read
+  contents: read     # checkout + read own commits/branches (branches-where-head)
+  actions: read      # read own workflow runs
 
-# Serialize runs so two near-simultaneous deploys don't race on the push.
 concurrency:
   group: deploy-dashboard
   cancel-in-progress: false
 
 jobs:
-  build:
+  build-and-publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          # Always commit to the default branch (Pages source), regardless of
-          # the tag that triggered the run. Full history keeps the rebase below
-          # reliable.
-          ref: development
-          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
 
+      # Load the deploy key so we can clone/push the publish repo over SSH.
+      - uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.DASHBOARD_DEPLOY_KEY }}
+
+      - name: Clone publish repo
+        run: git clone --depth 1 git@github.com:wepublish/deploy-dashboard.git publish
+
       - name: Build dashboard
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}   # default token reads THIS repo's runs
+          OUT_DIR: publish                            # writes publish/index.html AND reads the prior one for the branch store
         run: node deployment/dashboard/build-deploy-dashboard.mjs
 
-      - name: Commit dashboard if changed
+      - name: Commit & push to publish repo
         run: |
+          cd publish
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add docs/deploy
-          # --cached so a brand-new (untracked) docs/deploy/index.html counts as
-          # a change too; plain `git diff` would ignore it.
+          git add index.html
           if git diff --cached --quiet; then
-            echo "No dashboard changes — nothing to commit."
+            echo "No dashboard changes — nothing to publish."
             exit 0
           fi
-          git commit -m "chore(dashboard): update production deploy overview [skip ci]"
-          # Rebase + retry in case development advanced since checkout; the
-          # branch ruleset rejects non-fast-forward pushes.
-          for attempt in 1 2 3; do
-            if git pull --rebase origin development && git push origin HEAD:development; then
-              echo "Pushed dashboard update."
-              exit 0
-            fi
-            echo "Push attempt $attempt failed; retrying…"
-            sleep 5
-          done
-          echo "Failed to push dashboard update after 3 attempts." >&2
-          exit 1
+          git commit -m "Update production deploy overview"
+          git push origin HEAD:main


### PR DESCRIPTION
 --> avoid having to open PRs on wepublish/wepublish repo just to render the updated dashboard