### PR TITLE
feat(editor): bake EXIF rotation data into uploaded images

### DIFF
--- a/libs/media/api/src/lib/media-service/media.service.spec.ts
+++ b/libs/media/api/src/lib/media-service/media.service.spec.ts
@@ -381,6 +381,27 @@ describe('MediaService images', () => {
       .png()
       .toBuffer();
 
+  const createRotatedJpeg = () =>
+    sharp({
+      create: {
+        width: 8,
+        height: 4,
+        channels: 3,
+        background: { r: 200, g: 100, b: 50 },
+      },
+    })
+      .jpeg()
+      .withMetadata({ orientation: 6 })
+      .toBuffer();
+
+  const collectStream = async (stream: Readable) => {
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) {
+      chunks.push(chunk as Buffer);
+    }
+    return Buffer.concat(chunks);
+  };
+
   it('stores the uploaded image with its own content type', async () => {
     const { service, storage } = createService();
 
@@ -403,5 +424,39 @@ describe('MediaService images', () => {
     expect(storage.contentTypeOf(TRANSFORMATION_BUCKET, uri)).toBe(
       'image/webp'
     );
+  });
+
+  it('bakes the exif orientation into the stored image', async () => {
+    const { service, storage } = createService();
+
+    const returned = await service.saveImage(
+      'image-2',
+      await createRotatedJpeg()
+    );
+
+    const stored = await collectStream(
+      await storage.getFile(UPLOAD_BUCKET, 'images/image-2')
+    );
+    const metadata = await sharp(stored).metadata();
+    expect(metadata.width).toBe(4);
+    expect(metadata.height).toBe(8);
+    expect(metadata.orientation ?? 1).toBe(1);
+    expect(returned.width).toBe(4);
+    expect(returned.height).toBe(8);
+    expect(storage.contentTypeOf(UPLOAD_BUCKET, 'images/image-2')).toBe(
+      'image/jpeg'
+    );
+  });
+
+  it('stores an image without exif orientation byte-identical', async () => {
+    const { service, storage } = createService();
+    const image = await createImage();
+
+    await service.saveImage('image-3', image);
+
+    const stored = await collectStream(
+      await storage.getFile(UPLOAD_BUCKET, 'images/image-3')
+    );
+    expect(stored.equals(image)).toBe(true);
   });
 });

--- a/libs/media/api/src/lib/media-service/media.service.ts
+++ b/libs/media/api/src/lib/media-service/media.service.ts
@@ -285,11 +285,23 @@ export class MediaService {
   }
 
   public async saveImage(imageId: string, image: Buffer) {
-    const metadata = await sharp(image).metadata();
+    let buffer = image;
+    let metadata = await sharp(image).metadata();
+
+    const isAnimated = (metadata.pages ?? 1) > 1;
+    if (metadata.orientation && metadata.orientation > 1 && !isAnimated) {
+      const pipeline = sharp(image).rotate().withMetadata();
+      if (metadata.format === 'jpeg') {
+        pipeline.jpeg({ quality: 95, mozjpeg: true });
+      }
+      buffer = await pipeline.toBuffer();
+      metadata = await sharp(buffer).metadata();
+    }
+
     await this.storage.saveFile(
       this.config.uploadBucket,
       `images/${imageId}`,
-      image,
+      buffer,
       metadata.size,
       { 'Content-Type': `image/${metadata.format}` }
     );


### PR DESCRIPTION
- images with rotation EXIF data (e.g. shot on iphones) will keep their user-expected orientation after uploading them in the editor