### PR TITLE
refactor(onlinereports): render mitmachen from CMS page

### DIFF
--- a/apps/onlinereports/pages/_app.tsx
+++ b/apps/onlinereports/pages/_app.tsx
@@ -56,6 +56,7 @@ import { OnlineReportsCommentListItem } from '../src/components/online-reports-c
 import { OnlineReportsPage } from '../src/components/page';
 import { OnlineReportsPaymentAmount } from '../src/components/payment-amount';
 import { OnlineReportsQuoteBlock } from '../src/components/quote-block';
+import { OnlineReportsSubscribe } from '../src/components/onlinereports-subscribe';
 import { AdsProvider } from '../src/context/ads-context';
 import { OnlineReportsRegistrationForm } from '../src/forms/registration-form';
 import { OnlineReportsNavbar } from '../src/navigation/onlinereports-navbar';
@@ -225,6 +226,7 @@ function CustomApp({
                   TeaserGrid: OnlineReportsTeaserGridBlock,
                   Quote: OnlineReportsQuoteBlock,
                   Title: OnlineReportsTitle,
+                  Subscribe: OnlineReportsSubscribe,
                 }}
                 date={{ format: dateFormatter }}
                 meta={{ siteTitle }}

--- a/apps/onlinereports/pages/mitmachen.tsx
+++ b/apps/onlinereports/pages/mitmachen.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { UserFormWrapper } from '@wepublish/authentication/website';
+import { RichTextBlockWrapper } from '@wepublish/block-content/website';
 import {
   SubscribeButton,
   SubscribeCancelable,
@@ -22,6 +23,12 @@ import { useEffect } from 'react';
 import { useAdsContext } from '../src/context/ads-context';
 
 const MitmachenPage = styled(PageContainer)`
+  ${RichTextBlockWrapper} {
+    ${({ theme }) => theme.breakpoints.up('md')} {
+      grid-column: -1/1;
+    }
+  }
+
   ${SubscribeWrapper} {
     grid-template-columns: 100%;
     grid-template-areas:

--- a/apps/onlinereports/pages/mitmachen.tsx
+++ b/apps/onlinereports/pages/mitmachen.tsx
@@ -9,13 +9,20 @@ import {
   SubscribeWrapper,
   TransactionFeeIcon,
 } from '@wepublish/membership/website';
-import { SubscribePage } from '@wepublish/utils/website';
-import { useWebsiteBuilder } from '@wepublish/website/builder';
+import { PageContainer } from '@wepublish/page/website';
+import {
+  getApiUrl,
+  getSessionTokenProps,
+  ssrAuthLink,
+  SubscribePage,
+} from '@wepublish/utils/website';
+import { getApiClient, PageDocument } from '@wepublish/website/api';
+import { NextPageContext } from 'next';
 import { useEffect } from 'react';
 
 import { useAdsContext } from '../src/context/ads-context';
 
-const OnlineReportsSubscribePageWrapper = styled('div')`
+const MitmachenPage = styled(PageContainer)`
   ${SubscribeWrapper} {
     grid-template-columns: 100%;
     grid-template-areas:
@@ -42,13 +49,6 @@ const OnlineReportsSubscribePageWrapper = styled('div')`
       }
     }
   }
-`;
-
-const SubscribePageWrapper = styled('div')`
-  display: flex;
-  flex-direction: column;
-  gap: ${({ theme }) => theme.spacing(2.5)};
-  margin-top: ${({ theme }) => theme.spacing(4)};
 
   ${TransactionFeeIcon} {
     display: none;
@@ -72,30 +72,36 @@ const SubscribePageWrapper = styled('div')`
   }
 `;
 
-export const MitmachenInner = () => (
-  <OnlineReportsSubscribePageWrapper>
-    <SubscribePage fields={['firstName']} />
-  </OnlineReportsSubscribePageWrapper>
-);
-
 export default function Mitmachen() {
   const { setAdsDisabled } = useAdsContext();
-
-  const {
-    elements: { H3 },
-  } = useWebsiteBuilder();
 
   useEffect(() => {
     setAdsDisabled(true);
     return () => setAdsDisabled(false);
   }, [setAdsDisabled]);
 
-  return (
-    <SubscribePageWrapper>
-      <H3 component="h1">Herzlichen Dank für Ihre Unterstützung!</H3>
-      <MitmachenInner />
-    </SubscribePageWrapper>
-  );
+  return <MitmachenPage slug={'mitmachen'} />;
 }
 
-Mitmachen.getInitialProps = SubscribePage.getInitialProps;
+Mitmachen.getInitialProps = async (ctx: NextPageContext) => {
+  if (typeof window !== 'undefined') {
+    return {};
+  }
+
+  const client = getApiClient(getApiUrl(), [
+    ssrAuthLink(
+      async () => (await getSessionTokenProps(ctx)).sessionToken?.token
+    ),
+  ]);
+
+  await Promise.all([
+    client.query({
+      query: PageDocument,
+      variables: {
+        slug: 'mitmachen',
+      },
+    }),
+  ]);
+
+  return SubscribePage.getInitialProps(ctx);
+};

--- a/apps/onlinereports/pages/mitmachen.tsx
+++ b/apps/onlinereports/pages/mitmachen.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled';
 import { UserFormWrapper } from '@wepublish/authentication/website';
 import {
-  SubscribeAmount,
   SubscribeButton,
   SubscribeCancelable,
   SubscribeNarrowSection,
@@ -52,10 +51,6 @@ const MitmachenPage = styled(PageContainer)`
 
   ${TransactionFeeIcon} {
     display: none;
-  }
-
-  ${SubscribeAmount} {
-    background: ${({ theme }) => theme.palette.secondary.main};
   }
 
   ${SubscribeButton} {

--- a/apps/onlinereports/src/components/onlinereports-subscribe.tsx
+++ b/apps/onlinereports/src/components/onlinereports-subscribe.tsx
@@ -1,0 +1,9 @@
+import styled from '@emotion/styled';
+import { SubscribeBlock } from '@wepublish/block-content/website';
+import { SubscribeAmount } from '@wepublish/membership/website';
+
+export const OnlineReportsSubscribe = styled(SubscribeBlock)`
+  ${SubscribeAmount} {
+    background: ${({ theme }) => theme.palette.secondary.main};
+  }
+`;


### PR DESCRIPTION
 * render mitmachen page from cms-content instead of statically wiring the subscribe-form