### PR TITLE
perf(api): Use JOINs instead of running separate queries

### DIFF
--- a/libs/api/prisma/migrations/20260701204255_add_covering_index_to_tagged_articles/migration.sql
+++ b/libs/api/prisma/migrations/20260701204255_add_covering_index_to_tagged_articles/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "articles.tagged-articles_tagId_articleId_idx" ON "articles.tagged-articles"("tagId", "articleId");

--- a/libs/api/prisma/migrations/20260703144518_add_trigram_index_to_slugs/migration.sql
+++ b/libs/api/prisma/migrations/20260703144518_add_trigram_index_to_slugs/migration.sql
@@ -1,0 +1,6 @@
+-- This is an empty migration.
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX "articles_slug_trgm_idx" ON "articles" USING gin ("slug" gin_trgm_ops);
+CREATE INDEX "pages_slug_trgm_idx" ON "pages" USING gin ("slug" gin_trgm_ops);

--- a/libs/api/prisma/schema.prisma
+++ b/libs/api/prisma/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider        = "prisma-client-js"
-  previewFeatures = ["views"]
+  previewFeatures = ["views", "relationJoins"]
 }
 
 datasource db {

--- a/libs/api/prisma/schema.prisma
+++ b/libs/api/prisma/schema.prisma
@@ -177,6 +177,7 @@ model TaggedArticles {
 
   @@id([articleId, tagId])
   @@index([tagId])
+  @@index([tagId, articleId])
   @@map("articles.tagged-articles")
 }
 

--- a/libs/article/api/src/lib/__snapshots__/article-revision-dataloader.service.spec.ts.snap
+++ b/libs/article/api/src/lib/__snapshots__/article-revision-dataloader.service.spec.ts.snap
@@ -21,6 +21,7 @@ exports[`ArticleRevisionDataloaderService load should load many 1`] = `
           },
         },
       },
+      "relationLoadStrategy": "join",
       "where": {
         "id": {
           "in": [
@@ -55,6 +56,7 @@ exports[`ArticleRevisionDataloaderService load should load one 1`] = `
           },
         },
       },
