### PR TITLE
feat(editor): tell an external app who is in the iframe and which article is open

### DIFF
--- a/apps/editor/src/app/routes/articles/articleEditor.tsx
+++ b/apps/editor/src/app/routes/articles/articleEditor.tsx
@@ -8,6 +8,10 @@ import {
   DialogTitle as MuiDialogTitle,
 } from '@mui/material';
 import {
+  ExternalAppsTarget,
+  useExternalAppsQuery,
+} from '@wepublish/editor/api';
+import {
   CreateArticleMutationVariables,
   EditorBlockType,
   FullAuthorFragment,
@@ -77,6 +81,8 @@ import {
 } from 'rsuite';
 
 import { openPreviewWindow } from '../../openPreview';
+import { AppIcon } from '../externalApps/appIcon';
+import { ExternalAppArticlePanel } from '../externalApps/externalAppArticlePanel';
 
 const IconButtonMarginTop = styled(RIconButton)`
   margin-top: 4px;
@@ -228,6 +234,21 @@ function ArticleEditor() {
   );
 
   const articleID = id || createData?.createArticle.id;
+
+  // External apps that run in an iframe get a button beside the metadata, so
+  // an assistant can look at the article that is open instead of asking which
+  // one it is. The token is minted when the drawer opens, never before: the
+  // editor asks for no token for a tool nobody used.
+  const [openExternalAppId, setOpenExternalAppId] = useState<string | null>(
+    null
+  );
+  const { data: externalAppsData } = useExternalAppsQuery({
+    variables: { filter: { target: ExternalAppsTarget.Iframe } },
+  });
+  const externalApps = externalAppsData?.externalApps ?? [];
+  const openExternalApp = externalApps.find(
+    app => app.id === openExternalAppId
+  );
 
   const {
     data: articleData,
@@ -768,6 +789,21 @@ function ArticleEditor() {
                     {t('articleEditor.overview.metadata')}
                   </RIconButton>
 
+                  {!isNew &&
+                    articleID &&
+                    externalApps.map(app => (
+                      <IconButton
+                        key={app.id}
+                        className="actionButton"
+                        icon={<AppIcon iconName={app.icon} />}
+                        size="lg"
+                        disabled={isDisabled}
+                        onClick={() => setOpenExternalAppId(app.id)}
+                      >
+                        {app.name}
+                      </IconButton>
+                    ))}
+
                   {!isNew && (
                     <>
                       <PermissionControl
@@ -946,6 +982,19 @@ function ArticleEditor() {
             setChanged(true);
           }}
         />
+      </Drawer>
+
+      <Drawer
+        open={!!openExternalApp}
+        size="md"
+        onClose={() => setOpenExternalAppId(null)}
+      >
+        {openExternalApp && articleID && (
+          <ExternalAppArticlePanel
+            app={openExternalApp}
+            articleId={articleID}
+          />
+        )}
       </Drawer>
 
       <Modal

--- a/apps/editor/src/app/routes/dashboard/externalAppsDashboard.tsx
+++ b/apps/editor/src/app/routes/dashboard/externalAppsDashboard.tsx
@@ -13,10 +13,9 @@ import {
   useExternalAppsQuery,
 } from '@wepublish/editor/api';
 import { useTranslation } from 'react-i18next';
-import { MdExtension } from 'react-icons/md';
 import { useNavigate } from 'react-router-dom';
 
-import { ICON_REGISTRY } from '../externalApps/iconRegistry';
+import { AppIcon } from '../externalApps/appIcon';
 
 const AppGrid = styled(Grid)`
   padding: ${({ theme }) => theme.spacing(4)};
@@ -44,19 +43,6 @@ const EmptyText = styled(Typography)`
   padding: ${({ theme }) => theme.spacing(3)};
   text-align: center;
 `;
-
-interface AppIconProps {
-  iconName?: string | null;
-}
-
-function AppIcon({ iconName }: AppIconProps) {
-  if (!iconName || !ICON_REGISTRY[iconName]) {
-    return <MdExtension />;
-  }
-
-  const RegisteredIcon = ICON_REGISTRY[iconName].icon;
-  return <RegisteredIcon />;
-}
 
 export function ExternalAppsDashboard() {
   const { t } = useTranslation();

--- a/apps/editor/src/app/routes/externalApps/appIcon.tsx
+++ b/apps/editor/src/app/routes/externalApps/appIcon.tsx
@@ -1,0 +1,17 @@
+import { MdExtension } from 'react-icons/md';
+
+import { ICON_REGISTRY } from './iconRegistry';
+
+export interface AppIconProps {
+  iconName?: string | null;
+}
+
+/** The icon an external app was registered with, or a generic one. */
+export function AppIcon({ iconName }: AppIconProps) {
+  if (!iconName || !ICON_REGISTRY[iconName]) {
+    return <MdExtension />;
+  }
+
+  const RegisteredIcon = ICON_REGISTRY[iconName].icon;
+  return <RegisteredIcon />;
+}

--- a/apps/editor/src/app/routes/externalApps/externalAppArticlePanel.spec.tsx
+++ b/apps/editor/src/app/routes/externalApps/externalAppArticlePanel.spec.tsx
@@ -1,0 +1,91 @@
+import '@testing-library/jest-dom/vitest';
+import type { Mock } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { ExternalAppArticlePanel } from './externalAppArticlePanel';
+import { useExternalAppSrc } from './useExternalAppSrc';
+
+vi.mock('./useExternalAppSrc', () => ({
+  useExternalAppSrc: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) =>
+      options?.defaultValue ?? key,
+    i18n: { language: 'en' },
+  }),
+}));
+
+const mockedSrc = useExternalAppSrc as Mock;
+
+const app = { id: 'app-1', name: 'Souffleur', url: 'http://localhost:3177' };
+
+beforeEach(() => {
+  mockedSrc.mockReset();
+});
+
+describe('ExternalAppArticlePanel', () => {
+  it('shows no iframe while the token is still being fetched', () => {
+    mockedSrc.mockReturnValue({ loading: true });
+
+    render(
+      <ExternalAppArticlePanel
+        app={app}
+        articleId="art-7"
+      />
+    );
+
+    expect(screen.queryByTitle('Souffleur')).not.toBeInTheDocument();
+  });
+
+  it('asks for a src that carries the open article as a draft', () => {
+    mockedSrc.mockReturnValue({
+      src: 'http://localhost:3177#token=a-jwt&articleId=art-7&revision=draft',
+      loading: false,
+    });
+
+    render(
+      <ExternalAppArticlePanel
+        app={app}
+        articleId="art-7"
+      />
+    );
+
+    expect(mockedSrc).toHaveBeenCalledWith(app, {
+      articleId: 'art-7',
+      revision: 'draft',
+    });
+    expect(screen.getByTitle('Souffleur')).toHaveAttribute(
+      'src',
+      'http://localhost:3177#token=a-jwt&articleId=art-7&revision=draft'
+    );
+  });
+
+  it('names the app in the heading', () => {
+    mockedSrc.mockReturnValue({ src: 'http://localhost:3177#token=a-jwt' });
+
+    render(
+      <ExternalAppArticlePanel
+        app={app}
+        articleId="art-7"
+      />
+    );
+
+    expect(screen.getByText('Souffleur')).toBeInTheDocument();
+  });
+
+  it('shows the error instead of loading the app without a token', () => {
+    mockedSrc.mockReturnValue({ loading: false, error: new Error('No token') });
+
+    render(
+      <ExternalAppArticlePanel
+        app={app}
+        articleId="art-7"
+      />
+    );
+
+    expect(screen.getByText('No token')).toBeInTheDocument();
+    expect(screen.queryByTitle('Souffleur')).not.toBeInTheDocument();
+  });
+});

