### PR TITLE
refactor(api): remove tagged articles filtering from article queries

### DIFF
--- a/libs/article/api/src/lib/__snapshots__/article.service.spec.ts.snap
+++ b/libs/article/api/src/lib/__snapshots__/article.service.spec.ts.snap
@@ -265,7 +265,9 @@ exports[`ArticleService should query articles based on filter 2`] = `
       "AND": [
         {
           "id": {
-            "in": [],
+            "in": [
+              "12345",
+            ],
           },
         },
         {
@@ -361,6 +363,19 @@ exports[`ArticleService should query articles based on filter 2`] = `
         },
         {
           "shared": true,
+        },
+        {
+          "tags": {
+            "some": {
+              "tag": {
+                "id": {
+                  "in": [
+                    "1234",
+                  ],
+                },
+              },
+            },
+          },
         },
         {
           "ArticleRevisionDraft": {
@@ -459,7 +474,9 @@ exports[`ArticleService should query articles based on filter 3`] = `
       "AND": [
         {
           "id": {
-            "in": [],
+            "in": [
+              "12345",
+            ],
           },
         },
         {
@@ -555,6 +572,19 @@ exports[`ArticleService should query articles based on filter 3`] = `
         },
         {
           "shared": true,
+        },
+        {
+          "tags": {
+            "some": {
+              "tag": {
+                "id": {
+                  "in": [
+                    "1234",
+                  ],
+                },
+              },
+            },
+          },
         },
         {
           "ArticleRevisionDraft": {
@@ -683,6 +713,7 @@ exports[`ArticleService should query articles based on full text search 2`] = `
           "id": {
             "in": [
               "1234",
+              "1235",
             ],
           },
         },
@@ -779,6 +810,19 @@ exports[`ArticleService should query articles based on full text search 2`] = `
         },
         {
           "shared": true,
+        },
+        {
+          "tags": {
+            "some": {
+              "tag": {
+                "id": {
+                  "in": [
+                    "1234",
+                  ],
+                },
+              },
+            },
+          },
         },
         {
           "ArticleRevisionDraft": {
@@ -879,6 +923,7 @@ exports[`ArticleService should query articles based on full text search 3`] = `
           "id": {
             "in": [
               "1234",
+              "1235",
             ],
           },
         },
@@ -975,6 +1020,19 @@ exports[`ArticleService should query articles based on full text search 3`] = `
         },
         {
           "shared": true,
+        },
+        {
+          "tags": {
+            "some": {
+              "tag": {
+                "id": {
+                  "in": [
+                    "1234",
+                  ],
+                },
+              },
+            },
+          },
         },
         {
           "ArticleRevisionDraft": {
@@ -1101,7 +1159,9 @@ exports[`ArticleService should query articles on all revisions 2`] = `
       "AND": [
         {
           "id": {
-            "in": [],
+            "in": [
+              "12345",
+            ],
           },
         },
         {
@@ -1155,6 +1215,19 @@ exports[`ArticleService should query articles on all revisions 2`] = `
         },
         {
           "shared": true,
+        },
+        {
+          "tags": {
+            "some": {
+              "tag": {
+                "id": {
+                  "in": [
+                    "1234",
+                  ],
+                },
+              },
+            },
+          },
         },
         {
           "ArticleRevisionDraft": undefined,
@@ -1203,7 +1276,9 @@ exports[`ArticleService should query articles on all revisions 3`] = `
       "AND": [
         {
           "id": {
-            "in": [],
+            "in": [
+              "12345",
+            ],
           },
         },
         {
@@ -1257,6 +1332,19 @@ exports[`ArticleService should query articles on all revisions 3`] = `
         },
         {
           "shared": true,
+        },
+        {
+          "tags": {
+            "some": {
+              "tag": {
+                "id": {
+                  "in": [
+                    "1234",
+                  ],
+                },
+              },
+            },
+          },
         },
         {
           "ArticleRevisionDraft": undefined,

--- a/libs/article/api/src/lib/article.service.spec.ts
+++ b/libs/article/api/src/lib/article.service.spec.ts
@@ -93,9 +93,6 @@ describe('ArticleService', () => {
   it('should query articles based on filter', async () => {
     prismaMock.article.findMany?.mockResolvedValue([]);
     prismaMock.$queryRaw.mockResolvedValue([{ id: '1234' }, { id: '1235' }]);
-    prismaMock.taggedArticles.findMany?.mockResolvedValue([
-      { articleId: '1234' },
-    ]);
 
     await service.getArticles({
       filter: {
@@ -135,9 +132,6 @@ describe('ArticleService', () => {
   it('should query articles based on full text search', async () => {
     prismaMock.article.findMany?.mockResolvedValue([]);
     prismaMock.$queryRaw.mockResolvedValue([{ id: '1234' }, { id: '1235' }]);
-    prismaMock.taggedArticles.findMany?.mockResolvedValue([
-      { articleId: '1234' },
-    ]);
 
     await service.getArticles({
       filter: {
@@ -177,9 +171,6 @@ describe('ArticleService', () => {
   it('should query articles on all revisions', async () => {
     prismaMock.article.findMany?.mockResolvedValue([]);
     prismaMock.$queryRaw.mockResolvedValue([]);
-    prismaMock.taggedArticles.findMany?.mockResolvedValue([
-      { articleId: '1234' },
-    ]);
 
     await service.getArticles({
       filter: {

--- a/libs/article/api/src/lib/article.service.ts
+++ b/libs/article/api/src/lib/article.service.ts
@@ -57,21 +57,6 @@ export class ArticleService {
       }
     }
 
-    if (filter?.tags?.length) {
-      const taggedArticles = await this.prisma.taggedArticles.findMany({
-        where: { tagId: { in: filter.tags } },
-        select: { articleId: true },
-        distinct: ['articleId'],
-      });
-
-      const tagArticleIds = taggedArticles.map(ta => ta.articleId);
-      filter.ids =
-        filter.ids?.length ?
-          filter.ids.filter(id => tagArticleIds.includes(id))
-        : tagArticleIds;
-      filter.tags = undefined;
-    }
-
     const orderBy = createArticleOrder(sort, order);
     const where = createArticleFilter(filter ?? {});
 


### PR DESCRIPTION
The removed code ran a separate pre-query against the `taggedArticles` table to resolve which article IDs matched the requested tags, then narrowed `filter.ids` to that list manually. This is unnecessary because `createArticleFilter`, via `createTagsFilter`, already adds the tag condition directly into the main article query as a Prisma relation filter (`tags.some.tag.id.in`). So a single database query now handles the tag filtering, eliminating the extra round-trip and a query with an `IN` clause containing up to 23'000 ids.