### PR TITLE
fix(tools): make local production-database restore fail-safe

### DIFF
--- a/tools/setup-local-production-database.sh
+++ b/tools/setup-local-production-database.sh
@@ -53,10 +53,22 @@ if [[ -z $PROJECT ]]; then
   exit 99
 fi
 
+IS_TTY=false
+if [[ -t 0 ]]; then
+  IS_TTY=true
+fi
+
 echo "⚠️  WARNING: This will OVERWRITE the existing database! ($DATABASE_URL)"
-read -r -p "Type 'yes' to continue: " CONFIRM
-if [[ "${CONFIRM,,}" != "yes" ]]; then
-  echo "❌ Aborted."
+if [[ "${AUTO_CONFIRM}" == "yes" ]]; then
+  echo "✅  AUTO_CONFIRM=yes - skipping confirmation"
+elif [[ $IS_TTY == true ]]; then
+  read -r -p "Type 'yes' to continue: " CONFIRM
+  if [[ "${CONFIRM,,}" != "yes" ]]; then
+    echo "❌ Aborted."
+    exit 1
+  fi
+else
+  echo "❌  Error: Non-interactive run without AUTO_CONFIRM=yes - aborting." >&2
   exit 1
 fi
 echo "✅  Downloading..."
@@ -80,9 +92,17 @@ echo "✅  Unpack database dump successful"
 # an explicit override.
 if ! tail -n 2 "${TMP_DIR}/database.dump" | grep -q "WEPUBLISH_DUMP_COMPLETE"; then
   echo "⚠️  Warning: dump has no completeness marker - it may be TRUNCATED, or it predates marker support."
-  read -r -p "Restore anyway? Type 'yes' to continue: " CONFIRM_MARKER
-  if [[ "${CONFIRM_MARKER,,}" != "yes" ]]; then
-    echo "❌ Aborted."
+  if [[ "${ALLOW_UNVERIFIED_DUMP}" == "yes" ]]; then
+    echo "⚠️  ALLOW_UNVERIFIED_DUMP=yes - continuing without verification"
+  elif [[ $IS_TTY == true ]]; then
+    read -r -p "Restore anyway? Type 'yes' to continue: " CONFIRM_MARKER
+    if [[ "${CONFIRM_MARKER,,}" != "yes" ]]; then
+      echo "❌ Aborted."
+      rm "${TMP_DIR}/database.dump"
+      exit 1
+    fi
+  else
+    echo "❌  Error: Refusing to restore an unverified dump non-interactively (set ALLOW_UNVERIFIED_DUMP=yes to override)." >&2
     rm "${TMP_DIR}/database.dump"
     exit 1
   fi

--- a/tools/setup-local-production-database.sh
+++ b/tools/setup-local-production-database.sh
@@ -71,13 +71,46 @@ fi
 echo "✅  Download successful (${HTTP_CODE})"
 
 echo "⏳  Unpack database dump..."
-gzip -d "${TMP_DIR}/database.dump.gz"
+gzip -d -f "${TMP_DIR}/database.dump.gz"
 echo "✅  Unpack database dump successful"
 
+# A dump truncated inside a COPY block restores without any error (EOF ends
+# the COPY), silently dropping data and all indexes. The trailing marker is
+# the only reliable truncation check. Old dumps predate the marker, so allow
+# an explicit override.
+if ! tail -n 2 "${TMP_DIR}/database.dump" | grep -q "WEPUBLISH_DUMP_COMPLETE"; then
+  echo "⚠️  Warning: dump has no completeness marker - it may be TRUNCATED, or it predates marker support."
+  read -r -p "Restore anyway? Type 'yes' to continue: " CONFIRM_MARKER
+  if [[ "${CONFIRM_MARKER,,}" != "yes" ]]; then
+    echo "❌ Aborted."
+    rm "${TMP_DIR}/database.dump"
+    exit 1
+  fi
+fi
+
+# Older dumps miss extensions entirely (excluded by --schema=public), and
+# creating them beforehand does not help since the dump drops the public
+# schema (and with it the extension) first. Inject the statement right after
+# the schema is recreated instead.
+if ! grep -q "CREATE EXTENSION IF NOT EXISTS pg_trgm" "${TMP_DIR}/database.dump"; then
+  echo "⏳  Injecting missing pg_trgm extension into dump..."
+  awk '{print} /^CREATE SCHEMA public;$/ && !done {print "CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA public;"; done=1}' \
+    "${TMP_DIR}/database.dump" > "${TMP_DIR}/database.dump.patched" \
+    && mv "${TMP_DIR}/database.dump.patched" "${TMP_DIR}/database.dump"
+fi
+
 echo "⏳  Replacing database: $DATABASE_URL"
-psql "$DATABASE_URL" -f "${TMP_DIR}/database.dump"  1> ${TMP_DIR}/database_restore.log 2>&1
+# ON_ERROR_STOP fails on the first error instead of silently continuing;
+# --single-transaction rolls everything back on failure, so a failed restore
+# can never leave a partial schema behind.
+psql "$DATABASE_URL" --set ON_ERROR_STOP=1 --single-transaction \
+  -f "${TMP_DIR}/database.dump" 1> ${TMP_DIR}/database_restore.log 2>&1
 if [[ $? != 0 ]]; then