+      "relationLoadStrategy": "join",
       "where": {
         "id": {
           "in": [

--- a/libs/article/api/src/lib/__snapshots__/article.service.spec.ts.snap
+++ b/libs/article/api/src/lib/__snapshots__/article.service.spec.ts.snap
@@ -367,12 +367,10 @@ exports[`ArticleService should query articles based on filter 2`] = `
         {
           "tags": {
             "some": {
-              "tag": {
-                "id": {
-                  "in": [
-                    "1234",
-                  ],
-                },
+              "tagId": {
+                "in": [
+                  "1234",
+                ],
               },
             },
           },
@@ -467,9 +465,6 @@ exports[`ArticleService should query articles based on filter 2`] = `
 exports[`ArticleService should query articles based on filter 3`] = `
 [
   {
-    "orderBy": {
-      "publishedAt": "asc",
-    },
     "where": {
       "AND": [
         {
@@ -576,12 +571,10 @@ exports[`ArticleService should query articles based on filter 3`] = `
         {
           "tags": {
             "some": {
-              "tag": {
-                "id": {
-                  "in": [
-                    "1234",
-                  ],
-                },
+              "tagId": {
+                "in": [
+                  "1234",
+                ],
               },
             },
           },
@@ -814,12 +807,10 @@ exports[`ArticleService should query articles based on full text search 2`] = `
         {
           "tags": {
             "some": {
-              "tag": {
-                "id": {
-                  "in": [
-                    "1234",
-                  ],
-                },
+              "tagId": {
+                "in": [
+                  "1234",
+                ],
               },
             },
           },
@@ -914,9 +905,6 @@ exports[`ArticleService should query articles based on full text search 2`] = `
 exports[`ArticleService should query articles based on full text search 3`] = `
 [
   {
-    "orderBy": {
-      "publishedAt": "asc",
-    },
     "where": {
       "AND": [
         {
@@ -1024,12 +1012,10 @@ exports[`ArticleService should query articles based on full text search 3`] = `
         {
           "tags": {
             "some": {
-              "tag": {
-                "id": {
-                  "in": [
-                    "1234",
-                  ],
-                },
+              "tagId": {
+                "in": [
+                  "1234",
+                ],
               },
             },
           },
@@ -1219,12 +1205,10 @@ exports[`ArticleService should query articles on all revisions 2`] = `
         {
           "tags": {
             "some": {
-              "tag": {
-                "id": {
-                  "in": [
-                    "1234",
-                  ],
-                },
+              "tagId": {
+                "in": [
+                  "1234",
+                ],
               },
             },
           },
@@ -1269,9 +1253,6 @@ exports[`ArticleService should query articles on all revisions 2`] = `
 exports[`ArticleService should query articles on all revisions 3`] = `
 [
   {
-    "orderBy": {
-      "publishedAt": "asc",
-    },
     "where": {
       "AND": [
         {
@@ -1336,12 +1317,10 @@ exports[`ArticleService should query articles on all revisions 3`] = `
         {
           "tags": {
             "some": {
-              "tag": {
-                "id": {
-                  "in": [
-                    "1234",
-                  ],
-                },
+              "tagId": {
+                "in": [
+                  "1234",
+                ],
               },
             },
           },
@@ -1408,9 +1387,6 @@ exports[`ArticleService should query articles using cursor based pagination 1`] 
 exports[`ArticleService should query articles using cursor based pagination 2`] = `
 [
   {
-    "orderBy": {
-      "publishedAt": "desc",
-    },
     "where": {
       "AND": [
         {

--- a/libs/article/api/src/lib/article-revision-dataloader.service.ts
+++ b/libs/article/api/src/lib/article-revision-dataloader.service.ts
@@ -20,6 +20,7 @@ export class ArticleRevisionDataloaderService
   private dataloader = new DataLoader<string, RevisionMap>(
     async (articleIds: readonly string[]) => {
       const articles = await this.prisma.article.findMany({
+        relationLoadStrategy: 'join',
         where: {
           id: {
             in: articleIds as string[],

--- a/libs/article/api/src/lib/article.service.ts
+++ b/libs/article/api/src/lib/article.service.ts
@@ -68,7 +68,6 @@ export class ArticleService {
     const [totalCount, articles] = await Promise.all([
       this.prisma.article.count({
         where,
-        orderBy,
       }),
       this.prisma.article.findMany({
         where,

--- a/libs/article/api/src/lib/article.service.ts
+++ b/libs/article/api/src/lib/article.service.ts
@@ -982,10 +982,8 @@ const createTagsFilter = (
   if (filter?.tags?.length) {
     const hasTags = {
       some: {
-        tag: {
-          id: {
-            in: filter.tags,
-          },
+        tagId: {
+          in: filter.tags,
         },
       },
     } satisfies Prisma.TaggedArticlesListRelationFilter;
@@ -1004,10 +1002,8 @@ const createTagsNotInFilter = (
   if (filter?.tagsNotIn?.length) {
     const hasNotTags = {
       some: {
-        tag: {
-          id: {
-            notIn: filter.tagsNotIn,
-          },
+        tagId: {
+          notIn: filter.tagsNotIn,
         },
       },
     } satisfies Prisma.TaggedArticlesListRelationFilter;

--- a/libs/author/api/src/lib/article-author.dataloader.ts
+++ b/libs/author/api/src/lib/article-author.dataloader.ts
@@ -15,6 +15,7 @@ export class ArticleAuthorDataloader extends DataLoaderService<Author[]> {
     const authors = groupBy(
       author => author.revisionId!,
       await this.prisma.articleRevisionAuthor.findMany({
+        relationLoadStrategy: 'join',
         where: {
           revisionId: {
             in: articleRevisionIds,

--- a/libs/author/api/src/lib/article-social-media-author.dataloader.ts
+++ b/libs/author/api/src/lib/article-social-media-author.dataloader.ts
@@ -17,6 +17,7 @@ export class ArticleSocialMediaAuthorDataloader extends DataLoaderService<
     const authors = groupBy(
       author => author.revisionId!,
       await this.prisma.articleRevisionSocialMediaAuthor.findMany({
+        relationLoadStrategy: 'join',
         where: {
           revisionId: {
             in: articleRevisionIds,

--- a/libs/utils/sentry/config.ts
+++ b/libs/utils/sentry/config.ts
@@ -1,6 +1,7 @@
 /**
  * Shared Sentry configuration options used across all instrumentation variants.
  */
+import type { SpanJSON } from '@sentry/core';
 
 export const getBaseConfig = () => ({
   dsn: process.env.SENTRY_DSN,
@@ -8,6 +9,12 @@ export const getBaseConfig = () => ({
   sendDefaultPii: true,
   tracesSampleRate: process.env.APP_ENVIRONMENT === 'production' ? 0.1 : 1.0,
   release: process.env.APP_RELEASE_ID,
+  beforeSendSpan: (span: SpanJSON) => {
+    if (process.env.APP_NAME) {
+      span.data.app_name = process.env.APP_NAME;
+    }
+    return span;
+  },
 });
 
 export const setCommonTags = (

--- a/libs/utils/sentry/instrumentation.nextjs.ts
+++ b/libs/utils/sentry/instrumentation.nextjs.ts
@@ -17,8 +17,9 @@ export async function register() {
     Sentry.init({
       ...getBaseConfig(),
       integrations: [nodeProfilingIntegration()],
-      profilesSampleRate:
-        process.env.APP_ENVIRONMENT === 'production' ? 0.05 : 1.0,
+      profileLifecycle: 'trace',
+      profileSessionSampleRate:
+        process.env.APP_ENVIRONMENT === 'production' ? 0.1 : 1.0,
     });
 
     setCommonTags(Sentry, 'nextjs-server');


### PR DESCRIPTION
Prisma runs separate queries if not explicitely asked to use JOINS. This overloads the connection pools and leads to long staggered queries.