### PR TITLE
fix(wnti): Fix rich text list styles

### DIFF
--- a/apps/flimmer/src/components/flimmer-richtext.tsx
+++ b/apps/flimmer/src/components/flimmer-richtext.tsx
@@ -3,6 +3,6 @@ import { RichTextBlock } from '@wepublish/block-content/website';
 
 export const FlimmerRichText = styled(RichTextBlock)`
   .MuiTypography-body1 {
-    font-size: 1.25em;
+    font-size: 1.25rem;
   }
 `;

--- a/apps/wnti/src/components/tsri-richtext.tsx
+++ b/apps/wnti/src/components/tsri-richtext.tsx
@@ -3,6 +3,6 @@ import { RichTextBlock } from '@wepublish/block-content/website';
 
 export const TsriRichText = styled(RichTextBlock)`
   .MuiTypography-body1 {
-    font-size: 1.25em;
+    font-size: 1.25rem;
   }
 `;


### PR DESCRIPTION
Use `rem` instead of `em` in custom `RichText`. 