--- a/apps/editor/src/app/routes/externalApps/externalAppArticlePanel.tsx
+++ b/apps/editor/src/app/routes/externalApps/externalAppArticlePanel.tsx
@@ -1,0 +1,82 @@
+import styled from '@emotion/styled';
+import { Box, CircularProgress, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { Drawer } from 'rsuite';
+
+import { useExternalAppSrc } from './useExternalAppSrc';
+
+const PanelBody = styled(Drawer.Body)`
+  padding: 0;
+  height: 100%;
+`;
+
+const StyledIframe = styled('iframe')`
+  width: 100%;
+  height: 100%;
+  border: none;
+  background-color: transparent;
+`;
+
+const Centered = styled(Box)`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+`;
+
+export interface ExternalAppArticlePanelProps {
+  app: { id: string; name: string; url: string };
+  /** The article the editor has open; the app opens on this one. */
+  articleId: string;
+}
+
+/**
+ * An external app beside the article it is meant to work on (stage B, part 2).
+ *
+ * The app is told the article in the same url fragment that carries its token,
+ * so it needs no article picker. `revision` names what it should read; the
+ * draft is what the editor has open.
+ *
+ * The panel is mounted only while the drawer is open, which is also when the
+ * token is minted: the editor asks for no token for a tool nobody opened.
+ */
+export function ExternalAppArticlePanel({
+  app,
+  articleId,
+}: ExternalAppArticlePanelProps) {
+  const { t } = useTranslation();
+  const { src, loading, error } = useExternalAppSrc(app, {
+    articleId,
+    revision: 'draft',
+  });
+
+  return (
+    <>
+      <Drawer.Header>
+        <Drawer.Title>{app.name}</Drawer.Title>
+      </Drawer.Header>
+
+      <PanelBody>
+        {loading ?
+          <Centered>
+            <CircularProgress />
+          </Centered>
+        : !src ?
+          <Box p={3}>
+            <Typography color="error">
+              {error?.message ||
+                t('externalApps.noToken', {
+                  defaultValue: 'Could not create a token for this app',
+                })}
+            </Typography>
+          </Box>
+        : <StyledIframe
+            src={src}
+            title={app.name}
+            allow="fullscreen; microphone; camera; display-capture"
+          />
+        }
+      </PanelBody>
+    </>
+  );
+}

--- a/apps/editor/src/app/routes/externalApps/externalAppIframeView.spec.tsx
+++ b/apps/editor/src/app/routes/externalApps/externalAppIframeView.spec.tsx
@@ -1,0 +1,125 @@
+import '@testing-library/jest-dom/vitest';
+import type { Mock } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { ExternalAppIframeView } from './externalAppIframeView';
+import {
+  useCreateExternalAppTokenMutation,
+  useExternalAppQuery,
+} from '@wepublish/editor/api';
+
+vi.mock('@wepublish/editor/api', () => ({
+  useExternalAppQuery: vi.fn(),
+  useCreateExternalAppTokenMutation: vi.fn(),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({ id: 'app-1' }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) =>
+      options?.defaultValue ?? key,
+    i18n: { language: 'en' },
+  }),
+}));
+
+const mockedQuery = useExternalAppQuery as Mock;
+const mockedMutation = useCreateExternalAppTokenMutation as Mock;
+
+const app = {
+  id: 'app-1',
+  name: 'Souffleur',
+  url: 'http://localhost:3177',
+};
+
+const createToken = vi.fn();
+
+type MutationState = {
+  data?: { createExternalAppToken: { token: string; expiresAt: string } };
+  loading?: boolean;
+  error?: Error;
+  called?: boolean;
+};
+
+const renderWith = (mutation: MutationState) => {
+  mockedQuery.mockReturnValue({
+    data: { externalApp: app },
+    loading: false,
+    error: undefined,
+  });
+  mockedMutation.mockReturnValue([
+    createToken,
+    {
+      data: mutation.data,
+      loading: mutation.loading ?? false,
+      error: mutation.error,
+      called: mutation.called ?? true,
+    },
+  ]);
+  return render(<ExternalAppIframeView />);
+};
+
+const token = (value: string) => ({
+  data: { createExternalAppToken: { token: value, expiresAt: '2026-09-09' } },
+});
+
+beforeEach(() => {
+  createToken.mockClear();
+  mockedQuery.mockReset();
+  mockedMutation.mockReset();
+});
+
+describe('ExternalAppIframeView', () => {
+  it('shows no iframe while the token is still being fetched', () => {
+    renderWith({ loading: true });
+
+    expect(screen.queryByTitle('Souffleur')).not.toBeInTheDocument();
+  });
+
+  it('hands the token to the app in the url fragment', () => {
+    renderWith(token('a-jwt'));
+
+    expect(screen.getByTitle('Souffleur')).toHaveAttribute(
+      'src',
+      'http://localhost:3177#token=a-jwt'
+    );
+  });
+
+  it('encodes a token that carries url characters', () => {
+    renderWith(token('he/ad.pay+load=='));
+
+    expect(screen.getByTitle('Souffleur')).toHaveAttribute(
+      'src',
+      `http://localhost:3177#token=${encodeURIComponent('he/ad.pay+load==')}`
+    );
+  });
+
+  it('shows the error instead of loading the app without a token', () => {
+    renderWith({ error: new Error('Not allowed') });
+
+    expect(screen.getByText('Not allowed')).toBeInTheDocument();
+    expect(screen.queryByTitle('Souffleur')).not.toBeInTheDocument();
+  });
+
+  it('asks for a token once, for the app that was loaded', () => {
+    mockedQuery.mockReturnValue({
+      data: { externalApp: app },
+      loading: false,
+      error: undefined,
+    });
+    mockedMutation.mockReturnValue([
+      createToken,
+      { data: undefined, loading: false, error: undefined, called: false },
+    ]);
+
+    const { rerender } = render(<ExternalAppIframeView />);
+    rerender(<ExternalAppIframeView />);
+
+    expect(createToken).toHaveBeenCalledTimes(1);
+    expect(createToken).toHaveBeenCalledWith({
+      variables: { externalAppId: 'app-1' },
+    });
+  });
+});

