### PR TITLE
fix(website): image block calculation can be wrong sometimes

### DIFF
--- a/jest.setup-tests.ts
+++ b/jest.setup-tests.ts
@@ -35,3 +35,9 @@ global.console.error = (message, ...optionalParams) => {
 if (global.fetch === undefined) {
   global.fetch = fetch;
 }
+
+global.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};

--- a/libs/block-content/website/src/lib/image/contained-image-size.ts
+++ b/libs/block-content/website/src/lib/image/contained-image-size.ts
@@ -1,18 +1,21 @@
-export function getContainedImageSize(img: HTMLImageElement): [number, number] {
+export function getContainedImageSize(
+  img: HTMLImageElement,
+  availableWidth = Number.POSITIVE_INFINITY
+): [number, number] {
+  const boxWidth = Math.min(img.width, availableWidth);
+  const boxHeight = img.height;
   const ratio = img.naturalWidth / img.naturalHeight;
 
-  let width = img.height * ratio;
-  let height = img.height;
-
-  if (width > img.width) {
-    width = img.width;
-    height = img.width / ratio;
+  if (!Number.isFinite(ratio) || ratio <= 0) {
+    return [boxWidth, boxHeight];
   }
 
-  const parentWidth = img.parentElement?.clientWidth ?? 0;
+  let width = boxHeight * ratio;
+  let height = boxHeight;
 
-  if (width > parentWidth) {
-    width = parentWidth;
+  if (width > boxWidth) {
+    width = boxWidth;
+    height = boxWidth / ratio;
   }
 
   return [width, height] as const;

--- a/libs/block-content/website/src/lib/image/image-block.tsx
+++ b/libs/block-content/website/src/lib/image/image-block.tsx
@@ -40,6 +40,7 @@ export const ImageBlockImage = styled(Image)`
 
 export const ImageBlockCaption = styled('figcaption')`
   max-width: 100%;
+  overflow-wrap: anywhere;
 `;
 
 export const ImageBlockSource = styled('span')``;
@@ -51,6 +52,7 @@ export const ImageBlock = ({
   className,
 }: BuilderImageBlockProps) => {
   const [realImageWidth, setRealImageWidth] = useState<number>();
+  const wrapperRef = useRef<HTMLElement>(null);
   const imageRef = useRef<HTMLImageElement>(null);
   const captionRef = useRef<HTMLElement>(null);
   const img = image && (
@@ -62,31 +64,63 @@ export const ImageBlock = ({
   );
 
   useEffect(() => {
+    const imageElement = imageRef.current;
+    const wrapper = wrapperRef.current;
+
+    if (!imageElement || !wrapper) {
+      return;
+    }
+
     const calcImageSize = () => {
-      if (imageRef.current && captionRef.current) {
-        captionRef.current.setAttribute('style', 'display: none;');
-        const [newImageWidth] = getContainedImageSize(imageRef.current);
+      const caption = captionRef.current;
+      caption?.setAttribute('style', 'width:initial;');
 
-        if (realImageWidth !== newImageWidth) {
-          setRealImageWidth(newImageWidth);
-        }
+      const { paddingLeft, paddingRight } = window.getComputedStyle(wrapper);
+      const wrapperWidth =
+        wrapper.clientWidth -
+        (parseFloat(paddingLeft) || 0) -
+        (parseFloat(paddingRight) || 0);
 
-        captionRef.current.setAttribute('style', '');
-      }
+      // blocks can break out of their container with negative margins, so the
+      // wrapper itself can be wider than the visible page. clientWidth of the
+      // document excludes the scrollbar, unlike 100vw.
+      const viewportWidth = document.documentElement.clientWidth;
+      const { left, right } = wrapper.getBoundingClientRect();
+      const visibleWidth = Math.min(right, viewportWidth) - Math.max(left, 0);
+      const availableWidth = Math.min(wrapperWidth, visibleWidth);
+
+      const [newImageWidth] = getContainedImageSize(
+        imageElement,
+        availableWidth
+      );
+
+      caption?.removeAttribute('style');
+
+      setRealImageWidth(currentImageWidth =>
+        newImageWidth > 0 ? Math.floor(newImageWidth) : currentImageWidth
+      );
     };
 
     calcImageSize();
+
+    const observer = new ResizeObserver(calcImageSize);
+    observer.observe(wrapper);
+
     window.addEventListener('resize', calcImageSize);
-    imageRef.current?.addEventListener('load', calcImageSize);
+    imageElement.addEventListener('load', calcImageSize);
 
     return () => {
+      observer.disconnect();
       window.removeEventListener('resize', calcImageSize);
-      imageRef.current?.removeEventListener('load', calcImageSize);
+      imageElement.removeEventListener('load', calcImageSize);
     };
-  }, [realImageWidth]);
+  }, []);
 
   return (
-    <ImageBlockWrapper className={className}>
+    <ImageBlockWrapper
+      ref={wrapperRef}
+      className={className}
+    >
       <ImageBlockInnerWrapper>
         {linkUrl ?
           <Link


### PR DESCRIPTION
- margin-left and margin-right in minus can cause the element to be bigger than the viewport but are actually correct (e.g. Hauptstadt)
- parent can change size without a resize of parent so we need to check for that too
- scrollbar was not calculated in
- display: none; while recalculating came too late and didn't reset the width so running calculations on that was wrong