-  echo "❌  Error: Replacing database failed see log ${TMP_DIR}/database_restore.log" >&2
+  echo "❌  Error: Replacing database failed, database rolled back to previous state." >&2
+  echo "    See log ${TMP_DIR}/database_restore.log - last lines:" >&2
+  tail -n 5 "${TMP_DIR}/database_restore.log" >&2
+  rm "${TMP_DIR}/database.dump"
+  exit 1
 else
   echo "✅  Replacing database successful"
 fi

--- a/tools/setup-local-production-database.sh
+++ b/tools/setup-local-production-database.sh
@@ -53,22 +53,10 @@ if [[ -z $PROJECT ]]; then
   exit 99
 fi
 
-IS_TTY=false
-if [[ -t 0 ]]; then
-  IS_TTY=true
-fi
-
 echo "⚠️  WARNING: This will OVERWRITE the existing database! ($DATABASE_URL)"
-if [[ "${AUTO_CONFIRM}" == "yes" ]]; then
-  echo "✅  AUTO_CONFIRM=yes - skipping confirmation"
-elif [[ $IS_TTY == true ]]; then
-  read -r -p "Type 'yes' to continue: " CONFIRM
-  if [[ "${CONFIRM,,}" != "yes" ]]; then
-    echo "❌ Aborted."
-    exit 1
-  fi
-else
-  echo "❌  Error: Non-interactive run without AUTO_CONFIRM=yes - aborting." >&2
+read -r -p "Type 'yes' to continue: " CONFIRM
+if [[ "${CONFIRM,,}" != "yes" ]]; then
+  echo "❌ Aborted."
   exit 1
 fi
 echo "✅  Downloading..."
@@ -92,29 +80,22 @@ echo "✅  Unpack database dump successful"
 # an explicit override.
 if ! tail -n 2 "${TMP_DIR}/database.dump" | grep -q "WEPUBLISH_DUMP_COMPLETE"; then
   echo "⚠️  Warning: dump has no completeness marker - it may be TRUNCATED, or it predates marker support."
-  if [[ "${ALLOW_UNVERIFIED_DUMP}" == "yes" ]]; then
-    echo "⚠️  ALLOW_UNVERIFIED_DUMP=yes - continuing without verification"
-  elif [[ $IS_TTY == true ]]; then
-    read -r -p "Restore anyway? Type 'yes' to continue: " CONFIRM_MARKER
-    if [[ "${CONFIRM_MARKER,,}" != "yes" ]]; then
-      echo "❌ Aborted."
-      rm "${TMP_DIR}/database.dump"
-      exit 1
-    fi
-  else
-    echo "❌  Error: Refusing to restore an unverified dump non-interactively (set ALLOW_UNVERIFIED_DUMP=yes to override)." >&2
+  read -r -p "Restore anyway? Type 'yes' to continue: " CONFIRM_MARKER
+  if [[ "${CONFIRM_MARKER,,}" != "yes" ]]; then
+    echo "❌ Aborted."
     rm "${TMP_DIR}/database.dump"
     exit 1
   fi
 fi
 
+# Current dumps declare all extensions of the source database themselves.
 # Older dumps miss extensions entirely (excluded by --schema=public), and
 # creating them beforehand does not help since the dump drops the public
 # schema (and with it the extension) first. Inject the statement right after
 # the schema is recreated instead.
-if ! grep -q "CREATE EXTENSION IF NOT EXISTS pg_trgm" "${TMP_DIR}/database.dump"; then
-  echo "⏳  Injecting missing pg_trgm extension into dump..."
-  awk '{print} /^CREATE SCHEMA public;$/ && !done {print "CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA public;"; done=1}' \
+if ! grep -q "CREATE EXTENSION IF NOT EXISTS" "${TMP_DIR}/database.dump"; then
+  echo "⏳  Old dump without extension declarations - injecting pg_trgm..."
+  awk '{print} /^CREATE SCHEMA public;$/ && !done {print "CREATE EXTENSION IF NOT EXISTS \"pg_trgm\" WITH SCHEMA \"public\" CASCADE;"; done=1}' \
     "${TMP_DIR}/database.dump" > "${TMP_DIR}/database.dump.patched" \
     && mv "${TMP_DIR}/database.dump.patched" "${TMP_DIR}/database.dump"
 fi


### PR DESCRIPTION
- restore with ON_ERROR_STOP and --single-transaction so a failed restore rolls back completely instead of leaving a partial schema, and exit non-zero with the last log lines instead of reporting success
- verify the WEPUBLISH_DUMP_COMPLETE marker before restoring: a dump truncated inside a COPY block restores without errors while silently dropping data and all indexes; dumps predating the marker require explicit confirmation
- inject CREATE EXTENSION pg_trgm into older dumps right after CREATE SCHEMA public: schema-scoped dumps exclude extensions, and creating it up front does not survive the dump's DROP SCHEMA CASCADE

Partial restores are how review/local databases ended up with tables but no indexes, later failing migrate deploy with P3009.