--- a/apps/editor/src/app/routes/externalApps/externalAppIframeView.tsx
+++ b/apps/editor/src/app/routes/externalApps/externalAppIframeView.tsx
@@ -1,6 +1,10 @@
 import styled from '@emotion/styled';
 import { Box, CircularProgress, Typography } from '@mui/material';
-import { useExternalAppQuery } from '@wepublish/editor/api';
+import {
+  useCreateExternalAppTokenMutation,
+  useExternalAppQuery,
+} from '@wepublish/editor/api';
+import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 
@@ -31,7 +35,23 @@ export function ExternalAppIframeView() {
     skip: !id,
   });
 
-  if (loading) {
+  // The app is told who is sitting in the iframe with a short-lived JWT
+  // (`audience` = the app's registered url). It travels in the url fragment,
+  // never as a query parameter: fragments reach no server and no log, and the
+  // app is expected to strip it from the address bar once it has been traded
+  // for its own session.
+  const [createExternalAppToken, tokenState] =
+    useCreateExternalAppTokenMutation();
+
+  useEffect(() => {
+    if (data?.externalApp && !tokenState.called) {
+      createExternalAppToken({
+        variables: { externalAppId: data.externalApp.id },
+      });
+    }
+  }, [data, createExternalAppToken, tokenState.called]);
+
+  if (loading || tokenState.loading) {
     return (
       <Box
         p={3}
@@ -58,10 +78,36 @@ export function ExternalAppIframeView() {
     );
   }
 
+  // A token that cannot be minted is shown, not swallowed: loading the app
+  // without one would silently sign the editor out of it.
+  if (tokenState.error) {
+    return (
+      <Box p={3}>
+        <Typography color="error">{tokenState.error.message}</Typography>
+      </Box>
+    );
+  }
+
+  const token = tokenState.data?.createExternalAppToken.token;
+
+  if (!token) {
+    return (
+      <Box
+        p={3}
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        height="100%"
+      >
+        <CircularProgress />
+      </Box>
+    );
+  }
+
   return (
     <IframeWrapper>
       <StyledIframe
-        src={data.externalApp.url}
+        src={`${data.externalApp.url}#token=${encodeURIComponent(token)}`}
         title={data.externalApp.name}
         allow="fullscreen; microphone; camera; display-capture"
       />

--- a/apps/editor/src/app/routes/externalApps/externalAppIframeView.tsx
+++ b/apps/editor/src/app/routes/externalApps/externalAppIframeView.tsx
@@ -1,12 +1,10 @@
 import styled from '@emotion/styled';
 import { Box, CircularProgress, Typography } from '@mui/material';
-import {
-  useCreateExternalAppTokenMutation,
-  useExternalAppQuery,
-} from '@wepublish/editor/api';
-import { useEffect } from 'react';
+import { useExternalAppQuery } from '@wepublish/editor/api';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
+
+import { useExternalAppSrc } from './useExternalAppSrc';
 
 const IframeWrapper = styled(Box)`
   width: calc(100% + 80px);
@@ -35,23 +33,14 @@ export function ExternalAppIframeView() {
     skip: !id,
   });
 
-  // The app is told who is sitting in the iframe with a short-lived JWT
-  // (`audience` = the app's registered url). It travels in the url fragment,
-  // never as a query parameter: fragments reach no server and no log, and the
-  // app is expected to strip it from the address bar once it has been traded
-  // for its own session.
-  const [createExternalAppToken, tokenState] =
-    useCreateExternalAppTokenMutation();
+  const app = data?.externalApp;
+  const {
+    src,
+    loading: tokenLoading,
+    error: tokenError,
+  } = useExternalAppSrc(app);
 
-  useEffect(() => {
-    if (data?.externalApp && !tokenState.called) {
-      createExternalAppToken({
-        variables: { externalAppId: data.externalApp.id },
-      });
-    }
-  }, [data, createExternalAppToken, tokenState.called]);
-
-  if (loading || tokenState.loading) {
+  if (loading || (app && tokenLoading)) {
     return (
       <Box
         p={3}
@@ -65,7 +54,7 @@ export function ExternalAppIframeView() {
     );
   }
 
-  if (error || !data?.externalApp) {
+  if (error || !app) {
     return (
       <Box p={3}>
         <Typography color="error">
@@ -78,28 +67,15 @@ export function ExternalAppIframeView() {
     );
   }
 
-  // A token that cannot be minted is shown, not swallowed: loading the app
-  // without one would silently sign the editor out of it.
-  if (tokenState.error) {
+  if (tokenError || !src) {
     return (
       <Box p={3}>
-        <Typography color="error">{tokenState.error.message}</Typography>
-      </Box>
-    );
-  }
-
-  const token = tokenState.data?.createExternalAppToken.token;
-
-  if (!token) {
-    return (
-      <Box
-        p={3}
-        display="flex"
-        justifyContent="center"
-        alignItems="center"
-        height="100%"
-      >
-        <CircularProgress />
+        <Typography color="error">
+          {tokenError?.message ||
+            t('externalApps.noToken', {
+              defaultValue: 'Could not create a token for this app',
+            })}
+        </Typography>
       </Box>
     );
   }
@@ -107,8 +83,8 @@ export function ExternalAppIframeView() {
   return (
     <IframeWrapper>
       <StyledIframe
-        src={`${data.externalApp.url}#token=${encodeURIComponent(token)}`}
-        title={data.externalApp.name}
+        src={src}
+        title={app.name}
         allow="fullscreen; microphone; camera; display-capture"
       />
     </IframeWrapper>

--- a/apps/editor/src/app/routes/externalApps/useExternalAppSrc.spec.tsx
+++ b/apps/editor/src/app/routes/externalApps/useExternalAppSrc.spec.tsx
@@ -1,0 +1,112 @@
+import type { Mock } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+import { useExternalAppSrc } from './useExternalAppSrc';
+import { useCreateExternalAppTokenMutation } from '@wepublish/editor/api';
+
+vi.mock('@wepublish/editor/api', () => ({
+  useCreateExternalAppTokenMutation: vi.fn(),
+}));
+
+const mockedMutation = useCreateExternalAppTokenMutation as Mock;
+const createToken = vi.fn();
+
+const app = { id: 'app-1', url: 'http://localhost:3177' };
+
+const mitToken = (value?: string, error?: Error) => {
+  mockedMutation.mockReturnValue([
+    createToken,
+    {
+      data:
+        value ?
+          { createExternalAppToken: { token: value, expiresAt: '2026-09-09' } }
+        : undefined,
+      loading: false,
+      error,
+      called: true,
+    },
+  ]);
+};
+
+beforeEach(() => {
+  createToken.mockClear();
+  mockedMutation.mockReset();
+});
+
+describe('useExternalAppSrc', () => {
+  it('asks for nothing without an app', () => {
+    mockedMutation.mockReturnValue([
+      createToken,
+      { data: undefined, loading: false, error: undefined, called: false },
+    ]);
+
+    const { result } = renderHook(() => useExternalAppSrc(undefined));
+
+    expect(createToken).not.toHaveBeenCalled();
+    expect(result.current).toEqual({
+      src: undefined,
+      loading: false,
+      error: undefined,
+    });
+  });
+
+  it('asks for a token once and waits for it', () => {
+    mockedMutation.mockReturnValue([
+      createToken,
+      { data: undefined, loading: false, error: undefined, called: false },
+    ]);
+
+    const { result, rerender } = renderHook(() => useExternalAppSrc(app));
+    rerender();
+
+    expect(createToken).toHaveBeenCalledTimes(1);
+    expect(createToken).toHaveBeenCalledWith({
+      variables: { externalAppId: 'app-1' },
+    });
+    expect(result.current.loading).toBe(true);
+    expect(result.current.src).toBeUndefined();
+  });
+
+  it('puts the token in the fragment', () => {
+    mitToken('a-jwt');
+
+    const { result } = renderHook(() => useExternalAppSrc(app));
+
+    expect(result.current.src).toBe('http://localhost:3177#token=a-jwt');
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('adds the article and the revision when they are known', () => {
+    mitToken('a-jwt');
+
+    const { result } = renderHook(() =>
+      useExternalAppSrc(app, { articleId: 'art-7', revision: 'draft' })
+    );
+
+    expect(result.current.src).toBe(
+      'http://localhost:3177#token=a-jwt&articleId=art-7&revision=draft'
+    );
+  });
+
+  it('encodes values that carry url characters', () => {
+    mitToken('he/ad.pay+load==');
+
+    const { result } = renderHook(() =>
+      useExternalAppSrc(app, { articleId: 'a b&c' })
+    );
+
+    expect(result.current.src).toBe(
+      `http://localhost:3177#token=${encodeURIComponent('he/ad.pay+load==')}&articleId=${encodeURIComponent('a b&c')}`
+    );
+  });
+
+  it('reports a failed token instead of a src', () => {
+    mitToken(undefined, new Error('Not allowed'));
+
+    const { result } = renderHook(() => useExternalAppSrc(app));
+
+    expect(result.current.src).toBeUndefined();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error?.message).toBe('Not allowed');
+  });
+});

--- a/apps/editor/src/app/routes/externalApps/useExternalAppSrc.ts
+++ b/apps/editor/src/app/routes/externalApps/useExternalAppSrc.ts
@@ -1,0 +1,70 @@
+import type { ApolloError } from '@apollo/client';
+import { useCreateExternalAppTokenMutation } from '@wepublish/editor/api';
+import { useEffect } from 'react';
+
+export interface ExternalAppContext {
+  /** The article the app should look at; left out when there is none. */
+  articleId?: string;
+  /** Which revision the app should read: draft, pending, published, latest. */
+  revision?: string;
+}
+
+export interface ExternalAppSrc {
+  /** The iframe src, once the token is there. */
+  src?: string;
+  loading: boolean;
+  error?: ApolloError;
+}
+
+/**
+ * The iframe src of an external app, with a short-lived session token in the
+ * url fragment.
+ *
+ * The token travels in the fragment, never as a query parameter: fragments
+ * reach no server and no log, and the app is expected to strip it from the
+ * address bar once it has been traded for its own session. It is minted once
+ * per mounted app, which is why the caller mounts this only when the app is
+ * actually shown.
+ *
+ * A failed mutation is reported, never swallowed: loading the app without a
+ * token would silently sign the editor out of it.
+ */
+export function useExternalAppSrc(
+  app: { id: string; url: string } | undefined,
+  context: ExternalAppContext = {}
+): ExternalAppSrc {
+  const [createExternalAppToken, tokenState] =
+    useCreateExternalAppTokenMutation();
+
+  useEffect(() => {
+    if (app && !tokenState.called) {
+      createExternalAppToken({ variables: { externalAppId: app.id } });
+    }
+  }, [app, createExternalAppToken, tokenState.called]);
+
+  if (!app || tokenState.error) {
+    return { src: undefined, loading: false, error: tokenState.error };
+  }
+
+  const token = tokenState.data?.createExternalAppToken.token;
+
+  if (!token) {
+    return { src: undefined, loading: true, error: undefined };
+  }
+
+  const fragment = [`token=${encodeURIComponent(token)}`];
+
+  if (context.articleId) {
+    fragment.push(`articleId=${encodeURIComponent(context.articleId)}`);
+  }
+
+  if (context.revision) {
+    fragment.push(`revision=${encodeURIComponent(context.revision)}`);
+  }
+
+  return {
+    src: `${app.url}#${fragment.join('&')}`,
+    loading: false,
+    error: undefined,
+  };
+}

--- a/libs/editor/api/src/lib/graphql.ts
+++ b/libs/editor/api/src/lib/graphql.ts
@@ -8036,6 +8036,13 @@ export type DeleteExternalAppMutationVariables = Exact<{
 
 export type DeleteExternalAppMutation = { __typename?: 'Mutation', deleteExternalApp: { __typename?: 'ExternalApp', createdAt: string, icon?: string | null, id: string, modifiedAt: string, name: string, description?: string | null, target: ExternalAppsTarget, url: string } };
 
+export type CreateExternalAppTokenMutationVariables = Exact<{
+  externalAppId: Scalars['String'];
+}>;
+
+
+export type CreateExternalAppTokenMutation = { __typename?: 'Mutation', createExternalAppToken: { __typename?: 'ExternalAppToken', token: string, expiresAt: string } };
+
 export type FullGoodieFragment = { __typename?: 'Goodie', id: string, createdAt: string, modifiedAt: string, name: string, description?: RichtextJSONDocument | null, stock?: number | null, availableStock?: number | null, active: boolean, imageID?: string | null, image?: { __typename?: 'Image', id: string, createdAt: string, modifiedAt: string, title?: string | null, filename?: string | null, extension: string, width: number, height: number, fileSize: number, description?: string | null, tags: Array<string>, source?: string | null, link?: string | null, license?: string | null, focalPointX: number, focalPointY: number, url: string, largeURL?: string | null, mediumURL?: string | null, thumbURL?: string | null, squareURL?: string | null, previewURL?: string | null, column1URL?: string | null, column6URL?: string | null } | null, memberPlans: Array<{ __typename?: 'MemberPlan', id: string, name: string }> };
 
 export type GoodieListQueryVariables = Exact<{
@@ -15065,6 +15072,40 @@ export function useDeleteExternalAppMutation(baseOptions?: Apollo.MutationHookOp
 export type DeleteExternalAppMutationHookResult = ReturnType<typeof useDeleteExternalAppMutation>;
 export type DeleteExternalAppMutationResult = Apollo.MutationResult<DeleteExternalAppMutation>;
 export type DeleteExternalAppMutationOptions = Apollo.BaseMutationOptions<DeleteExternalAppMutation, DeleteExternalAppMutationVariables>;
+export const CreateExternalAppTokenDocument = gql`
+    mutation CreateExternalAppToken($externalAppId: String!) {
+  createExternalAppToken(externalAppId: $externalAppId) {
+    token
+    expiresAt
+  }
+}
+    `;
+export type CreateExternalAppTokenMutationFn = Apollo.MutationFunction<CreateExternalAppTokenMutation, CreateExternalAppTokenMutationVariables>;
+
+/**
+ * __useCreateExternalAppTokenMutation__
+ *
+ * To run a mutation, you first call `useCreateExternalAppTokenMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useCreateExternalAppTokenMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [createExternalAppTokenMutation, { data, loading, error }] = useCreateExternalAppTokenMutation({
+ *   variables: {
+ *      externalAppId: // value for 'externalAppId'
+ *   },
+ * });
+ */
+export function useCreateExternalAppTokenMutation(baseOptions?: Apollo.MutationHookOptions<CreateExternalAppTokenMutation, CreateExternalAppTokenMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateExternalAppTokenMutation, CreateExternalAppTokenMutationVariables>(CreateExternalAppTokenDocument, options);
+      }
+export type CreateExternalAppTokenMutationHookResult = ReturnType<typeof useCreateExternalAppTokenMutation>;
+export type CreateExternalAppTokenMutationResult = Apollo.MutationResult<CreateExternalAppTokenMutation>;
+export type CreateExternalAppTokenMutationOptions = Apollo.BaseMutationOptions<CreateExternalAppTokenMutation, CreateExternalAppTokenMutationVariables>;
 export const GoodieListDocument = gql`
     query GoodieList($filter: GoodieFilter, $cursor: String, $take: Int, $skip: Int, $order: SortOrder, $sort: GoodieSort) {
   goodies(

--- a/libs/editor/api/src/lib/schemas/external-apps.graphql
+++ b/libs/editor/api/src/lib/schemas/external-apps.graphql
@@ -52,3 +52,10 @@ mutation DeleteExternalApp($deleteExternalAppId: String!) {
     ...ExternalApp
   }
 }
+
+mutation CreateExternalAppToken($externalAppId: String!) {
+  createExternalAppToken(externalAppId: $externalAppId) {
+    token
+    expiresAt
+  }
+}


### PR DESCRIPTION
**Draft on purpose.** The editor side of an assistant we are piloting for hauptstadt; opening it early so the two design questions at the bottom can be answered before anyone polishes anything.

## What it does

An external app registered in the editor gets loaded today with nothing but its url, so it never learns who is sitting in the iframe or what they are working on. Two commits change that, using the `createExternalAppToken` mutation that already exists on the api but that no editor code called.

**1. Token in the url fragment.** `ExternalAppIframeView` mints a token once the app is loaded and renders the iframe only when it is there:

```
<url>#token=<jwt>
```

The token travels in the fragment, never as a query parameter: fragments reach no server and no log, and the app is expected to strip it from the address bar after trading it for its own session. A failed mutation is shown rather than swallowed, because loading the app without a token would silently sign the editor out of it.

**2. The app beside the article it works on.** Every app with `target = IFRAME` gets a button in the article editor's toolbar, next to Metadata, labelled with its own name and icon. It opens a drawer holding the app, which is told the open article in the same fragment:

```
<url>#token=<jwt>&articleId=<id>&revision=draft
```

so the app needs no article picker. The button appears only for a saved article, and the token is minted when the drawer opens, never on page load: the editor asks for no token for a tool nobody used.

The fragment is built in one place, `useExternalAppSrc`, which both callers use. `AppIcon` moves out of the external-apps dashboard into its own file because two callers need it now.

## How it was checked

- 97 tests in `editor` green, 15 of them new: the hook, the panel and the full-page view.
- `eslint` adds no warning, `prettier --check` clean, `tsc -p apps/editor/tsconfig.app.json --noEmit` clean.
- Measured against a local editor and a real external app: the minted jwt carries `iss` of the api and `aud` of the registered app url, the app trades it for its own session, and it comes up on the open article without a login form and without an article picker.

## Two questions for the team

1. **Which apps belong in the article editor?** This takes the cheap route: every app with `target = IFRAME`. The honest downside is that any future iframe app shows up there whether it has anything to do with an article or not. A third target value, `ARTICLE_EDITOR` beside `BLANK` and `IFRAME`, would say it properly, but that means a prisma migration, the api model, the schema, codegen and the registration form. Happy to do it that way if you prefer it.
2. **Where should the panel sit?** This follows the pattern the article editor already uses twice: a toolbar button and a drawer of size `md`. A docked sidebar would be closer to "an assistant reading along", but it changes the editor's layout, which felt like your call rather than ours.

Also worth knowing: `createExternalAppToken` carries `@Authenticated()` and no `@Permissions`, unlike the create/update/delete mutations beside it. Any signed-in user can therefore mint a token in their own name for any registered app. That is what makes this change small, and it may well be intended, but it seemed worth naming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
